### PR TITLE
Fix Upload.unit on Windows (lts-incremental)

### DIFF
--- a/packages/zosfiles/__tests__/api/methods/upload/Upload.unit.test.ts
+++ b/packages/zosfiles/__tests__/api/methods/upload/Upload.unit.test.ts
@@ -1096,7 +1096,9 @@ describe("z/OS Files - Upload", () => {
                 expect(attributesMock.fileShouldBeUploaded).toHaveBeenCalledWith("test/path/ignoreme");
 
                 expect(fileToUSSFileSpy).toHaveBeenCalledTimes(1);
-                expect(fileToUSSFileSpy).toHaveBeenCalledWith(dummySession, `${path.normalize(`${testPath}/uploadme`)}`, `${dsName}/uploadme`, true);
+                expect(fileToUSSFileSpy).toHaveBeenCalledWith(dummySession,
+                                                              path.normalize(path.join(testPath,"uploadme")),
+                                                             `${dsName}/uploadme`, true);
             });
 
             it("should not upload ignored directories", async () => {
@@ -1142,9 +1144,8 @@ describe("z/OS Files - Upload", () => {
                 expect(attributesMock.fileShouldBeUploaded).toHaveBeenCalledWith("test/path/uploaddir");
                 expect(fileToUSSFileSpy).toHaveBeenCalledTimes(1);
                 expect(fileToUSSFileSpy).toHaveBeenCalledWith(dummySession,
-                    `${path.normalize(`${testPath}/uploaddir/uploadedfile`)}`,
-                    `${dsName}/uploaddir/uploadedfile`,
-                     true);
+                                                              path.normalize(path.join(testPath, "uploaddir", "uploadedfile")),
+                                                              `${dsName}/uploaddir/uploadedfile`, true);
             });
             it("should upload files in text or binary according to attributes", async () => {
                 getFileListFromPathSpy.mockReturnValue(["textfile", "binaryfile"]);
@@ -1156,12 +1157,12 @@ describe("z/OS Files - Upload", () => {
                 expect(USSresponse.success).toBeTruthy();
                 expect(fileToUSSFileSpy).toHaveBeenCalledTimes(2);
                 expect(fileToUSSFileSpy).toHaveBeenCalledWith(dummySession,
-                                                             `${path.normalize(`${testPath}/textfile`)}`,
+                                                             path.normalize(path.join(testPath,"textfile")),
                                                              `${dsName}/textfile`,
                                                               false,
                                                               "ISO8859-1");
                 expect(fileToUSSFileSpy).toHaveBeenCalledWith(dummySession,
-                                                             `${path.normalize(`${testPath}/binaryfile`)}`,
+                                                              path.normalize(path.join(testPath,"binaryfile")),
                                                              `${dsName}/binaryfile`, true);
             });
 

--- a/packages/zosfiles/__tests__/api/methods/upload/Upload.unit.test.ts
+++ b/packages/zosfiles/__tests__/api/methods/upload/Upload.unit.test.ts
@@ -1092,8 +1092,8 @@ describe("z/OS Files - Upload", () => {
                 expect(USSresponse).toBeDefined();
                 expect(USSresponse.success).toBeTruthy();
                 expect(attributesMock.fileShouldBeUploaded).toHaveBeenCalledTimes(2);
-                expect(attributesMock.fileShouldBeUploaded).toHaveBeenCalledWith("test/path/uploadme");
-                expect(attributesMock.fileShouldBeUploaded).toHaveBeenCalledWith("test/path/ignoreme");
+                expect(attributesMock.fileShouldBeUploaded).toHaveBeenCalledWith(path.normalize(path.join(testPath,"uploadme")));
+                expect(attributesMock.fileShouldBeUploaded).toHaveBeenCalledWith(path.normalize(path.join(testPath,"ignoreme")));
 
                 expect(fileToUSSFileSpy).toHaveBeenCalledTimes(1);
                 expect(fileToUSSFileSpy).toHaveBeenCalledWith(dummySession,
@@ -1141,7 +1141,7 @@ describe("z/OS Files - Upload", () => {
 
                 expect(USSresponse).toBeDefined();
                 expect(USSresponse.success).toBeTruthy();
-                expect(attributesMock.fileShouldBeUploaded).toHaveBeenCalledWith("test/path/uploaddir");
+                expect(attributesMock.fileShouldBeUploaded).toHaveBeenCalledWith(path.normalize(path.join(testPath,"uploaddir")));
                 expect(fileToUSSFileSpy).toHaveBeenCalledTimes(1);
                 expect(fileToUSSFileSpy).toHaveBeenCalledWith(dummySession,
                                                               path.normalize(path.join(testPath, "uploaddir", "uploadedfile")),
@@ -1175,8 +1175,8 @@ describe("z/OS Files - Upload", () => {
                 expect(USSresponse).toBeDefined();
                 expect(USSresponse.success).toBeTruthy();
                 expect(chtagSpy).toHaveBeenCalledTimes(2);
-                expect(chtagSpy).toHaveBeenCalledWith(dummySession, `${path.normalize(`${dsName}/textfile`)}`, Tag.TEXT, "ISO8859-1");
-                expect(chtagSpy).toHaveBeenCalledWith(dummySession, `${path.normalize(`${dsName}/binaryfile`)}`, Tag.BINARY);
+                expect(chtagSpy).toHaveBeenCalledWith(dummySession, `${dsName}/textfile`, Tag.TEXT, "ISO8859-1");
+                expect(chtagSpy).toHaveBeenCalledWith(dummySession, `${dsName}/binaryfile`, Tag.BINARY);
             });
 
             it("should call API to tag a file as text that was uploaded in binary mode", async () => {
@@ -1187,7 +1187,7 @@ describe("z/OS Files - Upload", () => {
                 expect(USSresponse).toBeDefined();
                 expect(USSresponse.success).toBeTruthy();
                 expect(chtagSpy).toHaveBeenCalledTimes(1);
-                expect(chtagSpy).toHaveBeenCalledWith(dummySession, `${path.normalize(`${dsName}/asciifile`)}`, Tag.TEXT, "ISO8859-1");
+                expect(chtagSpy).toHaveBeenCalledWith(dummySession, `${dsName}/asciifile`, Tag.TEXT, "ISO8859-1");
             });
         });
     });


### PR DESCRIPTION
Fix problem with path separators for zosattributes tests on Windows as reported in #417 

Same changes as #428 