### PR TITLE
Fix/204

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,15 +4,15 @@
   "description": "Zowe CLI is a command line interface (CLI) that provides a simple and streamlined way to interact with IBM z/OS.",
   "author": "Broadcom",
   "license": "EPL-2.0",
-  "repository":   {
+  "repository": {
     "type": "git",
     "url": "https://github.com/zowe/zowe-cli.git"
   },
-  "bin":   {
+  "bin": {
     "bright": "./lib/main.js",
     "zowe": "./lib/main.js"
   },
-  "keywords":   [
+  "keywords": [
     "zosmf",
     "mainframe",
     "CLI",
@@ -23,16 +23,20 @@
     "z/OS",
     "zowe"
   ],
-  "files":   [
+  "files": [
     "lib",
     "docs",
     "scripts"
   ],
-  "publishConfig": {"registry": "https://gizaartifactory.jfrog.io/gizaartifactory/api/npm/npm-local-release/"},
-  "imperative": {"configurationModule": "lib/imperative.js"},
+  "publishConfig": {
+    "registry": "https://gizaartifactory.jfrog.io/gizaartifactory/api/npm/npm-local-release/"
+  },
+  "imperative": {
+    "configurationModule": "lib/imperative.js"
+  },
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
-  "scripts":   {
+  "scripts": {
     "generateCleanTypedoc": "npm run typedoc && gulp cleanTypedoc",
     "build": "gulp updateLicense && tsc --pretty && npm run lint && npm run checkTestsCompile && madge -c lib",
     "installWithBuild": "npm install && npm run build",
@@ -55,12 +59,12 @@
     "typedocSpecifySrc": "typedoc --options ./typedoc.json",
     "audit:public": "npm audit --registry https://registry.npmjs.org/"
   },
-  "dependencies":   {
+  "dependencies": {
     "@brightside/imperative": "^2.1.4-alpha.201902221433",
     "js-yaml": "3.9.0",
     "string-width": "2.1.1"
   },
-  "devDependencies":   {
+  "devDependencies": {
     "@types/chai": "^4.0.1",
     "@types/chai-string": "^1.1.30",
     "@types/jest": "^22.2.3",
@@ -106,29 +110,43 @@
     "typescript": "^2.6.2",
     "uuid": "^3.3.2"
   },
-  "resolutions": {"cpx/chokidar": "^2.1.1"},
-  "engines": {"node": ">=6.0.0"},
-  "jest":   {
-    "globals": {"ts-jest": {"disableSourceMapSupport": true}},
-    "watchPathIgnorePatterns": [".*jest-stare.*\\.js"],
-    "modulePathIgnorePatterns": ["__tests__/__snapshots__/"],
+  "resolutions": {
+    "cpx/chokidar": "^2.1.1"
+  },
+  "engines": {
+    "node": ">=6.0.0"
+  },
+  "jest": {
+    "globals": {
+      "ts-jest": {
+        "disableSourceMapSupport": true
+      }
+    },
+    "watchPathIgnorePatterns": [
+      ".*jest-stare.*\\.js"
+    ],
+    "modulePathIgnorePatterns": [
+      "__tests__/__snapshots__/"
+    ],
     "setupTestFrameworkScriptFile": "./__tests__/beforeTests.js",
     "testResultsProcessor": "jest-stare",
-    "transform": {".(ts)": "ts-jest"},
+    "transform": {
+      ".(ts)": "ts-jest"
+    },
     "testRegex": "__tests__.*\\.(spec|test)\\.ts$",
-    "moduleFileExtensions":     [
+    "moduleFileExtensions": [
       "ts",
       "js"
     ],
     "testEnvironment": "node",
-    "collectCoverageFrom":     [
+    "collectCoverageFrom": [
       "packages/**/*.ts",
       "!**/__tests__/**",
       "!packages/**/doc/I*.ts",
       "!**/main.ts"
     ],
     "collectCoverage": false,
-    "coverageReporters":     [
+    "coverageReporters": [
       "json",
       "lcov",
       "text",
@@ -136,14 +154,18 @@
     ],
     "coverageDirectory": "<rootDir>/__tests__/__results__/unit/coverage"
   },
-  "jestSonar": {"reportPath": "__tests__/__results__/jest-sonar"},
-  "jest-stare":   {
+  "jestSonar": {
+    "reportPath": "__tests__/__results__/jest-sonar"
+  },
+  "jest-stare": {
     "resultDir": "__tests__/__results__/jest-stare",
     "coverageLink": "../unit/coverage/lcov-report/index.html",
-    "additionalResultsProcessors":     [
+    "additionalResultsProcessors": [
       "jest-junit",
       "jest-sonar-reporter"
     ]
   },
-  "jest-junit": {"output": "__tests__/__results__/junit.xml"}
+  "jest-junit": {
+    "output": "__tests__/__results__/junit.xml"
+  }
 }

--- a/packages/zosfiles/__tests__/__integration__/cli/upload/dtu/__scripts__/command_upload_dtu_help.sh
+++ b/packages/zosfiles/__tests__/__integration__/cli/upload/dtu/__scripts__/command_upload_dtu_help.sh
@@ -2,12 +2,12 @@
 set -e
 
 echo "================ Z/OS FILES UPLOAD LOCAL DIRECTORY TO USS DIRECTORY HELP==============="
-zowe zos-files upload file-to-uss --help
+zowe zos-files upload dir-to-uss --help
 if [ $? -gt 0 ]
 then
     exit $?
 fi
 
 echo "================ Z/OS FILES UPLOAD LOCAL DIRECTORY TO USS DIRECTORY HELP WITH RFJ==============="
-zowe zos-files upload file-to-uss --help --rfj
+zowe zos-files upload dir-to-uss --help --rfj
 exit $?

--- a/packages/zosfiles/__tests__/__integration__/cli/upload/dtu/__snapshots__/cli.files.upload.dtu.integration.test.ts.snap
+++ b/packages/zosfiles/__tests__/__integration__/cli/upload/dtu/__snapshots__/cli.files.upload.dtu.integration.test.ts.snap
@@ -6,28 +6,28 @@ exports[`Upload local dir to uss dir should display the help 1`] = `
  COMMAND NAME
  ------------
 
-   file-to-uss | ftu
+   dir-to-uss | dtu
 
  DESCRIPTION
  -----------
 
-   Upload content to a USS file from local file
+   Upload a local directory to a USS directory
 
  USAGE
  -----
 
-   zowe zos-files upload file-to-uss <inputfile> <USSFileName> [options]
+   zowe zos-files upload dir-to-uss <inputDir> <USSDir> [options]
 
  POSITIONAL ARGUMENTS
  --------------------
 
-   inputfile		 (string)
+   inputDir		 (string)
 
-      The local file that you want to upload to a USS file
+      The local directory path that you want to upload to a USS directory
 
-   USSFileName		 (string)
+   USSDir		 (string)
 
-      The name of the USS file to which you want to upload the file
+      The name of the USS directory to which you want to upload the local directory
 
  OPTIONS
  -------
@@ -37,6 +37,37 @@ exports[`Upload local dir to uss dir should display the help 1`] = `
       Data content in binary mode, which means that no data conversion is performed.
       The data transfer process returns each record as-is, without translation. No
       delimiters are added between records.
+
+   --recursive  | -r (boolean)
+
+      Upload all directories recursively.
+
+   --binary-files  | --bf (string)
+
+      Comma separated list of file names to be uploaded in binary mode. Use this
+      option when you upload a directory in default ASCII mode, but you want to
+      specify certain files to be uploaded in binary mode. All files matching
+      specified file names will be uploaded in binary mode.
+
+   --ascii-files  | --af (string)
+
+      Comma separated list of file names to be uploaded in ASCII mode. Use this option
+      when you upload a directory with --binary/-b flag, but you want to specify
+      certain files to be uploaded in ASCII mode. All files matching specified file
+      names will be uploaded in ASCII mode.
+
+   --max-concurrent-requests  | --mcr (number)
+
+      Specifies the maximum number of concurrent z/OSMF REST API requests to upload
+      files. Increasing the value results in faster uploads. However, increasing the
+      value increases resource consumption on z/OS and can be prone to errors caused
+      by making too many concurrent requests. If the upload process encounters an
+      error, the following message displays:
+      The maximum number of TSO address spaces were created. When you specify 0, Zowe
+      CLI attempts to upload all members at once without a maximum number of
+      concurrent requests.
+
+      Default value: 1
 
  ZOSMF CONNECTION OPTIONS
  ------------------------
@@ -93,17 +124,34 @@ exports[`Upload local dir to uss dir should display the help 1`] = `
  EXAMPLES
  --------
 
-   - Upload to the USS file \\"/a/ibmuser/my_text.txt\\" from the
-   file \\"file.txt\\":
+   - Upload all files from the \\"local_dir\\" directory to the
+   \\"/a/ibmuser/my_dir\\" USS directory:\\":
 
-      $ zowe zos-files upload file-to-uss \\"file.txt\\" \\"/a/ibmuser/my_text.txt\\"
+      $ zowe zos-files upload dir-to-uss \\"local_dir\\" \\"/a/ibmuser/my_dir\\"
+
+   - Upload all files from the \\"local_dir\\" directory and all its
+   sub-directories, to the \\"/a/ibmuser/my_dir\\" USS directory::
+
+      $ zowe zos-files upload dir-to-uss \\"local_dir\\" \\"/a/ibmuser/my_dir\\" --recursive
+
+   - Upload all files from the \\"local_dir\\" directory to the
+   \\"/a/ibmuser/my_dir\\" USS directory in default ASCII mode, while specifying a list
+   of file names (without path) to be uploaded in binary mode::
+
+      $ zowe zos-files upload dir-to-uss \\"local_dir\\" \\"/a/ibmuser/my_dir\\" --binary-files \\"myFile1.exe,myFile2.exe,myFile3.exe\\"
+
+   - Upload all files from the \\"local_dir\\" directory to the
+   \\"/a/ibmuser/my_dir\\" USS directory in binary mode, while specifying a list of
+   file names (without path) to be uploaded in ASCII mode::
+
+      $ zowe zos-files upload dir-to-uss \\"local_dir\\" \\"/a/ibmuser/my_dir\\" --binary --ascii-files \\"myFile1.txt,myFile2.txt,myFile3.txt\\"
 
 ================ Z/OS FILES UPLOAD LOCAL DIRECTORY TO USS DIRECTORY HELP WITH RFJ===============
 {
   \\"success\\": true,
-  \\"message\\": \\"The help was constructed for command: file-to-uss.\\",
-  \\"stdout\\": \\"\\\\n COMMAND NAME\\\\n ------------\\\\n\\\\n   file-to-uss | ftu\\\\n\\\\n DESCRIPTION\\\\n -----------\\\\n\\\\n   Upload content to a USS file from local file\\\\n\\\\n USAGE\\\\n -----\\\\n\\\\n   zowe zos-files upload file-to-uss <inputfile> <USSFileName> [options]\\\\n\\\\n POSITIONAL ARGUMENTS\\\\n --------------------\\\\n\\\\n   inputfile\\\\t\\\\t (string)\\\\n\\\\n      The local file that you want to upload to a USS file\\\\n\\\\n   USSFileName\\\\t\\\\t (string)\\\\n\\\\n      The name of the USS file to which you want to upload the file\\\\n\\\\n OPTIONS\\\\n -------\\\\n\\\\n   --binary  | -b (boolean)\\\\n\\\\n      Data content in binary mode, which means that no data conversion is performed.\\\\n      The data transfer process returns each record as-is, without translation. No\\\\n      delimiters are added between records.\\\\n\\\\n ZOSMF CONNECTION OPTIONS\\\\n ------------------------\\\\n\\\\n   --host  | -H (string)\\\\n\\\\n      The z/OSMF server host name.\\\\n\\\\n   --port  | -P (number)\\\\n\\\\n      The z/OSMF server port.\\\\n\\\\n      Default value: 443\\\\n\\\\n   --user  | -u (string)\\\\n\\\\n      Mainframe (z/OSMF) user name, which can be the same as your TSO login.\\\\n\\\\n   --password  | --pass | --pw (string)\\\\n\\\\n      Mainframe (z/OSMF) password, which can be the same as your TSO password.\\\\n\\\\n   --reject-unauthorized  | --ru (boolean)\\\\n\\\\n      Reject self-signed certificates.\\\\n\\\\n      Default value: true\\\\n\\\\n   --base-path  | --bp (string)\\\\n\\\\n      The base path for your API mediation layer instance. Specify this option to\\\\n      prepend the base path to all z/OSMF resources when making REST requests. Do not\\\\n      specify this option if you are not using an API mediation layer.\\\\n\\\\n PROFILE OPTIONS\\\\n ---------------\\\\n\\\\n   --zosmf-profile  | --zosmf-p (string)\\\\n\\\\n      The name of a (zosmf) profile to load for this command execution.\\\\n\\\\n GLOBAL OPTIONS\\\\n --------------\\\\n\\\\n   --response-format-json  | --rfj (boolean)\\\\n\\\\n      Produce JSON formatted data from a command\\\\n\\\\n   --help  | -h (boolean)\\\\n\\\\n      Display help text\\\\n\\\\n\\\\n EXAMPLES\\\\n --------\\\\n\\\\n   - Upload to the USS file \\\\\\"/a/ibmuser/my_text.txt\\\\\\" from the\\\\n   file \\\\\\"file.txt\\\\\\":\\\\n\\\\n      $ zowe zos-files upload file-to-uss \\\\\\"file.txt\\\\\\" \\\\\\"/a/ibmuser/my_text.txt\\\\\\"\\\\n\\\\n\\",
+  \\"message\\": \\"The help was constructed for command: dir-to-uss.\\",
+  \\"stdout\\": \\"\\\\n COMMAND NAME\\\\n ------------\\\\n\\\\n   dir-to-uss | dtu\\\\n\\\\n DESCRIPTION\\\\n -----------\\\\n\\\\n   Upload a local directory to a USS directory\\\\n\\\\n USAGE\\\\n -----\\\\n\\\\n   zowe zos-files upload dir-to-uss <inputDir> <USSDir> [options]\\\\n\\\\n POSITIONAL ARGUMENTS\\\\n --------------------\\\\n\\\\n   inputDir\\\\t\\\\t (string)\\\\n\\\\n      The local directory path that you want to upload to a USS directory\\\\n\\\\n   USSDir\\\\t\\\\t (string)\\\\n\\\\n      The name of the USS directory to which you want to upload the local directory\\\\n\\\\n OPTIONS\\\\n -------\\\\n\\\\n   --binary  | -b (boolean)\\\\n\\\\n      Data content in binary mode, which means that no data conversion is performed.\\\\n      The data transfer process returns each record as-is, without translation. No\\\\n      delimiters are added between records.\\\\n\\\\n   --recursive  | -r (boolean)\\\\n\\\\n      Upload all directories recursively.\\\\n\\\\n   --binary-files  | --bf (string)\\\\n\\\\n      Comma separated list of file names to be uploaded in binary mode. Use this\\\\n      option when you upload a directory in default ASCII mode, but you want to\\\\n      specify certain files to be uploaded in binary mode. All files matching\\\\n      specified file names will be uploaded in binary mode.\\\\n\\\\n   --ascii-files  | --af (string)\\\\n\\\\n      Comma separated list of file names to be uploaded in ASCII mode. Use this option\\\\n      when you upload a directory with --binary/-b flag, but you want to specify\\\\n      certain files to be uploaded in ASCII mode. All files matching specified file\\\\n      names will be uploaded in ASCII mode.\\\\n\\\\n   --max-concurrent-requests  | --mcr (number)\\\\n\\\\n      Specifies the maximum number of concurrent z/OSMF REST API requests to upload\\\\n      files. Increasing the value results in faster uploads. However, increasing the\\\\n      value increases resource consumption on z/OS and can be prone to errors caused\\\\n      by making too many concurrent requests. If the upload process encounters an\\\\n      error, the following message displays:\\\\n      The maximum number of TSO address spaces were created. When you specify 0, Zowe\\\\n      CLI attempts to upload all members at once without a maximum number of\\\\n      concurrent requests.\\\\n\\\\n      Default value: 1\\\\n\\\\n ZOSMF CONNECTION OPTIONS\\\\n ------------------------\\\\n\\\\n   --host  | -H (string)\\\\n\\\\n      The z/OSMF server host name.\\\\n\\\\n   --port  | -P (number)\\\\n\\\\n      The z/OSMF server port.\\\\n\\\\n      Default value: 443\\\\n\\\\n   --user  | -u (string)\\\\n\\\\n      Mainframe (z/OSMF) user name, which can be the same as your TSO login.\\\\n\\\\n   --password  | --pass | --pw (string)\\\\n\\\\n      Mainframe (z/OSMF) password, which can be the same as your TSO password.\\\\n\\\\n   --reject-unauthorized  | --ru (boolean)\\\\n\\\\n      Reject self-signed certificates.\\\\n\\\\n      Default value: true\\\\n\\\\n   --base-path  | --bp (string)\\\\n\\\\n      The base path for your API mediation layer instance. Specify this option to\\\\n      prepend the base path to all z/OSMF resources when making REST requests. Do not\\\\n      specify this option if you are not using an API mediation layer.\\\\n\\\\n PROFILE OPTIONS\\\\n ---------------\\\\n\\\\n   --zosmf-profile  | --zosmf-p (string)\\\\n\\\\n      The name of a (zosmf) profile to load for this command execution.\\\\n\\\\n GLOBAL OPTIONS\\\\n --------------\\\\n\\\\n   --response-format-json  | --rfj (boolean)\\\\n\\\\n      Produce JSON formatted data from a command\\\\n\\\\n   --help  | -h (boolean)\\\\n\\\\n      Display help text\\\\n\\\\n\\\\n EXAMPLES\\\\n --------\\\\n\\\\n   - Upload all files from the \\\\\\"local_dir\\\\\\" directory to the\\\\n   \\\\\\"/a/ibmuser/my_dir\\\\\\" USS directory:\\\\\\":\\\\n\\\\n      $ zowe zos-files upload dir-to-uss \\\\\\"local_dir\\\\\\" \\\\\\"/a/ibmuser/my_dir\\\\\\"\\\\n\\\\n   - Upload all files from the \\\\\\"local_dir\\\\\\" directory and all its\\\\n   sub-directories, to the \\\\\\"/a/ibmuser/my_dir\\\\\\" USS directory::\\\\n\\\\n      $ zowe zos-files upload dir-to-uss \\\\\\"local_dir\\\\\\" \\\\\\"/a/ibmuser/my_dir\\\\\\" --recursive\\\\n\\\\n   - Upload all files from the \\\\\\"local_dir\\\\\\" directory to the\\\\n   \\\\\\"/a/ibmuser/my_dir\\\\\\" USS directory in default ASCII mode, while specifying a list\\\\n   of file names (without path) to be uploaded in binary mode::\\\\n\\\\n      $ zowe zos-files upload dir-to-uss \\\\\\"local_dir\\\\\\" \\\\\\"/a/ibmuser/my_dir\\\\\\" --binary-files \\\\\\"myFile1.exe,myFile2.exe,myFile3.exe\\\\\\"\\\\n\\\\n   - Upload all files from the \\\\\\"local_dir\\\\\\" directory to the\\\\n   \\\\\\"/a/ibmuser/my_dir\\\\\\" USS directory in binary mode, while specifying a list of\\\\n   file names (without path) to be uploaded in ASCII mode::\\\\n\\\\n      $ zowe zos-files upload dir-to-uss \\\\\\"local_dir\\\\\\" \\\\\\"/a/ibmuser/my_dir\\\\\\" --binary --ascii-files \\\\\\"myFile1.txt,myFile2.txt,myFile3.txt\\\\\\"\\\\n\\\\n\\",
   \\"stderr\\": \\"\\",
-  \\"data\\": \\"\\\\n COMMAND NAME\\\\n ------------\\\\n\\\\n   file-to-uss | ftu\\\\n\\\\n DESCRIPTION\\\\n -----------\\\\n\\\\n   Upload content to a USS file from local file\\\\n\\\\n USAGE\\\\n -----\\\\n\\\\n   zowe zos-files upload file-to-uss <inputfile> <USSFileName> [options]\\\\n\\\\n POSITIONAL ARGUMENTS\\\\n --------------------\\\\n\\\\n   inputfile\\\\t\\\\t (string)\\\\n\\\\n      The local file that you want to upload to a USS file\\\\n\\\\n   USSFileName\\\\t\\\\t (string)\\\\n\\\\n      The name of the USS file to which you want to upload the file\\\\n\\\\n OPTIONS\\\\n -------\\\\n\\\\n   --binary  | -b (boolean)\\\\n\\\\n      Data content in binary mode, which means that no data conversion is performed.\\\\n      The data transfer process returns each record as-is, without translation. No\\\\n      delimiters are added between records.\\\\n\\\\n ZOSMF CONNECTION OPTIONS\\\\n ------------------------\\\\n\\\\n   --host  | -H (string)\\\\n\\\\n      The z/OSMF server host name.\\\\n\\\\n   --port  | -P (number)\\\\n\\\\n      The z/OSMF server port.\\\\n\\\\n      Default value: 443\\\\n\\\\n   --user  | -u (string)\\\\n\\\\n      Mainframe (z/OSMF) user name, which can be the same as your TSO login.\\\\n\\\\n   --password  | --pass | --pw (string)\\\\n\\\\n      Mainframe (z/OSMF) password, which can be the same as your TSO password.\\\\n\\\\n   --reject-unauthorized  | --ru (boolean)\\\\n\\\\n      Reject self-signed certificates.\\\\n\\\\n      Default value: true\\\\n\\\\n   --base-path  | --bp (string)\\\\n\\\\n      The base path for your API mediation layer instance. Specify this option to\\\\n      prepend the base path to all z/OSMF resources when making REST requests. Do not\\\\n      specify this option if you are not using an API mediation layer.\\\\n\\\\n PROFILE OPTIONS\\\\n ---------------\\\\n\\\\n   --zosmf-profile  | --zosmf-p (string)\\\\n\\\\n      The name of a (zosmf) profile to load for this command execution.\\\\n\\\\n GLOBAL OPTIONS\\\\n --------------\\\\n\\\\n   --response-format-json  | --rfj (boolean)\\\\n\\\\n      Produce JSON formatted data from a command\\\\n\\\\n   --help  | -h (boolean)\\\\n\\\\n      Display help text\\\\n\\\\n\\\\n EXAMPLES\\\\n --------\\\\n\\\\n   - Upload to the USS file \\\\\\"/a/ibmuser/my_text.txt\\\\\\" from the\\\\n   file \\\\\\"file.txt\\\\\\":\\\\n\\\\n      $ zowe zos-files upload file-to-uss \\\\\\"file.txt\\\\\\" \\\\\\"/a/ibmuser/my_text.txt\\\\\\"\\\\n\\\\n\\"
+  \\"data\\": \\"\\\\n COMMAND NAME\\\\n ------------\\\\n\\\\n   dir-to-uss | dtu\\\\n\\\\n DESCRIPTION\\\\n -----------\\\\n\\\\n   Upload a local directory to a USS directory\\\\n\\\\n USAGE\\\\n -----\\\\n\\\\n   zowe zos-files upload dir-to-uss <inputDir> <USSDir> [options]\\\\n\\\\n POSITIONAL ARGUMENTS\\\\n --------------------\\\\n\\\\n   inputDir\\\\t\\\\t (string)\\\\n\\\\n      The local directory path that you want to upload to a USS directory\\\\n\\\\n   USSDir\\\\t\\\\t (string)\\\\n\\\\n      The name of the USS directory to which you want to upload the local directory\\\\n\\\\n OPTIONS\\\\n -------\\\\n\\\\n   --binary  | -b (boolean)\\\\n\\\\n      Data content in binary mode, which means that no data conversion is performed.\\\\n      The data transfer process returns each record as-is, without translation. No\\\\n      delimiters are added between records.\\\\n\\\\n   --recursive  | -r (boolean)\\\\n\\\\n      Upload all directories recursively.\\\\n\\\\n   --binary-files  | --bf (string)\\\\n\\\\n      Comma separated list of file names to be uploaded in binary mode. Use this\\\\n      option when you upload a directory in default ASCII mode, but you want to\\\\n      specify certain files to be uploaded in binary mode. All files matching\\\\n      specified file names will be uploaded in binary mode.\\\\n\\\\n   --ascii-files  | --af (string)\\\\n\\\\n      Comma separated list of file names to be uploaded in ASCII mode. Use this option\\\\n      when you upload a directory with --binary/-b flag, but you want to specify\\\\n      certain files to be uploaded in ASCII mode. All files matching specified file\\\\n      names will be uploaded in ASCII mode.\\\\n\\\\n   --max-concurrent-requests  | --mcr (number)\\\\n\\\\n      Specifies the maximum number of concurrent z/OSMF REST API requests to upload\\\\n      files. Increasing the value results in faster uploads. However, increasing the\\\\n      value increases resource consumption on z/OS and can be prone to errors caused\\\\n      by making too many concurrent requests. If the upload process encounters an\\\\n      error, the following message displays:\\\\n      The maximum number of TSO address spaces were created. When you specify 0, Zowe\\\\n      CLI attempts to upload all members at once without a maximum number of\\\\n      concurrent requests.\\\\n\\\\n      Default value: 1\\\\n\\\\n ZOSMF CONNECTION OPTIONS\\\\n ------------------------\\\\n\\\\n   --host  | -H (string)\\\\n\\\\n      The z/OSMF server host name.\\\\n\\\\n   --port  | -P (number)\\\\n\\\\n      The z/OSMF server port.\\\\n\\\\n      Default value: 443\\\\n\\\\n   --user  | -u (string)\\\\n\\\\n      Mainframe (z/OSMF) user name, which can be the same as your TSO login.\\\\n\\\\n   --password  | --pass | --pw (string)\\\\n\\\\n      Mainframe (z/OSMF) password, which can be the same as your TSO password.\\\\n\\\\n   --reject-unauthorized  | --ru (boolean)\\\\n\\\\n      Reject self-signed certificates.\\\\n\\\\n      Default value: true\\\\n\\\\n   --base-path  | --bp (string)\\\\n\\\\n      The base path for your API mediation layer instance. Specify this option to\\\\n      prepend the base path to all z/OSMF resources when making REST requests. Do not\\\\n      specify this option if you are not using an API mediation layer.\\\\n\\\\n PROFILE OPTIONS\\\\n ---------------\\\\n\\\\n   --zosmf-profile  | --zosmf-p (string)\\\\n\\\\n      The name of a (zosmf) profile to load for this command execution.\\\\n\\\\n GLOBAL OPTIONS\\\\n --------------\\\\n\\\\n   --response-format-json  | --rfj (boolean)\\\\n\\\\n      Produce JSON formatted data from a command\\\\n\\\\n   --help  | -h (boolean)\\\\n\\\\n      Display help text\\\\n\\\\n\\\\n EXAMPLES\\\\n --------\\\\n\\\\n   - Upload all files from the \\\\\\"local_dir\\\\\\" directory to the\\\\n   \\\\\\"/a/ibmuser/my_dir\\\\\\" USS directory:\\\\\\":\\\\n\\\\n      $ zowe zos-files upload dir-to-uss \\\\\\"local_dir\\\\\\" \\\\\\"/a/ibmuser/my_dir\\\\\\"\\\\n\\\\n   - Upload all files from the \\\\\\"local_dir\\\\\\" directory and all its\\\\n   sub-directories, to the \\\\\\"/a/ibmuser/my_dir\\\\\\" USS directory::\\\\n\\\\n      $ zowe zos-files upload dir-to-uss \\\\\\"local_dir\\\\\\" \\\\\\"/a/ibmuser/my_dir\\\\\\" --recursive\\\\n\\\\n   - Upload all files from the \\\\\\"local_dir\\\\\\" directory to the\\\\n   \\\\\\"/a/ibmuser/my_dir\\\\\\" USS directory in default ASCII mode, while specifying a list\\\\n   of file names (without path) to be uploaded in binary mode::\\\\n\\\\n      $ zowe zos-files upload dir-to-uss \\\\\\"local_dir\\\\\\" \\\\\\"/a/ibmuser/my_dir\\\\\\" --binary-files \\\\\\"myFile1.exe,myFile2.exe,myFile3.exe\\\\\\"\\\\n\\\\n   - Upload all files from the \\\\\\"local_dir\\\\\\" directory to the\\\\n   \\\\\\"/a/ibmuser/my_dir\\\\\\" USS directory in binary mode, while specifying a list of\\\\n   file names (without path) to be uploaded in ASCII mode::\\\\n\\\\n      $ zowe zos-files upload dir-to-uss \\\\\\"local_dir\\\\\\" \\\\\\"/a/ibmuser/my_dir\\\\\\" --binary --ascii-files \\\\\\"myFile1.txt,myFile2.txt,myFile3.txt\\\\\\"\\\\n\\\\n\\"
 }"
 `;

--- a/packages/zosfiles/__tests__/__system__/api/methods/upload/Upload.system.test.ts
+++ b/packages/zosfiles/__tests__/__system__/api/methods/upload/Upload.system.test.ts
@@ -596,7 +596,7 @@ describe("Upload a local directory to USS directory", () => {
             let uploadResponse: IZosFilesResponse;
             let isDirectoryExist: any;
             try {
-                uploadResponse = await Upload.dirToUSSDir(REAL_SESSION, localDir, ussname, false, true);
+                uploadResponse = await Upload.dirToUSSDir(REAL_SESSION, localDir, ussname, {binary: false, recursive: true});
                 isDirectoryExist = await Upload.isDirectoryExist(REAL_SESSION, `${ussname}/longline`);
             } catch (err) {
                 error = err;
@@ -616,7 +616,7 @@ describe("Upload a local directory to USS directory", () => {
             let isDirectoryExist: any;
             let getResponse;
             try {
-                uploadResponse = await Upload.dirToUSSDir(REAL_SESSION, localDir, ussname, true);
+                uploadResponse = await Upload.dirToUSSDir(REAL_SESSION, localDir, ussname, {binary: true});
                 isDirectoryExist = await Upload.isDirectoryExist(REAL_SESSION, ussname);
                 getResponse = await Get.USSFile(REAL_SESSION, `${ussname}/file1.txt`, {binary: true});
             } catch (err) {
@@ -640,7 +640,7 @@ describe("Upload a local directory to USS directory", () => {
             let getResponse;
             let longResponse: string = "";
             try {
-                uploadResponse = await Upload.dirToUSSDir(REAL_SESSION, localDir, ussname, true, true);
+                uploadResponse = await Upload.dirToUSSDir(REAL_SESSION, localDir, ussname, {binary: true, recursive: true});
                 isDirectoryExist = await Upload.isDirectoryExist(REAL_SESSION, ussname);
                 getResponse = await Get.USSFile(REAL_SESSION, `${ussname}/longline/longline.txt`, {binary: true});
                 for(let i = 0; i < magicNum; i++) {
@@ -668,9 +668,9 @@ describe("Upload a local directory to USS directory", () => {
             let getResponseLongFile;
             let longResponse: string = "";
             const magicNum = 6;
-            const filesMap: IUploadMap = {binary:  true, fileNames: ["file3.txt", "longline.txt"]};
+            const fileMap: IUploadMap = {binary:  true, fileNames: ["file3.txt", "longline.txt"]};
             try {
-                uploadResponse = await Upload.dirToUSSDir(REAL_SESSION, localDir, ussname, false, true, filesMap);
+                uploadResponse = await Upload.dirToUSSDir(REAL_SESSION, localDir, ussname, {binary: false, recursive: true, filesMap: fileMap});
                 isDirectoryExist = await Upload.isDirectoryExist(REAL_SESSION, `${ussname}/longline`);
                 // file3.txt should be binary as it is mentioned in filesMap
                 getResponseFile3 = await Get.USSFile(REAL_SESSION, `${ussname}/file3.txt`, {binary: true});
@@ -707,7 +707,7 @@ describe("Upload a local directory to USS directory", () => {
             const magicNum = 6;
             const filesMap: IUploadMap = {binary:  false, fileNames: ["file3.txt", "longline.txt"]};
             try {
-                uploadResponse = await Upload.dirToUSSDir(REAL_SESSION, localDir, ussname, true, true, filesMap);
+                uploadResponse = await Upload.dirToUSSDir(REAL_SESSION, localDir, ussname, {recursive: true, binary: true, filesMap});
                 isDirectoryExist = await Upload.isDirectoryExist(REAL_SESSION, `${ussname}/longline`);
                 // file3.txt should be ASCII as it is mentioned in filesMap
                 getResponseFile3 = await Get.USSFile(REAL_SESSION, `${ussname}/file3.txt`, {binary: false});
@@ -865,4 +865,3 @@ describe("Upload a local directory to USS directory", () => {
         });
     });
 });
-

--- a/packages/zosfiles/__tests__/__system__/cli/upload/dtu/cli.dir.upload.dtu.system.test.ts
+++ b/packages/zosfiles/__tests__/__system__/cli/upload/dtu/cli.dir.upload.dtu.system.test.ts
@@ -247,5 +247,33 @@ describe("Upload directory to USS", () => {
             expect(stdoutText).toContain(
                 "\"commandResponse\": \"Directory uploaded successfully.\"");
         });
+
+        it("should upload local directory to USS directory with --max-concurrent-requests 2", async () => {
+            const localDirName = path.join(__dirname, "__data__", "command_upload_dtu_dir/command_upload_dtu_subdir_ascii");
+            const shellScript = path.join(__dirname, "__scripts__", "command", "command_upload_dtu.sh");
+            const response = runCliScript(shellScript, TEST_ENVIRONMENT,
+            [
+                localDirName,
+                ussname,
+                "--mcr 2"
+            ]);
+            expect(response.stderr.toString()).toBe("");
+            expect(response.status).toBe(0);
+            expect(response.stdout.toString()).toContain("Directory uploaded successfully.");
+        });
+
+        it("should upload local directory to USS directory with --max-concurrent-requests 0", async () => {
+            const localDirName = path.join(__dirname, "__data__", "command_upload_dtu_dir/command_upload_dtu_subdir_ascii");
+            const shellScript = path.join(__dirname, "__scripts__", "command", "command_upload_dtu.sh");
+            const response = runCliScript(shellScript, TEST_ENVIRONMENT,
+            [
+                localDirName,
+                ussname,
+                "--mcr 0"
+            ]);
+            expect(response.stderr.toString()).toBe("");
+            expect(response.status).toBe(0);
+            expect(response.stdout.toString()).toContain("Directory uploaded successfully.");
+        });
     });
 });

--- a/packages/zosfiles/__tests__/api/methods/upload/Upload.unit.test.ts
+++ b/packages/zosfiles/__tests__/api/methods/upload/Upload.unit.test.ts
@@ -784,7 +784,7 @@ describe("z/OS Files - Upload", () => {
         const pathJoinSpy = jest.spyOn(path, "join");
         const pathNormalizeSpy = jest.spyOn(path, "normalize");
         const promiseSpy = jest.spyOn(Promise, "all");
-
+        const dirToUSSDirRecursive = jest.spyOn(Upload, "dirToUSSDirRecursive");
 
         beforeEach(() => {
             USSresponse = undefined;
@@ -897,19 +897,9 @@ describe("z/OS Files - Upload", () => {
             isDirectoryExistsSpy.mockReturnValueOnce(false);
             createUssDirSpy.mockReturnValueOnce({});
             getFileListWithFsSpy.mockReturnValueOnce(["test", "file1.txt", "file2.txt"]);
-            isDirSpy.mockReturnValueOnce(true);
-            isDirectoryExistsSpy.mockReturnValueOnce(false);
-            createUssDirSpy.mockReturnValueOnce({});
-            isDirSpy.mockReturnValueOnce(false);
-            pathNormalizeSpy.mockReturnValueOnce("test/path/file1.txt");
-            fileToUSSFileSpy.mockReturnValue(testReturn);
-            isDirSpy.mockReturnValueOnce(false);
-            pathNormalizeSpy.mockReturnValueOnce("test/path/file2.txt");
-            fileToUSSFileSpy.mockReturnValue(testReturn);
-            promiseSpy.mockReturnValueOnce({});
 
             try {
-                USSresponse = await Upload.dirToUSSDir(dummySession, testPath, dsName, null, true);
+                USSresponse = await Upload.dirToUSSDir(dummySession, testPath, dsName, {recursive: true});
             } catch (err) {
                 error = err;
             }
@@ -917,9 +907,8 @@ describe("z/OS Files - Upload", () => {
             expect(error).toBeUndefined();
             expect(USSresponse).toBeDefined();
             expect(USSresponse.success).toBeTruthy();
-            expect(fileToUSSFileSpy).toHaveBeenCalledTimes(2);
-            expect(createUssDirSpy).toHaveBeenCalledTimes(2);
-            expect(fileToUSSFileSpy).toHaveBeenCalledWith(dummySession, `${path.normalize(`${testPath}/file2.txt`)}`, `${dsName}/file2.txt`, null);
+            expect(dirToUSSDirRecursive).toHaveBeenCalledTimes(1);
+            expect(createUssDirSpy).toHaveBeenCalledTimes(1);
         });
     });
 });

--- a/packages/zosfiles/__tests__/cli/upload/dtu/DirToUSS.handler.unit.test.ts
+++ b/packages/zosfiles/__tests__/cli/upload/dtu/DirToUSS.handler.unit.test.ts
@@ -102,7 +102,15 @@ describe("Upload dir-to-uss handler", () => {
             expect(error).toBeUndefined();
             expect(profFunc).toHaveBeenCalledWith("zosmf", false);
             expect(Upload.dirToUSSDir).toHaveBeenCalledTimes(1);
-            expect(Upload.dirToUSSDir).toHaveBeenCalledWith(fakeSession, inputDir, USSDir, undefined, undefined, null);
+            expect(Upload.dirToUSSDir).toHaveBeenCalledWith(fakeSession, inputDir, USSDir, {
+                binary: undefined,
+                filesMap: null,
+                maxConcurrentRequests: undefined,
+                recursive: undefined,
+                task: {
+                    percentComplete: 0,
+                    stageName: 0,
+                    statusMessage: "Uploading all files"}});
             expect(jsonObj).toMatchSnapshot();
             expect(apiMessage).toMatchSnapshot();
             expect(logMessage).toMatchSnapshot();

--- a/packages/zosfiles/__tests__/cli/upload/dtu/__snapshots__/DirToUSS.definition.unit.test.ts.snap
+++ b/packages/zosfiles/__tests__/cli/upload/dtu/__snapshots__/DirToUSS.definition.unit.test.ts.snap
@@ -40,13 +40,27 @@ Array [
     "name": "ascii-files",
     "type": "string",
   },
+  Object {
+    "aliases": Array [
+      "mcr",
+    ],
+    "defaultValue": 1,
+    "description": "Specifies the maximum number of concurrent z/OSMF REST API requests to upload files. Increasing the value results in faster uploads. However, increasing the value increases resource consumption on z/OS and can be prone to errors caused by making too many concurrent requests. If the upload process encounters an error, the following message displays:
+The maximum number of TSO address spaces were created. When you specify 0, Zowe CLI attempts to upload all members at once without a maximum number of concurrent requests. ",
+    "name": "max-concurrent-requests",
+    "numericValueRange": Array [
+      0,
+      99999,
+    ],
+    "type": "number",
+  },
 ]
 `;
 
 exports[`zos-files upload dtu command definition should not have changed 2`] = `
 Array [
   Object {
-    "description": "Upload all files from the \\"local_dir\\" directory to the \\"/a/ibmuser/my_dir\\" USS directory:\\"",
+    "description": "Upload all files from the \\"local_dir\\" directory to the \\"/a/ibmuser/my_dir\\" USS directory:\\"",
     "options": "\\"local_dir\\" \\"/a/ibmuser/my_dir\\"",
   },
   Object {

--- a/packages/zosfiles/src/api/methods/upload/Upload.ts
+++ b/packages/zosfiles/src/api/methods/upload/Upload.ts
@@ -23,7 +23,8 @@ import { List } from "../list";
 import { IUploadOptions } from "./doc/IUploadOptions";
 import { IUploadResult } from "./doc/IUploadResult";
 import { Create } from "../create";
-import { IUploadMap } from "./doc/IUploadMap";
+import { IUploadFile } from "./doc/IUploadFile";
+import { asyncPool } from "../../../../../utils";
 
 export class Upload {
 
@@ -455,21 +456,23 @@ export class Upload {
      * @param {AbstractSession} session - z/OS connection info
      * @param {string} inputDirectory   - the path of local directory
      * @param {string} ussname          - the name of uss folder
-     * @param {boolean} binary          - the indicator to upload the file in binary mode
-     * @param {boolean} recursive       - the indicator to upload local folder recursively
-     * @param {IUploadMap} filesMap     - the map to define which files to upload in binary or asci mode
+     * @param {IUploadOptions} [options={}]   - Uploading options
      * @returns {Promise<IZosFilesResponse>}
      */
     public static async dirToUSSDir(session: AbstractSession,
                                     inputDirectory: string,
                                     ussname: string,
-                                    binary: boolean = false,
-                                    recursive: boolean = false,
-                                    filesMap?: IUploadMap): Promise<IZosFilesResponse> {
+                                    options: IUploadOptions = {}): Promise<IZosFilesResponse> {
         ImperativeExpect.toNotBeNullOrUndefined(inputDirectory, ZosFilesMessages.missingInputDirectory.message);
         ImperativeExpect.toNotBeEqual(inputDirectory,"", ZosFilesMessages.missingInputDirectory.message);
         ImperativeExpect.toNotBeNullOrUndefined(ussname, ZosFilesMessages.missingUSSDirectoryName.message);
         ImperativeExpect.toNotBeEqual(ussname, "", ZosFilesMessages.missingUSSDirectoryName.message);
+
+        // Set default values for options
+        options.binary = options.binary == null ? false : options.binary;
+        options.recursive = options.recursive == null ? false : options.recursive;
+        // Set maxConcurrentRequests default value to 1
+        const maxConcurrentRequests = options.maxConcurrentRequests == null ? 1 : options.maxConcurrentRequests;
 
         // Check if inputDirectory is directory
         if(!IO.isDir(inputDirectory)) {
@@ -484,39 +487,76 @@ export class Upload {
             await Create.uss(session, ussname, "directory");
         }
 
-        if(recursive === false) {
-            const files = ZosFilesUtils.getFileListFromPath(inputDirectory, false);
-            await Promise.all(files.map(async (fileName) => {
-                const filePath = path.normalize(path.join(inputDirectory, fileName));
-                if(!IO.isDir(filePath)) {
-                    let tempBinary;
-                    if(filesMap) {
-                        if(filesMap.fileNames.indexOf(fileName) > -1) {
-                            tempBinary = filesMap.binary;
-                        } else {
-                            tempBinary = binary;
-                        }
-                    } else {
-                        tempBinary = binary;
-                    }
-                    const ussFilePath = path.posix.join(ussname, fileName);
-                    await this.fileToUSSFile(session, filePath, ussFilePath, tempBinary);
-                }
-            }));
-        } else {
-            await this.dirToUSSDirRecursive(session, inputDirectory, ussname, binary, filesMap);
-        }
+        try {
+            // initialize array for the files to be uploaded
+            const filesArray: IUploadFile[] = [];
 
-        const result: IUploadResult = {
-            success: true,
-            from: inputDirectory,
-            to: ussname
-        };
-        return {
-            success: true,
-            commandResponse: ZosFilesMessages.ussDirUploadedSuccessfully.message,
-            apiResponse: result
-        };
+            // initialize the counter for uploaded files (used in progress bar)
+            let uploadsInitiated = 0;
+
+            if(options.recursive === false) {
+                // getting list of files from directory
+                const files = ZosFilesUtils.getFileListFromPath(inputDirectory, false);
+                // building list of files with full path and transfer mode
+                files.forEach((file) => {
+                    let tempBinary = options.binary;
+                    // check if filesMap is specified, and verify if file is in the list
+                    if(options.filesMap) {
+                        if(options.filesMap.fileNames.indexOf(file) > -1) {
+                            // if file is in list, assign binary mode from mapping
+                            tempBinary = options.filesMap.binary;
+                        }
+                    }
+                    // update the array
+                    filesArray.push({
+                        binary: tempBinary,
+                        fileName: file}
+                        );
+                });
+            } else {
+                await this.dirToUSSDirRecursive(session,
+                    inputDirectory,
+                    ussname,
+                    {binary: options.binary,
+                     filesMap: options.filesMap,
+                     task: options.task,
+                     maxConcurrentRequests});
+            }
+
+            const createUploadPromise = (file: IUploadFile) => {
+                // update the progress bar if any
+                if (options.task != null) {
+                    options.task.percentComplete = Math.floor(TaskProgress.ONE_HUNDRED_PERCENT *
+                        (uploadsInitiated / filesArray.length));
+                    uploadsInitiated++;
+                }
+                const fileName = path.normalize(path.join(inputDirectory, file.fileName));
+                const ussFilePath = path.posix.join(ussname, file.fileName);
+                return this.fileToUSSFile(session, fileName, ussFilePath, file.binary);
+
+            };
+
+            if (maxConcurrentRequests === 0) {
+                await Promise.all(filesArray.map(createUploadPromise));
+            } else {
+                await asyncPool(maxConcurrentRequests, filesArray, createUploadPromise);
+            }
+
+            const result: IUploadResult = {
+                success: true,
+                from: inputDirectory,
+                to: ussname
+            };
+            return {
+                success: true,
+                commandResponse: ZosFilesMessages.ussDirUploadedSuccessfully.message,
+                apiResponse: result
+            };
+        } catch (error) {
+            Logger.getAppLogger().error(error);
+
+            throw error;
+        }
     }
 
     /**
@@ -543,43 +583,77 @@ export class Upload {
 
     /**
      * Upload directory to USS recursively
-     * @param {AbstractSession} session - z/OS connection info
-     * @param {string} inputDirectory   - the path of local directory
-     * @param {string} ussname          - the name of uss folder
-     * @param {boolean} binary          - the indicator to upload the file in binary mode
-     * @param {IUploadMap} filesMap     - the map to define which files to upload in binary or asci mode
+     * @param {AbstractSession} session       - z/OS connection info
+     * @param {string} inputDirectory         - the path of local directory
+     * @param {string} ussname                - the name of uss folder
+     * @param {IUploadOptions} [options={}]   - Uploading options
      * @return {null}
      */
-    private static async dirToUSSDirRecursive(session: AbstractSession,
-                                              inputDirectory: string,
-                                              ussname: string,
-                                              binary: boolean,
-                                              filesMap?: IUploadMap) {
-        await Promise.all(fs.readdirSync(inputDirectory).map(async (fileName) => {
-            const filePath = path.normalize(path.join(inputDirectory, fileName));
+    public static async dirToUSSDirRecursive(session: AbstractSession,
+                                             inputDirectory: string,
+                                             ussname: string,
+                                             options: IUploadOptions = {}) {
+        // initialize array for the files to be uploaded
+        const filesArray: IUploadFile[] = [];
+
+        // getting list of files and directories from directory
+        const files = fs.readdirSync(inputDirectory);
+        // building list of files with full path and transfer mode
+        files.forEach(async (file) => {
+            // generate the full file specification
+            const filePath = path.normalize(path.join(inputDirectory, file));
             if(!IO.isDir(filePath)) {
-                let tempBinary;
-                if(filesMap) {
-                    if(filesMap.fileNames.indexOf(fileName) > -1) {
-                        tempBinary = filesMap.binary;
-                    } else {
-                        tempBinary = binary;
+                let tempBinary = options.binary;
+                // check if filesMap is specified, and verify if file is in the list
+                if(options.filesMap) {
+                    if(options.filesMap.fileNames.indexOf(file) > -1) {
+                        // if file is in list, assign binary mode from mapping
+                        tempBinary = options.filesMap.binary;
                     }
-                } else {
-                    tempBinary = binary;
                 }
-                const ussFilePath = path.posix.join(ussname, fileName);
-                await this.fileToUSSFile(session, filePath, ussFilePath, tempBinary);
+                // update the array
+                filesArray.push({
+                    binary: tempBinary,
+                    fileName: file}
+                    );
             } else {
-                const tempUssPath = path.posix.join(ussname, fileName);
+                const tempUssPath = path.posix.join(ussname, file);
                 // Check if provided unix directory exists
                 const isDirectoryExist = await this.isDirectoryExist(session, tempUssPath);
                 if(!isDirectoryExist) {
                     await Create.uss(session, tempUssPath, "directory");
                 }
-                await this.dirToUSSDirRecursive(session, filePath, tempUssPath, binary, filesMap);
+                await this.dirToUSSDirRecursive(session,
+                    filePath,
+                    tempUssPath,
+                    {binary: options.binary,
+                     filesMap: options.filesMap,
+                     maxConcurrentRequests: options.maxConcurrentRequests});
             }
-        }));
+        });
+
+        // skip if processing an empty directory
+        if(filesArray.length > 0) {
+            let uploadsInitiated = 0;
+            const createUploadPromise = (file: IUploadFile) => {
+                // update the progress bar if any
+                if (options.task != null) {
+                    options.task.percentComplete = Math.floor(TaskProgress.ONE_HUNDRED_PERCENT *
+                        (uploadsInitiated / filesArray.length));
+                    uploadsInitiated++;
+                }
+                const filePath = path.normalize(path.join(inputDirectory, file.fileName));
+                const ussFilePath = path.posix.join(ussname, file.fileName);
+                return this.fileToUSSFile(session, filePath, ussFilePath, file.binary);
+
+            };
+
+            if (options.maxConcurrentRequests === 0) {
+                await Promise.all(filesArray.map(createUploadPromise));
+            } else {
+                await asyncPool(options.maxConcurrentRequests, filesArray, createUploadPromise);
+            }
+        }
     }
 
     /**

--- a/packages/zosfiles/src/api/methods/upload/doc/IUploadFile.ts
+++ b/packages/zosfiles/src/api/methods/upload/doc/IUploadFile.ts
@@ -1,0 +1,26 @@
+/*
+* This program and the accompanying materials are made available under the terms of the
+* Eclipse Public License v2.0 which accompanies this distribution, and is available at
+* https://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Copyright Contributors to the Zowe Project.
+*
+*/
+
+
+/**
+ * This interface defines the map option that can be sent into the upload uss directory function
+ */
+export interface IUploadFile {
+    /**
+     * The indicator to upload the data set in binary mode
+     */
+    binary: boolean;
+
+    /**
+     * List of file names to be uploaded in binary or asci
+     */
+    fileName: string;
+}

--- a/packages/zosfiles/src/api/methods/upload/doc/IUploadOptions.ts
+++ b/packages/zosfiles/src/api/methods/upload/doc/IUploadOptions.ts
@@ -10,6 +10,7 @@
 */
 
 import { ITaskWithStatus } from "@brightside/imperative";
+import { IUploadMap } from "./IUploadMap";
 
 /**
  * This interface defines the options that can be sent into the upload data set function
@@ -53,4 +54,18 @@ export interface IUploadOptions {
      * The list of files to be uploaded in ASCII mode
      */
     ascii_files?: string;
+
+    /**
+     * The map of files and their upload mode to be used for binary_files and ascii_files
+     */
+    filesMap?: IUploadMap;
+
+    /**
+     * The maximum REST requests to perform at once
+     * Increasing this value results in faster uploads but increases resource consumption
+     * on z/OS and risks encountering an error caused
+     * by making too many requests at once.
+     * Default: 1
+     */
+    maxConcurrentRequests?: number;
 }

--- a/packages/zosfiles/src/cli/-strings-/en.ts
+++ b/packages/zosfiles/src/cli/-strings-/en.ts
@@ -363,7 +363,7 @@ export default {
                     USSDIR: "The name of the USS directory to which you want to upload the local directory"
                 },
                 EXAMPLES: {
-                    EX1: `Upload all files from the "local_dir" directory to the "/a/ibmuser/my_dir" USS directory:"`,
+                    EX1: `Upload all files from the "local_dir" directory to the "/a/ibmuser/my_dir" USS directory:"`,
                     EX2: `Upload all files from the "local_dir" directory and all its sub-directories, `+
                     `to the "/a/ibmuser/my_dir" USS directory:`,
                     EX3: `Upload all files from the "local_dir" directory to the "/a/ibmuser/my_dir" USS directory ` +
@@ -388,7 +388,15 @@ export default {
             ASCII_FILES: "Comma separated list of file names to be uploaded in ASCII mode. " +
             "Use this option when you upload a directory with --binary/-b flag, " +
             "but you want to specify certain files to be uploaded in ASCII mode. "  +
-            "All files matching specified file names will be uploaded in ASCII mode."
+            "All files matching specified file names will be uploaded in ASCII mode.",
+            MAX_CONCURRENT_REQUESTS: "Specifies the maximum number of concurrent z/OSMF REST API requests to upload files." +
+            " Increasing the value results in faster uploads. " +
+            "However, increasing the value increases resource consumption on z/OS and can be prone " +
+            "to errors caused by making too many concurrent requests. If the upload process encounters an error, " +
+            "the following message displays:\n" +
+            "The maximum number of TSO address spaces were created. When you specify 0, " +
+            Constants.DISPLAY_NAME + " attempts to upload all members at once" +
+            " without a maximum number of concurrent requests. "
         }
     }
 };

--- a/packages/zosfiles/src/cli/upload/Upload.options.ts
+++ b/packages/zosfiles/src/cli/upload/Upload.options.ts
@@ -16,6 +16,8 @@ import i18nTypings from "../-strings-/en";
 // Does not use the import in anticipation of some internationalization work to be done later.
 const strings = (require("../-strings-/en").default as typeof i18nTypings).UPLOAD.OPTIONS;
 
+const maxConcurrentRequestsMaxValue = 99999;
+
 /**
  * Object containing all options to be used by the Upload API
  */
@@ -87,5 +89,17 @@ export const UploadOptions: {[key: string]: ICommandOptionDefinition} = {
         description: strings.ASCII_FILES,
         type: "string",
         conflictsWith: ["binary-files"]
-    }
+    },
+    /**
+     *  The maximum concurrent requests for upload
+     * @type {ICommandOptionDefinition}
+     */
+    maxConcurrentRequests: {
+        name: "max-concurrent-requests",
+        aliases: ["mcr"],
+        description: strings.MAX_CONCURRENT_REQUESTS,
+        type: "number",
+        defaultValue: 1,
+        numericValueRange: [0, maxConcurrentRequestsMaxValue]
+    },
 };

--- a/packages/zosfiles/src/cli/upload/dtu/DirToUSSDir.definition.ts
+++ b/packages/zosfiles/src/cli/upload/dtu/DirToUSSDir.definition.ts
@@ -49,7 +49,8 @@ export const DirToUSSDirDefinition: ICommandDefinition = {
         UploadOptions.binary,
         UploadOptions.recursive,
         UploadOptions.binaryFiles,
-        UploadOptions.asciiFiles
+        UploadOptions.asciiFiles,
+        UploadOptions.maxConcurrentRequests
     ],
     examples: [
         {


### PR DESCRIPTION
 - Fix for https://github.com/zowe/zowe-cli/issues/204 by introducing `--max-concurrent-requests` option on the `files upload dtu` command. 

Refactored `dirToUSSDir` API and CLI to:
- accept pool of options
- create empty directories but skip processing them if empty
- added progress bar  

Updated snapshots
Updated command used in shell script (it was wrongly using file-to-uss)
Updated related tests