### PR TITLE
Fixed using cwd option also returns correct exit code

### DIFF
--- a/packages/zosuss/__tests__/__system__/api/Shell.system.test.ts
+++ b/packages/zosuss/__tests__/__system__/api/Shell.system.test.ts
@@ -75,4 +75,28 @@ describe("zowe uss issue ssh api call test", () => {
 
     }, TIME_OUT);
 
+    it("should receive return code for valid command with cwd option", async () => {
+        const command = "ls";
+        const cwd =  `${defaultSystem.unix.testdir}`;
+        let stdoutData = "";
+        const COMMAND_RC = 0;
+        const rc = await Shell.executeSshCwd(SSH_SESSION, command, cwd, (data: string) => {
+            stdoutData += data;
+        });
+        expect(rc).toBe(COMMAND_RC);
+
+    }, TIME_OUT);
+
+    it("should receive return code for invalid command with cwd option", async () => {
+        const command = "invalidCommand";
+        const cwd =  `${defaultSystem.unix.testdir}`;
+        let stdoutData = "";
+        const COMMAND_NOT_FOUND_RC = 127;
+        const rc = await Shell.executeSshCwd(SSH_SESSION, command, cwd, (data: string) => {
+            stdoutData += data;
+        });
+        expect(rc).toBe(COMMAND_NOT_FOUND_RC);
+
+    }, TIME_OUT);
+
 });

--- a/packages/zosuss/__tests__/__system__/cli/issue/cli.issue.ssh.system.test.ts
+++ b/packages/zosuss/__tests__/__system__/cli/issue/cli.issue.ssh.system.test.ts
@@ -92,7 +92,7 @@ describe("zowe uss issue ssh without running bash scripts", () => {
         // Imperative.console.info("Invalid directory Command:" + commandName +"--cwd /" +cwd);
         const response = await runCliScript(__dirname + "/__scripts__/issue_ssh_with_cwd.sh", TEST_ENVIRONMENT, [commandName, "/" + cwd]);
 
-        checkResponse(response, 0);
+        checkResponse(response, 1);
         expect(response.stdout.toString()).toContain("EDC5129I No such file or directory");
     });
 });

--- a/packages/zosuss/src/api/Shell.ts
+++ b/packages/zosuss/src/api/Shell.ts
@@ -129,7 +129,7 @@ export class Shell {
                                       cwd: string,
                                       stdoutHandler: (data: string) => void): Promise<any> {
         const cwdCommand = `cd ${cwd} && ${command}`;
-        await this.executeSsh(session, cwdCommand, stdoutHandler);
+        return this.executeSsh(session, cwdCommand, stdoutHandler);
     }
 
     /**


### PR DESCRIPTION
Fix #370 

"return" keyword was prepended as @ChrisBoehmCA mentioned. 
Added/changed system tests accordingly.