### PR TITLE
Show retcode / CC and job ID in progress bar message  for `zos-jobs submit` commands

### DIFF
--- a/packages/zosjobs/src/api/SubmitJobs.ts
+++ b/packages/zosjobs/src/api/SubmitJobs.ts
@@ -101,16 +101,14 @@ export class SubmitJobs {
         if (parms.internalReaderLrecl) {
             this.log.debug("Custom internal reader logical record length (internalReaderLrecl) '%s' specified ", parms.internalReaderLrecl);
             headers.push({"X-IBM-Intrdr-Lrecl": parms.internalReaderLrecl});
-        }
-        else {
+        } else {
             // default to 80 record length
             headers.push(ZosmfHeaders.X_IBM_INTRDR_LRECL_80);
         }
         if (parms.internalReaderRecfm) {
             this.log.debug("Custom internal reader record format (internalReaderRecfm) '%s' specified ", parms.internalReaderRecfm);
             headers.push({"X-IBM-Intrdr-Recfm": parms.internalReaderRecfm});
-        }
-        else {
+        } else {
             // default to fixed format records
             headers.push(ZosmfHeaders.X_IBM_INTRDR_RECFM_F);
         }
@@ -199,7 +197,8 @@ export class SubmitJobs {
             }
             const job: IJob = await MonitorJobs.waitForJobOutputStatus(session, responseJobInfo);
             if (parms.task != null) {
-                parms.task.statusMessage = "Retrieving spool content";
+                parms.task.statusMessage = "Retrieving spool content for " + job.jobid +
+                    (job.retcode == null ? "" : ", " + job.retcode);
                 parms.task.percentComplete = TaskProgress.SEVENTY_PERCENT;
             }
             const spoolFiles: IJobFile[] = await GetJobs.getSpoolFilesForJob(session, job);

--- a/packages/zosjobs/src/api/SubmitJobs.ts
+++ b/packages/zosjobs/src/api/SubmitJobs.ts
@@ -233,7 +233,8 @@ export class SubmitJobs {
                 downloadParms.extension = IO.normalizeExtension(parms.extension);
             }
             if (parms.task != null) {
-                parms.task.statusMessage = "Downloading spool content";
+                parms.task.statusMessage = "Downloading spool content for " + job.jobid +
+                    (job.retcode == null ? "" : ", " + job.retcode);
                 parms.task.percentComplete = TaskProgress.SEVENTY_PERCENT;
             }
             (await DownloadJobs.downloadAllSpoolContentCommon(session, downloadParms));


### PR DESCRIPTION
Updates a progress bar message like so:

![image](https://user-images.githubusercontent.com/42545737/50660723-c9ebbe00-0f6e-11e9-9967-b76bf80d6466.png)
