### PR TITLE
fix links in doc files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,6 +83,21 @@ The following list describes conventions for contributing to Zowe CLI APIs:
 
 - When developing programmatic asynchronous APIs, return promises instead of using call-backs.
 - Use ImperativeExpect to perform minimum parameter validation for API methods (e.g. verify parms exist `ImperativeExpect.toBeDefinedAndNonBlank(prefix, "prefix", "prefix is required");)
+- Include trace messages.
+- Support backward compatibility throughout releases.
+- Provide a `Common` version API call that accepts: 
+  - Connection information, when applicable.
+  - Parm objects that can be extended in the future while maintaining forward and backward compatibility.
+- Include *convenience methods* that aid in calling `Common` methods, when appropriate.
+- Should be categorized in classes that identify theirs actions. For example, `GetJobs.getJobStatus` or `SubmitJobs.submitJcl`.
+
+Programmatic APIs should also adhere to the following standards and conventions:
+
+- [Code Standards](#code-guidelines)
+- [General Conventions](#general-guidelines)
+- [Source File Naming Standards](#file-naming-guidelines)
+- [Testing Guidelines](./docs/TESTING.md)
+- [JS Documentation](#js-documentation)
 
 ## File Naming Guidelines
 

--- a/docs/PackagesAndPluginGuidelines.md
+++ b/docs/PackagesAndPluginGuidelines.md
@@ -87,27 +87,6 @@ The following diagram illustrates the plug-in directory structure
 └── package.json
 ```
 
-## Programmatic APIs
-
-Programmatic APIs should adhere to the following standards and conventions:
-
-- [Code Standards](../CONTRIBUTING.md#code-standards)
-- [General Conventions](../CONTRIBUTING.md#general-conventions)
-- [Programmatic APIs Standards](../CONTRIBUTING.md#programmatic-apis)
-- [Source File Naming Standards](../CONTRIBUTING.md#source-file-naming-standards)
-- [Testing Guidelines](TESTING.md)
-- [JS Documentation](../CONTRIBUTING.md#js-documentation)
-
-Additionally, programmatic APIs should support and the following capabilities:
-
-- Include trace messages.
-- Support backward compatibility throughout releases.
-- Provide a `Common` version API call that accepts: 
-  - Connection information, when applicable.
-  - Parm objects that can be extended in the future while maintaining forward and backward compatibility.
-- Include *convenience methods* that aid in calling `Common` methods, when appropriate.
-- Should be categorized in classes that identify theirs actions. For example, `GetJobs.getJobStatus` or `SubmitJobs.submitJcl`.
-
 ## Commands
 Packages and plug-ins will always introduce a new command `[group]` to the Zowe CLI. The command `[group]` is the first term you type into the command line after zowe (e.g., `zowe cics`). 
 


### PR DESCRIPTION
Fixes #457 

- Fixed broken anchors. 
- I realized that the API guidelines were split across 2 files, so I moved the other half into contributing.md so that all the relevant info is in one place. 

