### PR TITLE
Cancel Jobs API

### DIFF
--- a/packages/zosjobs/__tests__/__system__/api/CancelJobs.system.test.ts
+++ b/packages/zosjobs/__tests__/__system__/api/CancelJobs.system.test.ts
@@ -51,25 +51,25 @@ describe("CancelJobs System tests", () => {
 
     describe("Positive tests", () => {
         it("should be able to cancel a job using cancelJob", async () => {
-            const job = await SubmitJobs.submitJclNotifyCommon(REAL_SESSION, { jcl: iefbr14JCL });
-            expect(job.retcode).toEqual("CC 0000");
+            const job = await SubmitJobs.submitJclNotifyCommon(REAL_SESSION, { jcl: iefbr14JCL, status: "INPUT" });
+            expect(job.retcode).toBeNull(); // job is not complete, no CC
             await CancelJobs.cancelJob(REAL_SESSION, job.jobname, job.jobid);
         }, LONG_TIMEOUT);
 
         it("should be able to cancel a job using cancelJobForJob", async () => {
-            const job = await SubmitJobs.submitJclNotifyCommon(REAL_SESSION, { jcl: iefbr14JCL });
-            expect(job.retcode).toEqual("CC 0000");
+            const job = await SubmitJobs.submitJclNotifyCommon(REAL_SESSION, { jcl: iefbr14JCL, status: "INPUT" });
+            expect(job.retcode).toBeNull(); // job is not complete, no CC
             await CancelJobs.cancelJobForJob(REAL_SESSION, job);
         }, LONG_TIMEOUT);
 
         it("should be able to cancel a job using cancelJobCommon", async () => {
-            const job = await SubmitJobs.submitJclNotifyCommon(REAL_SESSION, { jcl: iefbr14JCL });
-            expect(job.retcode).toEqual("CC 0000");
+            const job = await SubmitJobs.submitJclNotifyCommon(REAL_SESSION, { jcl: iefbr14JCL, status: "INPUT" });
+            expect(job.retcode).toBeNull(); // job is not complete, no CC
             await CancelJobs.cancelJobCommon(REAL_SESSION, { jobname: job.jobname, jobid: job.jobid });
         }, LONG_TIMEOUT);
 
         it("should be able to cancel a job using cancelJobCommon (job version 2.0 - synchronous)", async () => {
-            const job = await SubmitJobs.submitJclNotifyCommon(REAL_SESSION, { jcl: iefbr14JCL });
+            const job = await SubmitJobs.submitJclNotifyCommon(REAL_SESSION, { jcl: iefbr14JCL, status: "INPUT" });
             await CancelJobs.cancelJobCommon(REAL_SESSION, { jobname: job.jobname, jobid: job.jobid, version: "2.0" });
         }, LONG_TIMEOUT);
     });

--- a/packages/zosjobs/__tests__/__system__/api/CancelJobs.system.test.ts
+++ b/packages/zosjobs/__tests__/__system__/api/CancelJobs.system.test.ts
@@ -1,0 +1,129 @@
+/*
+* This program and the accompanying materials are made available under the terms of the *
+* Eclipse Public License v2.0 which accompanies this distribution, and is available at *
+* https://www.eclipse.org/legal/epl-v20.html                                      *
+*                                                                                 *
+* SPDX-License-Identifier: EPL-2.0                                                *
+*                                                                                 *
+* Copyright Contributors to the Zowe Project.                                     *
+*                                                                                 *
+*/
+
+import { ImperativeError, Session } from "@brightside/imperative";
+import { CancelJobs, SubmitJobs } from "../../../";
+import { IJob } from "../../../index";
+import { ITestEnvironment } from "../../../../../__tests__/__src__/environment/doc/response/ITestEnvironment";
+import { TestProperties } from "../../../../../__tests__/__src__/properties/TestProperties";
+import { ITestSystemSchema } from "../../../../../__tests__/__src__/properties/ITestSystemSchema";
+import { TestEnvironment } from "../../../../../__tests__/__src__/environment/TestEnvironment";
+import { JobTestsUtils } from "./JobTestsUtils";
+
+let REAL_SESSION: Session;
+let iefbr14JCL: string;
+
+let defaultSystem: ITestSystemSchema;
+let testEnvironment: ITestEnvironment;
+let systemProps: TestProperties;
+const LONG_TIMEOUT = 100000; // 100 second timeout - jobs could take a while to complete due to system load
+
+describe("CancelJobs System tests", () => {
+
+    beforeAll(async () => {
+        testEnvironment = await TestEnvironment.setUp({
+            testName: "zos_get_jobs"
+        });
+        systemProps = new TestProperties(testEnvironment.systemTestProperties);
+        defaultSystem = systemProps.getDefaultSystem();
+
+        REAL_SESSION = new Session({
+            user: defaultSystem.zosmf.user,
+            password: defaultSystem.zosmf.pass,
+            hostname: defaultSystem.zosmf.host,
+            port: defaultSystem.zosmf.port,
+            type: "basic",
+            rejectUnauthorized: defaultSystem.zosmf.rejectUnauthorized
+        });
+
+        const ACCOUNT = defaultSystem.tso.account;
+
+        iefbr14JCL = JobTestsUtils.getIefbr14JCL(REAL_SESSION.ISession.user, ACCOUNT);
+    });
+
+    describe("Positive tests", () => {
+        it("should be able to cancel a job using cancelJob", async () => {
+            const job = await SubmitJobs.submitJclNotifyCommon(REAL_SESSION, { jcl: iefbr14JCL });
+            expect(job.retcode).toEqual("CC 0000");
+            await CancelJobs.cancelJob(REAL_SESSION, job.jobname, job.jobid);
+        }, LONG_TIMEOUT);
+
+        it("should be able to cancel a job using cancelJobForJob", async () => {
+            const job = await SubmitJobs.submitJclNotifyCommon(REAL_SESSION, { jcl: iefbr14JCL });
+            expect(job.retcode).toEqual("CC 0000");
+            await CancelJobs.cancelJobForJob(REAL_SESSION, job);
+        }, LONG_TIMEOUT);
+
+        it("should be able to cancel a job using cancelJobCommon", async () => {
+            const job = await SubmitJobs.submitJclNotifyCommon(REAL_SESSION, { jcl: iefbr14JCL });
+            expect(job.retcode).toEqual("CC 0000");
+            await CancelJobs.cancelJobCommon(REAL_SESSION, { jobname: job.jobname, jobid: job.jobid });
+        }, LONG_TIMEOUT);
+
+        it("should be able to cancel a job using cancelJobCommon (job version 2.0 - synchronous)", async () => {
+            const job = await SubmitJobs.submitJclNotifyCommon(REAL_SESSION, { jcl: iefbr14JCL });
+            await CancelJobs.cancelJobCommon(REAL_SESSION, { jobname: job.jobname, jobid: job.jobid, version: "2.0" });
+        }, LONG_TIMEOUT);
+    });
+
+    describe("Negative tests", () => {
+        it("should surface errors from z/OSMF when trying to cancel a non existent job with cancelJob", async () => {
+            let err: Error | ImperativeError;
+            try {
+                await CancelJobs.cancelJob(REAL_SESSION, "FAKEJOB", "JOB00001");
+            } catch (e) {
+                err = e;
+            }
+            expect(err).toBeDefined();
+            expect(err instanceof ImperativeError).toEqual(true);
+            expect(err.message).toContain("FAKEJOB");
+        });
+
+        it("should surface errors from z/OSMF when trying to cancel a non-existent job using cancelJobForJob", async () => {
+            let err: Error | ImperativeError;
+            const badJob: IJob = {
+                "jobid": "JOB00001",
+                "jobname": "FAKEJOB",
+                "retcode": "CC 0000",
+                "owner": "dummy",
+                "subsystem": "JES2",
+                "status": "OUTPUT",
+                "type": "JOB",
+                "class": "A",
+                "url": "myfakeurl.com",
+                "files-url": "myfakeurl.com/files/records",
+                "phase": 2,
+                "phase-name": "OUTPUT",
+                "job-correlator": "mycorrelator"
+            };
+            try {
+                await CancelJobs.cancelJobForJob(REAL_SESSION, badJob);
+            } catch (e) {
+                err = e;
+            }
+            expect(err).toBeDefined();
+            expect(err instanceof ImperativeError).toEqual(true);
+            expect(err.message).toContain("FAKEJOB");
+        });
+
+        it("should surface errors from z/OSMF when trying to cancel a non-existent job using cancelJobCommon", async () => {
+            let err: Error | ImperativeError;
+            try {
+                await CancelJobs.cancelJobCommon(REAL_SESSION, { jobname: "FAKEJOB", jobid: "JOB00001" });
+            } catch (e) {
+                err = e;
+            }
+            expect(err).toBeDefined();
+            expect(err instanceof ImperativeError).toEqual(true);
+            expect(err.message).toContain("FAKEJOB");
+        });
+    });
+});

--- a/packages/zosjobs/__tests__/__system__/api/CancelJobs.system.test.ts
+++ b/packages/zosjobs/__tests__/__system__/api/CancelJobs.system.test.ts
@@ -30,7 +30,7 @@ describe("CancelJobs System tests", () => {
 
     beforeAll(async () => {
         testEnvironment = await TestEnvironment.setUp({
-            testName: "zos_get_jobs"
+            testName: "zos_cancel_jobs"
         });
         systemProps = new TestProperties(testEnvironment.systemTestProperties);
         defaultSystem = systemProps.getDefaultSystem();

--- a/packages/zosjobs/__tests__/api/CancelJobs.unit.test.ts
+++ b/packages/zosjobs/__tests__/api/CancelJobs.unit.test.ts
@@ -1,0 +1,271 @@
+/*
+* This program and the accompanying materials are made available under the terms of the *
+* Eclipse Public License v2.0 which accompanies this distribution, and is available at *
+* https://www.eclipse.org/legal/epl-v20.html                                      *
+*                                                                                 *
+* SPDX-License-Identifier: EPL-2.0                                                *
+*                                                                                 *
+* Copyright Contributors to the Zowe Project.                                     *
+*                                                                                 *
+*/
+
+import { ZosmfHeaders, ZosmfRestClient } from "../../../rest";
+import { ImperativeError } from "@brightside/imperative";
+import { CancelJobs, IJob } from "../../";
+
+jest.mock("../../../rest/src/ZosmfRestClient");
+
+const returnEmpty = async () => {
+    return;
+};
+
+const mockErrorText = "My fake error for unit tests has this text - Cancel Jobs unit tests";
+const throwImperativeError = async () => {
+    throw new ImperativeError({ msg: mockErrorText });
+};
+const fakeSession: any = {};
+
+describe("Cancel Jobs unit tests", () => {
+
+    const fakeJob: IJob = {
+        "jobid": "JOB00001",
+        "jobname": "MYJOB1",
+        "retcode": "CC 0000",
+        "owner": "dummy",
+        "subsystem": "JES2",
+        "status": "OUTPUT",
+        "type": "JOB",
+        "class": "A",
+        "url": "myfakeurl.com",
+        "files-url": "myfakeurl.com/files/records",
+        "phase": 2,
+        "phase-name": "OUTPUT",
+        "job-correlator": "mycorrelator"
+    };
+    describe("Positive tests", () => {
+        it("should allow users to call cancelJob with correct parameters", async () => {
+            ZosmfRestClient.putExpectString = jest.fn(returnEmpty);
+            await CancelJobs.cancelJob(fakeSession, "MYJOB1", "JOB00001");
+        });
+
+        it("should allow users to call cancelJobForJob with correct parameters", async () => {
+            ZosmfRestClient.putExpectString = jest.fn(returnEmpty);
+            await CancelJobs.cancelJobForJob(fakeSession, fakeJob);
+        });
+
+        it("should allow users to call cancelJobForJob with correct parameters (with version 1_0)", async () => {
+            ZosmfRestClient.putExpectString = jest.fn(async (session: any, resource: string, headers: any[], body: any) => {
+                expect(body).toMatchSnapshot();
+                return {};
+            });
+            await CancelJobs.cancelJobForJob(fakeSession, fakeJob, "1.0");
+        });
+
+        it("should allow users to call cancelJobForJob with correct parameters (with version 2_0)", async () => {
+            ZosmfRestClient.putExpectString = jest.fn(async (session: any, resource: string, headers: any[], body: any) => {
+                expect(body).toMatchSnapshot();
+                return {};
+            });
+            await CancelJobs.cancelJobForJob(fakeSession, fakeJob, "2.0");
+        });
+
+        it("should allow users to call cancelJobCommon with correct parameters", async () => {
+            ZosmfRestClient.putExpectString = jest.fn(returnEmpty);
+            await CancelJobs.cancelJobCommon(fakeSession, { jobname: "MYJOB1", jobid: "JOB00001" });
+        });
+
+        it("should allow users to call cancelJobCommon with correct parameters (with version 1_0)", async () => {
+            ZosmfRestClient.putExpectString = jest.fn(async (session: any, resource: string, headers: any[], body: any) => {
+                expect(body).toMatchSnapshot();
+                return {};
+            });
+            await CancelJobs.cancelJobCommon(fakeSession, { jobname: "MYJOB1", jobid: "JOB00001", version: "1.0" });
+        });
+
+        it("should allow users to call cancelJobCommon with correct parameters (with version 2_0)", async () => {
+            ZosmfRestClient.putExpectString = jest.fn(async (session: any, resource: string, headers: any[], body: any) => {
+                expect(body).toMatchSnapshot();
+                return {};
+            });
+            await CancelJobs.cancelJobCommon(fakeSession, { jobname: "MYJOB1", jobid: "JOB00001", version: "2.0" });
+        });
+    });
+
+    describe("Error handling tests - async/await", () => {
+        it("should be able to catch errors from cancelJob with async/await syntax", async () => {
+            ZosmfRestClient.putExpectString = jest.fn(throwImperativeError);
+            let err: Error | ImperativeError;
+            try {
+                await CancelJobs.cancelJob(fakeSession, "MYJOB1", "JOB0000");
+            } catch (e) {
+                err = e;
+            }
+            expect(err).toBeDefined();
+            expect(err instanceof ImperativeError).toEqual(true);
+            expect(err.message).toEqual(mockErrorText);
+        });
+
+        it("should be able to catch errors from cancelJobForJob with async/await syntax", async () => {
+            ZosmfRestClient.putExpectString = jest.fn(throwImperativeError);
+            let err: Error | ImperativeError;
+            try {
+                await CancelJobs.cancelJobForJob(fakeSession, fakeJob);
+            } catch (e) {
+                err = e;
+            }
+            expect(err).toBeDefined();
+            expect(err instanceof ImperativeError).toEqual(true);
+            expect(err.message).toEqual(mockErrorText);
+        });
+
+        it("should be able to catch errors from cancelJobCommon with async/await syntax", async () => {
+            ZosmfRestClient.putExpectString = jest.fn(throwImperativeError);
+            let err: Error | ImperativeError;
+            try {
+                await CancelJobs.cancelJobCommon(fakeSession, {
+                    jobname: "MYJOB1",
+                    jobid: "JOB0001"
+                });
+            } catch (e) {
+                err = e;
+            }
+            expect(err).toBeDefined();
+            expect(err instanceof ImperativeError).toEqual(true);
+            expect(err.message).toEqual(mockErrorText);
+        });
+    });
+
+    describe("Error handling tests - Promise catch() syntax", () => {
+        it("should be able to catch errors from cancelJob with Promise.catch() syntax", (done: any) => {
+            ZosmfRestClient.putExpectString = jest.fn(throwImperativeError);
+            CancelJobs.cancelJob(fakeSession, "MYJOB1", "JOB0000").then(() => {
+                expect(".catch() should have been called").toEqual("test failed");
+            }).catch((err) => {
+                expect(err).toBeDefined();
+                expect(err instanceof ImperativeError).toEqual(true);
+                expect(err.message).toEqual(mockErrorText);
+                done();
+            });
+        });
+
+        it("should be able to catch errors from cancelJobForJob with Promise.catch() syntax", (done: any) => {
+            ZosmfRestClient.putExpectString = jest.fn(throwImperativeError);
+            CancelJobs.cancelJobForJob(fakeSession, fakeJob)
+                .then(() => {
+                    expect(".catch() should have been called").toEqual("test failed");
+                }).catch((err) => {
+                    expect(err).toBeDefined();
+                    expect(err instanceof ImperativeError).toEqual(true);
+                    expect(err.message).toEqual(mockErrorText);
+                    done();
+                });
+        });
+
+        it("should be able to catch errors from cancelJobCommon with Promise.catch() syntax", (done: any) => {
+            ZosmfRestClient.putExpectString = jest.fn(throwImperativeError);
+            CancelJobs.cancelJobCommon(fakeSession, {
+                jobname: "MYJOB1",
+                jobid: "JOB0001"
+            }).then(() => {
+                expect(".catch() should have been called").toEqual("test failed");
+            }).catch((err) => {
+                expect(err).toBeDefined();
+                expect(err instanceof ImperativeError).toEqual(true);
+                expect(err.message).toEqual(mockErrorText);
+                done();
+            });
+        });
+    });
+
+    describe("Parameter validation", () => {
+
+        it("should reject calls to cancelJob that omit jobname", async () => {
+            ZosmfRestClient.putExpectString = jest.fn(throwImperativeError);
+            let err: Error | ImperativeError;
+            try {
+                await CancelJobs.cancelJob(fakeSession, undefined, "JOB0000");
+            } catch (e) {
+                err = e;
+            }
+            expect(err).toBeDefined();
+            expect(err instanceof ImperativeError).toEqual(true);
+            expect(err.message).toContain("jobname");
+        });
+
+        it("should reject calls to cancelJob that omit jobname", async () => {
+            ZosmfRestClient.putExpectString = jest.fn(throwImperativeError);
+            let err: Error | ImperativeError;
+            try {
+                await CancelJobs.cancelJob(fakeSession, "MYJOB1", undefined);
+            } catch (e) {
+                err = e;
+            }
+            expect(err).toBeDefined();
+            expect(err instanceof ImperativeError).toEqual(true);
+            expect(err.message).toContain("jobid");
+        });
+
+        it("should reject calls to cancelJobForJob that omit jobname", async () => {
+            ZosmfRestClient.putExpectString = jest.fn(throwImperativeError);
+            let err: Error | ImperativeError;
+            const badJob: IJob = JSON.parse(JSON.stringify(fakeJob));
+            delete badJob.jobname;
+            try {
+                await CancelJobs.cancelJobForJob(fakeSession, badJob);
+            } catch (e) {
+                err = e;
+            }
+            expect(err).toBeDefined();
+            expect(err instanceof ImperativeError).toEqual(true);
+            expect(err.message).toContain("jobname");
+        });
+
+        it("should reject calls to cancelJobForJob that omit jobid", async () => {
+            ZosmfRestClient.putExpectString = jest.fn(throwImperativeError);
+            let err: Error | ImperativeError;
+            const badJob: IJob = JSON.parse(JSON.stringify(fakeJob));
+            delete badJob.jobid;
+            try {
+                await CancelJobs.cancelJobForJob(fakeSession, badJob);
+            } catch (e) {
+                err = e;
+            }
+            expect(err).toBeDefined();
+            expect(err instanceof ImperativeError).toEqual(true);
+            expect(err.message).toContain("jobid");
+        });
+
+        it("should reject calls to cancelJobCommon that omit jobname from the parms object", async () => {
+            ZosmfRestClient.putExpectString = jest.fn(throwImperativeError);
+            let err: Error | ImperativeError;
+            try {
+                await CancelJobs.cancelJobCommon(fakeSession, {
+                    jobname: undefined,
+                    jobid: "JOB0001"
+                });
+            } catch (e) {
+                err = e;
+            }
+            expect(err).toBeDefined();
+            expect(err instanceof ImperativeError).toEqual(true);
+            expect(err.message).toContain("jobname");
+        });
+
+        it("should reject calls to cancelJobCommon that omit jobid from the parms object", async () => {
+            ZosmfRestClient.putExpectString = jest.fn(throwImperativeError);
+            let err: Error | ImperativeError;
+            try {
+                await CancelJobs.cancelJobCommon(fakeSession, {
+                    jobname: "MYJOB1",
+                    jobid: undefined
+                });
+            } catch (e) {
+                err = e;
+            }
+            expect(err).toBeDefined();
+            expect(err instanceof ImperativeError).toEqual(true);
+            expect(err.message).toContain("jobid");
+        });
+    });
+
+});

--- a/packages/zosjobs/__tests__/api/__snapshots__/CancelJobs.unit.test.ts.snap
+++ b/packages/zosjobs/__tests__/api/__snapshots__/CancelJobs.unit.test.ts.snap
@@ -1,0 +1,29 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Cancel Jobs unit tests Positive tests should allow users to call cancelJobCommon with correct parameters (with version 1_0) 1`] = `
+Object {
+  "request": "cancel",
+  "version": "1.0",
+}
+`;
+
+exports[`Cancel Jobs unit tests Positive tests should allow users to call cancelJobCommon with correct parameters (with version 2_0) 1`] = `
+Object {
+  "request": "cancel",
+  "version": "2.0",
+}
+`;
+
+exports[`Cancel Jobs unit tests Positive tests should allow users to call cancelJobForJob with correct parameters (with version 1_0) 1`] = `
+Object {
+  "request": "cancel",
+  "version": "1.0",
+}
+`;
+
+exports[`Cancel Jobs unit tests Positive tests should allow users to call cancelJobForJob with correct parameters (with version 2_0) 1`] = `
+Object {
+  "request": "cancel",
+  "version": "2.0",
+}
+`;

--- a/packages/zosjobs/index.ts
+++ b/packages/zosjobs/index.ts
@@ -9,6 +9,8 @@
 *                                                                                 *
 */
 
+export * from "./src/api/doc/input/ICancelJob";
+export * from "./src/api/doc/input/ICancelJobParms";
 export * from "./src/api/doc/input/IDownloadSpoolContentParms";
 export * from "./src/api/doc/input/IDownloadAllSpoolContentParms";
 export * from "./src/api/doc/input/ICommonJobParms";
@@ -33,6 +35,7 @@ export * from "./src/api/types/JobDataResolve";
 export * from "./src/api/types/JobResolve";
 export * from "./src/api/types/JobStatus";
 
+export * from "./src/api/CancelJobs";
 export * from "./src/api/DeleteJobs";
 export * from "./src/api/DownloadJobs";
 export * from "./src/api/GetJobs";

--- a/packages/zosjobs/src/api/CancelJobs.ts
+++ b/packages/zosjobs/src/api/CancelJobs.ts
@@ -9,7 +9,7 @@
 *                                                                                 *
 */
 
-import { AbstractSession, ImperativeExpect, IO, Logger } from "@brightside/imperative";
+import { AbstractSession, ImperativeExpect, IO, Logger, Headers } from "@brightside/imperative";
 import { JobsConstants } from "./JobsConstants";
 import { ZosmfHeaders, ZosmfRestClient } from "../../../rest";
 import { IJob } from "./doc/response/IJob";
@@ -71,7 +71,7 @@ export class CancelJobs {
             parms.version = JobsConstants.DEFAULT_CANCEL_VERSION;
         }
         this.log.info("Canceling job %s(%s). Job modify version?: %s", parms.jobname, parms.jobid, parms.version);
-        const headers: any = [];
+        const headers: any = [Headers.APPLICATION_JSON];
 
         // build request
         const request: ICancelJob = {
@@ -79,7 +79,7 @@ export class CancelJobs {
             version: parms.version,
         };
 
-        const parameters: string = IO.FILE_DELIM + parms.jobname + IO.FILE_DELIM + parms.jobid;
+        const parameters: string = "/" + parms.jobname + "/" + parms.jobid;
         await ZosmfRestClient.putExpectString(session, JobsConstants.RESOURCE + parameters, headers, request);
     }
 

--- a/packages/zosjobs/src/api/CancelJobs.ts
+++ b/packages/zosjobs/src/api/CancelJobs.ts
@@ -1,0 +1,94 @@
+/*
+* This program and the accompanying materials are made available under the terms of the *
+* Eclipse Public License v2.0 which accompanies this distribution, and is available at *
+* https://www.eclipse.org/legal/epl-v20.html                                      *
+*                                                                                 *
+* SPDX-License-Identifier: EPL-2.0                                                *
+*                                                                                 *
+* Copyright Contributors to the Zowe Project.                                     *
+*                                                                                 *
+*/
+
+import { AbstractSession, ImperativeExpect, IO, Logger } from "@brightside/imperative";
+import { JobsConstants } from "./JobsConstants";
+import { ZosmfHeaders, ZosmfRestClient } from "../../../rest";
+import { IJob } from "./doc/response/IJob";
+import { ICancelJobParms } from "./doc/input/ICancelJobParms";
+import { ICancelJob } from "./doc/input/ICancelJob";
+
+/**
+ * Class to handle deletion of job information
+ * @export
+ * @class CancelJobs
+ */
+export class CancelJobs {
+
+    /**
+     * Cancel and purge a job
+     * @static
+     * @param {AbstractSession} session - z/OSMF connection info
+     * @param {string} jobname - job name to be translated into parms object
+     * @param {string} jobid - job id to be translated into parms object
+     * @returns {Promise<void>} - promise that resolves when the API call is complete
+     * @memberof CancelJobs
+     */
+    public static async cancelJob(session: AbstractSession, jobname: string, jobid: string, version?: string) {
+        this.log.trace("cancelJob called with jobname %s jobid %s", jobname, jobid);
+        return CancelJobs.cancelJobCommon(session, { jobname, jobid });
+    }
+
+    /**
+     * Cancel and purge a job
+     * Alternative version of the cancel API accepting an IJob object returned from other APIs such as GetJobs and SubmitJobs
+     * @static
+     * @param {AbstractSession} session - z/OSMF connection info
+     * @param {IJob} job - the job that you want to cancel
+     * @param {string} version - version of cancel request
+     * @returns {Promise<void>} -  promise that resolves when the API call is complete
+     * @memberof CancelJobs
+     */
+    public static async cancelJobForJob(session: AbstractSession, job: IJob, version?: string) {
+        this.log.trace("cancelJobForJob called with job %s", JSON.stringify(job));
+        return CancelJobs.cancelJobCommon(session, { jobname: job.jobname, jobid: job.jobid, version });
+    }
+
+    /**
+     * Cancel and purge a job
+     * Full version of the API with a parameter object
+     * @static
+     * @param {AbstractSession} session - z/OSMF connection info
+     * @param {ICancelJobParms} parms - parm object (see ICancelJobParms interface for details)
+     * @returns {Promise<void>} - promise that resolves when the API call is complete
+     * @memberof CancelJobs
+     */
+    public static async cancelJobCommon(session: AbstractSession, parms: ICancelJobParms) {
+        this.log.trace("cancelJobCommon called with parms %s", JSON.stringify(parms));
+        ImperativeExpect.keysToBeDefinedAndNonBlank(parms, ["jobname", "jobid"],
+            "You must specify jobname and jobid for the job you want to cancel.");
+
+        // set default if unset
+        if (parms.version === null) {
+            parms.version = JobsConstants.DEFAULT_CANCEL_VERSION;
+        }
+        this.log.info("Canceling job %s(%s). Job modify version?: %s", parms.jobname, parms.jobid, parms.version);
+        const headers: any = [];
+
+        // build request
+        const request: ICancelJob = {
+            request: JobsConstants.REQUEST_CANCEL,
+            version: parms.version,
+        };
+
+        const parameters: string = IO.FILE_DELIM + parms.jobname + IO.FILE_DELIM + parms.jobid;
+        await ZosmfRestClient.putExpectString(session, JobsConstants.RESOURCE + parameters, headers, request);
+    }
+
+
+    /**
+     * Getter for brightside logger
+     * @returns {Logger}
+     */
+    private static get log(): Logger {
+        return Logger.getAppLogger();
+    }
+}

--- a/packages/zosjobs/src/api/JobsConstants.ts
+++ b/packages/zosjobs/src/api/JobsConstants.ts
@@ -119,4 +119,18 @@ export class JobsConstants {
      * @memberof JobsConstants
      */
     public static readonly RESOURCE_SPOOL_CONTENT: string = "/records";
+
+    /**
+     * Cancel request constant
+     * @static
+     * @memberof JobsConstants
+     */
+    public static readonly REQUEST_CANCEL = "cancel";
+
+    /**
+     * Default version of cancel
+     * @static
+     * @memberof JobsConstants
+     */
+    public static readonly DEFAULT_CANCEL_VERSION = "1.0";
 }

--- a/packages/zosjobs/src/api/doc/input/ICancelJob.ts
+++ b/packages/zosjobs/src/api/doc/input/ICancelJob.ts
@@ -1,0 +1,32 @@
+/*
+* This program and the accompanying materials are made available under the terms of the *
+* Eclipse Public License v2.0 which accompanies this distribution, and is available at *
+* https://www.eclipse.org/legal/epl-v20.html                                      *
+*                                                                                 *
+* SPDX-License-Identifier: EPL-2.0                                                *
+*                                                                                 *
+* Copyright Contributors to the Zowe Project.                                     *
+*                                                                                 *
+*/
+
+/**
+ * Interface for payload to cancel a job.
+ * @export
+ * @interface ICancelJob
+ */
+export interface ICancelJob {
+
+    /**
+     * "cancel" is currently the only valid value
+     * @type {string}
+     * @memberof ICancelJob
+     */
+    request: string;
+
+    /**
+     * Version, at the time of writing, 1.0 or 2.0 are accepted.
+     * @type {string}
+     * @memberof ICancelJob
+     */
+    version: string;
+}

--- a/packages/zosjobs/src/api/doc/input/ICancelJobParms.ts
+++ b/packages/zosjobs/src/api/doc/input/ICancelJobParms.ts
@@ -1,0 +1,40 @@
+/*
+* This program and the accompanying materials are made available under the terms of the *
+* Eclipse Public License v2.0 which accompanies this distribution, and is available at *
+* https://www.eclipse.org/legal/epl-v20.html                                      *
+*                                                                                 *
+* SPDX-License-Identifier: EPL-2.0                                                *
+*                                                                                 *
+* Copyright Contributors to the Zowe Project.                                     *
+*                                                                                 *
+*/
+
+/**
+ * Interface for cancel job z/OSMF API
+ * @export
+ * @interface ICancelJobParms
+ */
+export interface ICancelJobParms {
+
+    /**
+     * job id for the job you want to cancel
+     * @type {string}
+     * @memberof ICancelJobParms
+     */
+    jobid: string;
+
+    /**
+     * job name for the job you want to cancel
+     * @type {string}
+     * @memberof ICancelJobParms
+     */
+    jobname: string;
+
+
+    /**
+     * version of the cancel request
+     * @type {string}
+     * @memberof ICancelJobParms
+     */
+    version?: string;
+}


### PR DESCRIPTION
Add API classes and tests for future CLI PR workings towards #97 .  

Modeled after Delete API with adjustments for the differences in z/OSMF delete API over cancel API (different headers & payloads).