### PR TITLE
move @types  to dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,8 +60,6 @@
     "audit:public": "npm audit --registry https://registry.npmjs.org/"
   },
   "dependencies": {
-    "@types/minimatch": "^3.0.3",
-    "@types/ssh2": "^0.5.38",
     "@zowe/imperative": "^4.1.1-alpha.201904251420",
     "@zowe/perf-timing": "^1.0.3-alpha.201902201448",
     "js-yaml": "3.13.0",
@@ -76,6 +74,8 @@
     "@types/jest": "^22.2.3",
     "@types/js-yaml": "^3.11.1",
     "@types/node": "8.0.28",
+    "@types/minimatch": "^3.0.3",
+    "@types/ssh2": "^0.5.38",
     "@types/sinon": "2.3.3",
     "@types/yargs": "8.0.2",
     "chai": "^4.1.2",


### PR DESCRIPTION
I think having these in regular dependencies was causing an installation problem for a user on Slack. CLI users will not need these types. Consumers of the APIs might, but they can add these types to their dev dependencies