### PR TITLE
fix #440 Examples for zowe files list uss-files are slightly incorrect 

### DIFF
--- a/packages/zosfiles/src/cli/list/uss/UssFile.definition.ts
+++ b/packages/zosfiles/src/cli/list/uss/UssFile.definition.ts
@@ -50,11 +50,11 @@ export const USSFileDefinition: ICommandDefinition = {
         },
         {
             description: strings.EXAMPLES.EX2,
-            options: `"/u/ibmuser --rff name"`
+            options: `"/u/ibmuser" --rff name`
         },
         {
             description: strings.EXAMPLES.EX3,
-            options: `"/u/ibmuser --rfh"`
+            options: `"/u/ibmuser" --rfh`
         }
     ]
 };


### PR DESCRIPTION
It related for issue #440 .