### PR TITLE
Fix #313

### DIFF
--- a/packages/zosfiles/__tests__/__system__/api/methods/delete/DeleteUSSFile.system.test.ts
+++ b/packages/zosfiles/__tests__/__system__/api/methods/delete/DeleteUSSFile.system.test.ts
@@ -72,6 +72,24 @@ describe("Delete a USS File", () => {
             expect(response.success).toBe(true);
             expect(response.commandResponse).toContain(ZosFilesMessages.ussFileDeletedSuccessfully.message);
         });
+
+        it("should delete a uss file even if it has multiple slashes pre-pended", async () => {
+            let error;
+            let response;
+
+            try {
+                response = await Delete.ussFile(REAL_SESSION, "//"+filename);
+                Imperative.console.info("Response: " + inspect(response));
+            } catch (err) {
+                error = err;
+                Imperative.console.info("Error: " + inspect(error));
+            }
+
+            expect(error).toBeFalsy();
+            expect(response).toBeTruthy();
+            expect(response.success).toBe(true);
+            expect(response.commandResponse).toContain(ZosFilesMessages.ussFileDeletedSuccessfully.message);
+        });
     });
 
     describe("Failure scenarios", () => {

--- a/packages/zosfiles/src/api/methods/delete/Delete.ts
+++ b/packages/zosfiles/src/api/methods/delete/Delete.ts
@@ -22,6 +22,7 @@ import { Invoke } from "../invoke";
 import { IDeleteDatasetOptions } from "./doc/IDeleteDatasetOptions";
 import { IDeleteVsamOptions } from "./doc/IDeleteVsamOptions";
 import { IDeleteVsamResponse } from "./doc/IDeleteVsamResponse";
+import { ZosFilesUtils } from "../../utils/ZosFilesUtils";
 
 /**
  * This class holds helper functions that are used to delete files through the
@@ -141,6 +142,8 @@ export class Delete {
         // Format the endpoint to send the request to
         let endpoint = posix.join(ZosFilesConstants.RESOURCE, ZosFilesConstants.RES_USS_FILES);
 
+        fileName = posix.normalize(fileName);
+        fileName = ZosFilesUtils.formatUnixFilepath(fileName);
         fileName = encodeURIComponent(fileName);
         endpoint = posix.join(endpoint, fileName);
         Logger.getAppLogger().debug(`Endpoint: ${endpoint}`);

--- a/packages/zosfiles/src/api/methods/upload/Upload.ts
+++ b/packages/zosfiles/src/api/methods/upload/Upload.ts
@@ -461,7 +461,7 @@ export class Upload {
                                         binary: boolean = false) {
         ImperativeExpect.toNotBeNullOrUndefined(ussname, ZosFilesMessages.missingUSSFileName.message);
         ussname = path.posix.normalize(ussname);
-        ussname = Upload.formatUnixFilepath(ussname);
+        ussname = ZosFilesUtils.formatUnixFilepath(ussname);
         ussname = encodeURIComponent(ussname);
         const parameters: string = ZosFilesConstants.RES_USS_FILES + "/" + ussname;
         const headers: any[] = [];
@@ -490,7 +490,7 @@ export class Upload {
                                         task?: ITaskWithStatus) {
         ImperativeExpect.toNotBeNullOrUndefined(ussname, ZosFilesMessages.missingUSSFileName.message);
         ussname = path.posix.normalize(ussname);
-        ussname = Upload.formatUnixFilepath(ussname);
+        ussname = ZosFilesUtils.formatUnixFilepath(ussname);
         ussname = encodeURIComponent(ussname);
         const parameters: string = ZosFilesConstants.RES_USS_FILES + "/" + ussname;
         const headers: any[] = [];
@@ -801,17 +801,6 @@ export class Upload {
         // return Logger.getConsoleLogger();
     }
 
-    /**
-     * Format USS filepaths in the way that the APIs expect (no leading /)
-     * @param {string} usspath - the path to format
-     */
-    private static formatUnixFilepath(usspath: string) {
-        if (usspath.charAt(0) === "/") {
-            // trim leading slash from unix files - API doesn't like it
-            usspath = usspath.substring(1);
-        }
-        return usspath;
-    }
 
     /**
      * Checks if a given directory has sub-directories or not

--- a/packages/zosfiles/src/api/utils/ZosFilesUtils.ts
+++ b/packages/zosfiles/src/api/utils/ZosFilesUtils.ts
@@ -152,5 +152,17 @@ export class ZosFilesUtils {
     public static normalizeNewline(buffer: Buffer): Buffer {
         return Buffer.from(buffer.toString().replace(new RegExp("\r\n", "g"), "\n"));
     }
+
+    /**
+     * Format USS filepaths in the way that the APIs expect (no leading /)
+     * @param {string} usspath - the path to format
+     */
+    public static formatUnixFilepath(usspath: string) {
+        if (usspath.charAt(0) === "/") {
+            // trim leading slash from unix files - API doesn't like it
+            usspath = usspath.substring(1);
+        }
+        return usspath;
+    }
 }
 


### PR DESCRIPTION
addressing issue https://github.com/zowe/zowe-cli/issues/313
- moved formatUnixFilepath from `Upload.ts` to common file `ZosFilesUtils.ts`
- added `posix.normalize` and `formatUnixFilepath` for `fileName` variable in `Delete.ts`  
    - this will ensure that user can pass full file path without impacting the z/OSMF REST call
- added specific test for deleting a uss file with multiple leading slashes 