### PR TITLE
Workflow CANCEL API

### DIFF
--- a/packages/workflows/__tests__/__system__/Cancel.system.test.ts
+++ b/packages/workflows/__tests__/__system__/Cancel.system.test.ts
@@ -1,0 +1,173 @@
+/*
+* This program and the accompanying materials are made available under the terms of the
+* Eclipse Public License v2.0 which accompanies this distribution, and is available at
+* https://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Copyright Contributors to the Zowe Project.
+*
+*/
+
+import { CreateWorkflow, DeleteWorkflow, CancelWorkflow } from "../..";
+import { Imperative, ImperativeError, Session } from "@brightside/imperative";
+import { ZosmfRestClient } from "../../../rest";
+import { TestEnvironment } from "../../../../__tests__/__src__/environment/TestEnvironment";
+import { TestProperties } from "../../../../__tests__/__src__/properties/TestProperties";
+import { Upload } from "../../../zosfiles/src/api/methods/upload";
+import { ITestEnvironment } from "../../../../__tests__/__src__/environment/doc/response/ITestEnvironment";
+import { ITestSystemSchema } from "../../../../__tests__/__src__/properties/ITestSystemSchema";
+import { ZosFilesConstants } from "../../../zosfiles/src/api";
+import { inspect } from "util";
+import { getUniqueDatasetName } from "../../../../__tests__/__src__/TestUtils";
+import { noSession, noWorkflowKey, nozOSMFVersion } from "../../src/api/WorkflowConstants";
+
+
+let REAL_SESSION: Session;
+let testEnvironment: ITestEnvironment;
+let systemProps: TestProperties;
+let defaultSystem: ITestSystemSchema;
+let definitionFile: string;
+let wfKey: string;
+let system: string;
+let owner: string;
+let wfName: string;
+
+const workflow = __dirname + "/testfiles/demo.xml";
+
+
+function expectZosmfResponseSucceeded(response: string, error: ImperativeError) {
+    expect(error).not.toBeDefined();
+    expect(response).toBeDefined();
+}
+
+function expectZosmfResponseFailed(response: string, error: ImperativeError, msg: string) {
+    expect(response).not.toBeDefined();
+    expect(error).toBeDefined();
+    expect(error.details.msg).toContain(msg);
+}
+
+describe("Cancel workflow", () => {
+    beforeAll(async () => {
+        testEnvironment = await TestEnvironment.setUp({
+            // tempProfileTypes: ["zosmf"],
+            testName: "create_workflow"
+        });
+        systemProps = new TestProperties(testEnvironment.systemTestProperties);
+        defaultSystem = systemProps.getDefaultSystem();
+        system = testEnvironment.systemTestProperties.workflows.system;
+        owner = defaultSystem.zosmf.user;
+        wfName = `${getUniqueDatasetName(owner)}`;
+        definitionFile = `${defaultSystem.unix.testdir}/${getUniqueDatasetName(owner)}.xml`;
+
+        REAL_SESSION = TestEnvironment.createZosmfSession(testEnvironment);
+    });
+
+    afterAll(async () => {
+        await TestEnvironment.cleanUp(testEnvironment);
+    });
+    describe("Success Scenarios", () => {
+        beforeAll(async () => {
+            // Upload files only for successful scenarios
+            await Upload.fileToUSSFile(REAL_SESSION, workflow, definitionFile, true);
+        });
+        afterAll(async () => {
+            let error;
+            let response;
+
+            const endpoint: string = ZosFilesConstants.RESOURCE + ZosFilesConstants.RES_USS_FILES;
+            // Deleting uploaded workflow file
+            try {
+                const wfEndpoint = endpoint + definitionFile;
+                response = await ZosmfRestClient.deleteExpectString(REAL_SESSION, wfEndpoint);
+            } catch (err) {
+                error = err;
+            }
+        });
+        beforeEach(async () =>{
+            const response = await CreateWorkflow.createWorkflow(REAL_SESSION, wfName, definitionFile, system, owner);
+            wfKey = response.workflowKey;
+        });
+        afterEach(async () => {
+            // deleting workflow
+            await DeleteWorkflow.deleteWorkflow(REAL_SESSION, wfKey);
+        });
+        it("Should cancel workflow in zOSMF.", async () => {
+            let error;
+            let response;
+
+            try {
+                response = await CancelWorkflow.cancelWorkflow(REAL_SESSION, wfKey);
+                Imperative.console.info("Response: " + inspect(response));
+            } catch (err) {
+                error = err;
+                Imperative.console.info("Error wut: " + inspect(error));
+            }
+            expectZosmfResponseSucceeded(response, error);
+        });
+        it("Successful even with zOSMF version undefined (because of default value).", async () => {
+            let error;
+            let response;
+
+            try {
+                response = await CancelWorkflow.cancelWorkflow(REAL_SESSION, wfKey, undefined);
+                Imperative.console.info("Response: " + inspect(response));
+            } catch (err) {
+                error = err;
+                Imperative.console.info("Error wut: " + inspect(error));
+            }
+            expectZosmfResponseSucceeded(response, error);
+         });
+    });
+    describe("Fail scenarios", () => {
+        // wfKey has value from last called CreateWorkflow
+        it("should throw an error if the session parameter is undefined", async () => {
+            let error: ImperativeError;
+            let response: any;
+            try {
+                response = await CancelWorkflow.cancelWorkflow(undefined, wfKey);
+                Imperative.console.info(`Response ${response}`);
+            } catch (thrownError) {
+                error = thrownError;
+                Imperative.console.info(`Error ${error}`);
+            }
+            expectZosmfResponseFailed(response, error, noSession.message);
+        });
+        it("should throw an error if the workflowKey parameter is undefined", async () => {
+            let error: ImperativeError;
+            let response: any;
+            try {
+                response = await CancelWorkflow.cancelWorkflow(REAL_SESSION, undefined);
+                Imperative.console.info(`Response ${response}`);
+            } catch (thrownError) {
+                error = thrownError;
+                Imperative.console.info(`Error ${error}`);
+            }
+            expectZosmfResponseFailed(response, error, noWorkflowKey.message);
+        });
+        it("Should throw error if workflowKey is empty string.", async () => {
+            let error: ImperativeError;
+            let response: any;
+            try {
+                response = await CancelWorkflow.cancelWorkflow(REAL_SESSION, "");
+                Imperative.console.info(`Response ${response}`);
+            } catch (thrownError) {
+                error = thrownError;
+                Imperative.console.info(`Error ${error}`);
+            }
+            expectZosmfResponseFailed(response, error, noWorkflowKey.message);
+        });
+        it("Should throw error if zOSMF version is empty string.", async () => {
+            let error: ImperativeError;
+            let response: any;
+            try {
+                response = await CancelWorkflow.cancelWorkflow(REAL_SESSION, wfKey, "");
+                Imperative.console.info(`Response ${response}`);
+            } catch (thrownError) {
+                error = thrownError;
+                Imperative.console.info(`Error ${error}`);
+            }
+            expectZosmfResponseFailed(response, error, nozOSMFVersion.message);
+        });
+    });
+});

--- a/packages/workflows/__tests__/__system__/Cancel.system.test.ts
+++ b/packages/workflows/__tests__/__system__/Cancel.system.test.ts
@@ -20,8 +20,7 @@ import { ITestSystemSchema } from "../../../../__tests__/__src__/properties/ITes
 import { ZosFilesConstants } from "../../../zosfiles/src/api";
 import { inspect } from "util";
 import { getUniqueDatasetName } from "../../../../__tests__/__src__/TestUtils";
-import { noSession, noWorkflowKey, nozOSMFVersion } from "../../src/api/WorkflowConstants";
-
+import { noSession, noWorkflowKey, nozOSMFVersion, WrongWorkflowKey } from "../../src/api/WorkflowConstants";
 
 let REAL_SESSION: Session;
 let testEnvironment: ITestEnvironment;
@@ -121,7 +120,7 @@ describe("Cancel workflow", () => {
     });
     describe("Fail scenarios", () => {
         // wfKey has value from last called CreateWorkflow
-        it("should throw an error if the session parameter is undefined", async () => {
+        it("Should throw an error if the session parameter is undefined", async () => {
             let error: ImperativeError;
             let response: any;
             try {
@@ -133,7 +132,7 @@ describe("Cancel workflow", () => {
             }
             expectZosmfResponseFailed(response, error, noSession.message);
         });
-        it("should throw an error if the workflowKey parameter is undefined", async () => {
+        it("Should throw an error if the workflowKey parameter is undefined", async () => {
             let error: ImperativeError;
             let response: any;
             try {
@@ -156,6 +155,22 @@ describe("Cancel workflow", () => {
                 Imperative.console.info(`Error ${error}`);
             }
             expectZosmfResponseFailed(response, error, noWorkflowKey.message);
+        });
+        it("Should throw error if workflow does not exist (workflowKey is wrong).", async () => {
+            let error: ImperativeError;
+            let response: any;
+            try {
+                response = await CancelWorkflow.cancelWorkflow(REAL_SESSION, "blabla");
+                Imperative.console.info(`Response ${response}`);
+            } catch (thrownError) {
+                error = thrownError;
+                Imperative.console.info(`Error ${error}`);
+            }
+            expectZosmfResponseFailed(response, error, WrongWorkflowKey.message);
+            // parse from message the workflow key
+            const actual: string = JSON.stringify(error);
+            const expected: RegExp = /The workflow key .+ was not found/gm;
+            expect(actual).toEqual(expect.stringMatching(expected));
         });
         it("Should throw error if zOSMF version is empty string.", async () => {
             let error: ImperativeError;

--- a/packages/workflows/__tests__/api/Cancel.unit.test.ts
+++ b/packages/workflows/__tests__/api/Cancel.unit.test.ts
@@ -1,0 +1,140 @@
+/*
+* This program and the accompanying materials are made available under the terms of the
+* Eclipse Public License v2.0 which accompanies this distribution, and is available at
+* https://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Copyright Contributors to the Zowe Project.
+*
+*/
+
+import { ZosmfRestClient } from "../../../rest";
+import { Session, ImperativeError, Imperative, Headers } from "@brightside/imperative";
+import { CancelWorkflow } from "../..";
+import { WorkflowConstants, noSession, noWorkflowKey, nozOSMFVersion } from "../../src/api/WorkflowConstants";
+
+const wfKey = "1234567_abcde";
+
+let START_RESOURCE_QUERY: string = `${WorkflowConstants.RESOURCE}/${WorkflowConstants.ZOSMF_VERSION}/`;
+START_RESOURCE_QUERY += `${WorkflowConstants.WORKFLOW_RESOURCE}/${wfKey}/${WorkflowConstants.CANCEL_WORKFLOW}`;
+
+
+const PRETEND_SESSION = new Session({
+    user: "usr",
+    password: "pasword",
+    hostname: "host.com",
+    port: 443,
+    type: "basic",
+    rejectUnauthorized: false
+});
+
+
+function expectZosmfResponseSucceeded(response: any, error: ImperativeError) {
+    expect(error).not.toBeDefined();
+    expect(response).toBeDefined();
+}
+
+function expectZosmfResponseFailed(response: any, error: ImperativeError, msg: string) {
+    expect(response).not.toBeDefined();
+    expect(error).toBeDefined();
+    expect(error.details.msg).toContain(msg);
+}
+
+
+describe("Cancel workflow", () => {
+    describe("Successful scenarios", () => {
+        it("Successful call returns 204 - No Content.", async () => {
+
+            (ZosmfRestClient.putExpectString as any) = jest.fn<string>(() => {
+                return "";
+            });
+
+            let error: ImperativeError;
+            let response: any;
+            try {
+                response = await CancelWorkflow.cancelWorkflow(PRETEND_SESSION, wfKey);
+                Imperative.console.info(`Response ${response}`);
+            } catch (thrownError) {
+                error = thrownError;
+                Imperative.console.info(`Error ${error}`);
+            }
+            expect((ZosmfRestClient.putExpectString as any)).toHaveBeenCalledTimes(1);
+            expect((ZosmfRestClient.putExpectString as any)).toHaveBeenCalledWith(PRETEND_SESSION, START_RESOURCE_QUERY,
+                                                                                 [Headers.APPLICATION_JSON], {});
+            expectZosmfResponseSucceeded(response, error);
+            expect(response).toEqual("");
+        });
+        it("Successful even with zOSMF version undefined (because of default value).", async () => {
+
+            (ZosmfRestClient.putExpectString as any) = jest.fn<string>(() => {
+                return "";
+            });
+
+            let error: ImperativeError;
+            let response: any;
+            try {
+                response = await CancelWorkflow.cancelWorkflow(PRETEND_SESSION, wfKey, undefined);
+                Imperative.console.info(`Response ${response}`);
+            } catch (thrownError) {
+                error = thrownError;
+                Imperative.console.info(`Error ${error}`);
+            }
+            expect((ZosmfRestClient.putExpectString as any)).toHaveBeenCalledTimes(1);
+            expect((ZosmfRestClient.putExpectString as any)).toHaveBeenCalledWith(PRETEND_SESSION, START_RESOURCE_QUERY,
+                                                                                 [Headers.APPLICATION_JSON], {});
+            expectZosmfResponseSucceeded(response, error);
+            expect(response).toEqual("");
+        });
+    });
+    describe("Fail scenarios", () => {
+        it("should throw an error if the session parameter is undefined", async () => {
+            let error: ImperativeError;
+            let response: any;
+            try {
+                response = await CancelWorkflow.cancelWorkflow(undefined, wfKey);
+                Imperative.console.info(`Response ${response}`);
+            } catch (thrownError) {
+                error = thrownError;
+                Imperative.console.info(`Error ${error}`);
+            }
+            expectZosmfResponseFailed(response, error, noSession.message);
+        });
+        it("should throw an error if the workflowKey parameter is undefined", async () => {
+            let error: ImperativeError;
+            let response: any;
+            try {
+                response = await CancelWorkflow.cancelWorkflow(PRETEND_SESSION, undefined);
+                Imperative.console.info(`Response ${response}`);
+            } catch (thrownError) {
+                error = thrownError;
+                Imperative.console.info(`Error ${error}`);
+            }
+            expectZosmfResponseFailed(response, error, noWorkflowKey.message);
+        });
+        it("Should throw error if workflowKey is empty string.", async () => {
+            let error: ImperativeError;
+            let response: any;
+            try {
+                response = await CancelWorkflow.cancelWorkflow(PRETEND_SESSION, "");
+                Imperative.console.info(`Response ${response}`);
+            } catch (thrownError) {
+                error = thrownError;
+                Imperative.console.info(`Error ${error}`);
+            }
+            expectZosmfResponseFailed(response, error, noWorkflowKey.message);
+        });
+        it("Should throw error if zOSMF version is empty string.", async () => {
+            let error: ImperativeError;
+            let response: any;
+            try {
+                response = await CancelWorkflow.cancelWorkflow(PRETEND_SESSION, wfKey, "");
+                Imperative.console.info(`Response ${response}`);
+            } catch (thrownError) {
+                error = thrownError;
+                Imperative.console.info(`Error ${error}`);
+            }
+            expectZosmfResponseFailed(response, error, nozOSMFVersion.message);
+        });
+    });
+});

--- a/packages/workflows/__tests__/api/Cancel.unit.test.ts
+++ b/packages/workflows/__tests__/api/Cancel.unit.test.ts
@@ -88,7 +88,7 @@ describe("Cancel workflow", () => {
         });
     });
     describe("Fail scenarios", () => {
-        it("should throw an error if the session parameter is undefined", async () => {
+        it("Should throw an error if the session parameter is undefined", async () => {
             let error: ImperativeError;
             let response: any;
             try {
@@ -100,7 +100,7 @@ describe("Cancel workflow", () => {
             }
             expectZosmfResponseFailed(response, error, noSession.message);
         });
-        it("should throw an error if the workflowKey parameter is undefined", async () => {
+        it("Should throw an error if the workflowKey parameter is undefined", async () => {
             let error: ImperativeError;
             let response: any;
             try {

--- a/packages/workflows/index.ts
+++ b/packages/workflows/index.ts
@@ -24,3 +24,4 @@ export * from "./src/api/Delete";
 export * from "./src/api/Start";
 export * from "./src/api/Properties";
 export * from "./src/api/ListWorkflows";
+export * from "./src/api/Cancel";

--- a/packages/workflows/src/api/Cancel.ts
+++ b/packages/workflows/src/api/Cancel.ts
@@ -1,0 +1,42 @@
+/*
+* This program and the accompanying materials are made available under the terms of the
+* Eclipse Public License v2.0 which accompanies this distribution, and is available at
+* https://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Copyright Contributors to the Zowe Project.
+*
+*/
+
+
+import { AbstractSession, Headers } from "@brightside/imperative";
+import { ZosmfRestClient } from "../../../rest";
+import { WorkflowConstants, nozOSMFVersion, noWorkflowKey } from "./WorkflowConstants";
+import { WorkflowValidator } from "./WorkflowValidator";
+
+/**
+ * Class to handle canceling of zOSMF workflow instance
+ */
+export class CancelWorkflow {
+
+    /**
+     * Cancel a workflow instance
+     * @param {AbstractSession} session                     - z/OSMF connection info
+     * @param {string} workflowKey                          - Unique identifier of the workflow instance.
+     * @param {string} zOSMFVersion                         - Identifies the version of the zOSMF workflow service.
+     * @returns {Promise}
+     * @memberof CancelWorkflow
+     */
+ public static async cancelWorkflow(session: AbstractSession, workflowKey: string, zOSMFVersion = WorkflowConstants.ZOSMF_VERSION){
+    WorkflowValidator.validateSession(session);
+    WorkflowValidator.validateNotEmptyString(zOSMFVersion, nozOSMFVersion.message);
+    WorkflowValidator.validateNotEmptyString(workflowKey, noWorkflowKey.message);
+
+    const data = {};
+    let resourcesQuery: string = `${WorkflowConstants.RESOURCE}/${zOSMFVersion}/`;
+    resourcesQuery += `${WorkflowConstants.WORKFLOW_RESOURCE}/${workflowKey}/${WorkflowConstants.CANCEL_WORKFLOW}`;
+
+    return ZosmfRestClient.putExpectString(session, resourcesQuery, [Headers.APPLICATION_JSON], data);
+ }
+}

--- a/packages/workflows/src/api/Cancel.ts
+++ b/packages/workflows/src/api/Cancel.ts
@@ -25,7 +25,7 @@ export class CancelWorkflow {
      * @param {AbstractSession} session                     - z/OSMF connection info
      * @param {string} workflowKey                          - Unique identifier of the workflow instance.
      * @param {string} zOSMFVersion                         - Identifies the version of the zOSMF workflow service.
-     * @returns {Promise}
+     * @returns {Promise<string>}                           - Promise that specifies the new name of the canceled workflow.
      * @memberof CancelWorkflow
      */
  public static async cancelWorkflow(session: AbstractSession, workflowKey: string, zOSMFVersion = WorkflowConstants.ZOSMF_VERSION){
@@ -33,10 +33,9 @@ export class CancelWorkflow {
     WorkflowValidator.validateNotEmptyString(zOSMFVersion, nozOSMFVersion.message);
     WorkflowValidator.validateNotEmptyString(workflowKey, noWorkflowKey.message);
 
-    const data = {};
     let resourcesQuery: string = `${WorkflowConstants.RESOURCE}/${zOSMFVersion}/`;
     resourcesQuery += `${WorkflowConstants.WORKFLOW_RESOURCE}/${workflowKey}/${WorkflowConstants.CANCEL_WORKFLOW}`;
 
-    return ZosmfRestClient.putExpectString(session, resourcesQuery, [Headers.APPLICATION_JSON], data);
+    return ZosmfRestClient.putExpectString(session, resourcesQuery, [Headers.APPLICATION_JSON], {} );
  }
 }

--- a/packages/workflows/src/api/WorkflowConstants.ts
+++ b/packages/workflows/src/api/WorkflowConstants.ts
@@ -43,6 +43,14 @@ export class WorkflowConstants {
     public static readonly START_WORKFLOW: string = "operations/start";
 
     /**
+     * URI base for canceling workflow API.
+     * @static
+     * @type {string}
+     * @memberof WorkflowConstants
+     */
+    public static readonly CANCEL_WORKFLOW: string = "operations/cancel";
+
+    /**
      * URI base for list workflows from registry API.
      * @static
      * @type {string}

--- a/packages/workflows/src/api/WorkflowConstants.ts
+++ b/packages/workflows/src/api/WorkflowConstants.ts
@@ -178,6 +178,18 @@ export const nozOSMFVersion: IMessageDefinition = {
 export const noWorkflowKey: IMessageDefinition = {
     message: apiErrorHeader + `No workflow key parameter was supplied.`
 };
+
+/**
+ * Error message that workflow key that was supplied does not exist.
+ * IZUWF5001W: The workflow key "workflowkey" was not found.
+ * @static
+ * @type {IMessageDefinition}
+ * @memberof WorkflowConstants
+ */
+export const WrongWorkflowKey: IMessageDefinition = {
+    message: "IZUWF5001W"
+    };
+
 /**
  * Error message that no steps parameter was supplied.
  * @static


### PR DESCRIPTION
API for operation to cancel a z/OSMF workflow on a z/OS system. This operation is used to cancel a workflow. Canceling a workflow does not undo any actions that were already performed on the system as part of the workflow.
Unit and system tests added