### PR TITLE
Allow JCL to be submitted from stdin

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
   "dependencies": {
     "@zowe/imperative": "^4.1.9-alpha.201906191533",
     "@zowe/perf-timing": "^1.0.3-alpha.201902201448",
+    "get-stdin": "^7.0.0",
     "js-yaml": "^3.13.1",
     "minimatch": "^3.0.4",
     "ssh2": "^0.8.2",

--- a/packages/zosjobs/__tests__/__integration__/cli/submit/__snapshots__/cli.zos-jobs.submit.integration.test.ts.snap
+++ b/packages/zosjobs/__tests__/__integration__/cli/submit/__snapshots__/cli.zos-jobs.submit.integration.test.ts.snap
@@ -19,6 +19,7 @@ exports[`zos-jobs submit command should display the help 1`] = `
 
    data-set | ds   Submit a job contained in a data set  
    local-file | lf Submit a job contained in a local file
+   stdin | in      Submit a job read from standard in    
 
  GLOBAL OPTIONS
  --------------
@@ -35,8 +36,8 @@ exports[`zos-jobs submit command should display the help 1`] = `
   \\"success\\": true,
   \\"exitCode\\": 0,
   \\"message\\": \\"The help was constructed for command: submit.\\",
-  \\"stdout\\": \\"\\\\n DESCRIPTION\\\\n -----------\\\\n\\\\n   Submit jobs (JCL) contained in data sets.\\\\n\\\\n USAGE\\\\n -----\\\\n\\\\n   zowe zos-jobs submit <command>\\\\n\\\\n   Where <command> is one of the following:\\\\n\\\\n COMMANDS\\\\n --------\\\\n\\\\n   data-set | ds   Submit a job contained in a data set  \\\\n   local-file | lf Submit a job contained in a local file\\\\n\\\\n GLOBAL OPTIONS\\\\n --------------\\\\n\\\\n   --response-format-json  | --rfj (boolean)\\\\n\\\\n      Produce JSON formatted data from a command\\\\n\\\\n   --help  | -h (boolean)\\\\n\\\\n      Display help text\\\\n\\\\n\\",
+  \\"stdout\\": \\"\\\\n DESCRIPTION\\\\n -----------\\\\n\\\\n   Submit jobs (JCL) contained in data sets.\\\\n\\\\n USAGE\\\\n -----\\\\n\\\\n   zowe zos-jobs submit <command>\\\\n\\\\n   Where <command> is one of the following:\\\\n\\\\n COMMANDS\\\\n --------\\\\n\\\\n   data-set | ds   Submit a job contained in a data set  \\\\n   local-file | lf Submit a job contained in a local file\\\\n   stdin | in      Submit a job read from standard in    \\\\n\\\\n GLOBAL OPTIONS\\\\n --------------\\\\n\\\\n   --response-format-json  | --rfj (boolean)\\\\n\\\\n      Produce JSON formatted data from a command\\\\n\\\\n   --help  | -h (boolean)\\\\n\\\\n      Display help text\\\\n\\\\n\\",
   \\"stderr\\": \\"\\",
-  \\"data\\": \\"\\\\n DESCRIPTION\\\\n -----------\\\\n\\\\n   Submit jobs (JCL) contained in data sets.\\\\n\\\\n USAGE\\\\n -----\\\\n\\\\n   zowe zos-jobs submit <command>\\\\n\\\\n   Where <command> is one of the following:\\\\n\\\\n COMMANDS\\\\n --------\\\\n\\\\n   data-set | ds   Submit a job contained in a data set  \\\\n   local-file | lf Submit a job contained in a local file\\\\n\\\\n GLOBAL OPTIONS\\\\n --------------\\\\n\\\\n   --response-format-json  | --rfj (boolean)\\\\n\\\\n      Produce JSON formatted data from a command\\\\n\\\\n   --help  | -h (boolean)\\\\n\\\\n      Display help text\\\\n\\\\n\\"
+  \\"data\\": \\"\\\\n DESCRIPTION\\\\n -----------\\\\n\\\\n   Submit jobs (JCL) contained in data sets.\\\\n\\\\n USAGE\\\\n -----\\\\n\\\\n   zowe zos-jobs submit <command>\\\\n\\\\n   Where <command> is one of the following:\\\\n\\\\n COMMANDS\\\\n --------\\\\n\\\\n   data-set | ds   Submit a job contained in a data set  \\\\n   local-file | lf Submit a job contained in a local file\\\\n   stdin | in      Submit a job read from standard in    \\\\n\\\\n GLOBAL OPTIONS\\\\n --------------\\\\n\\\\n   --response-format-json  | --rfj (boolean)\\\\n\\\\n      Produce JSON formatted data from a command\\\\n\\\\n   --help  | -h (boolean)\\\\n\\\\n      Display help text\\\\n\\\\n\\"
 }"
 `;

--- a/packages/zosjobs/__tests__/__integration__/cli/submit/stdin/__scripts__/submit_help.sh
+++ b/packages/zosjobs/__tests__/__integration__/cli/submit/stdin/__scripts__/submit_help.sh
@@ -1,0 +1,10 @@
+set -e
+
+zowe zos-jobs submit stdin -h
+if [ $? -gt 0 ]
+then
+    exit $?
+fi
+
+zowe zos-jobs submit stdin --help --response-format-json
+exit $?

--- a/packages/zosjobs/__tests__/__integration__/cli/submit/stdin/__snapshots__/cli.zos-jobs.submit.stdin.test.ts.snap
+++ b/packages/zosjobs/__tests__/__integration__/cli/submit/stdin/__snapshots__/cli.zos-jobs.submit.stdin.test.ts.snap
@@ -1,0 +1,136 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`zos-jobs submit command should display the help 1`] = `
+"
+ COMMAND NAME
+ ------------
+
+   stdin | in
+
+ DESCRIPTION
+ -----------
+
+   Submit a job (JCL) passed to the command via the stdin stream. The command
+   presents errors verbatim from the z/OSMF Jobs REST endpoints. For more
+   information about z/OSMF Jobs API errors, see the z/OSMF Jobs API REST
+   documentation.
+
+ USAGE
+ -----
+
+   zowe zos-jobs submit stdin [options]
+
+ OPTIONS
+ -------
+
+   --view-all-spool-content  | --vasc (boolean)
+
+      Print all spool output. If you use this option you will wait the job to
+      complete.
+
+   --directory  | -d (string)
+
+      The local directory you would like to download the output of the job. Creates a
+      subdirectory using the jobID as the name and files are titled based on DD names.
+      If you use this option you will wait the job to complete.
+
+   --extension  | -e (string)
+
+      A file extension to save the job output with. Default is '.txt'.
+
+ ZOSMF CONNECTION OPTIONS
+ ------------------------
+
+   --host  | -H (string)
+
+      The z/OSMF server host name.
+
+   --port  | -P (number)
+
+      The z/OSMF server port.
+
+      Default value: 443
+
+   --user  | -u (string)
+
+      Mainframe (z/OSMF) user name, which can be the same as your TSO login.
+
+   --password  | --pass | --pw (string)
+
+      Mainframe (z/OSMF) password, which can be the same as your TSO password.
+
+   --reject-unauthorized  | --ru (boolean)
+
+      Reject self-signed certificates.
+
+      Default value: true
+
+   --base-path  | --bp (string)
+
+      The base path for your API mediation layer instance. Specify this option to
+      prepend the base path to all z/OSMF resources when making REST requests. Do not
+      specify this option if you are not using an API mediation layer.
+
+ PROFILE OPTIONS
+ ---------------
+
+   --zosmf-profile  | --zosmf-p (string)
+
+      The name of a (zosmf) profile to load for this command execution.
+
+ RESPONSE FORMAT OPTIONS
+ -----------------------
+
+   --response-format-filter  | --rff (array)
+
+      Filter (include) fields in the response. Accepts an array of field/property
+      names to include in the output response. You can filter JSON objects properties
+      OR table columns/fields. In addition, you can use this option in conjunction
+      with '--response-format-type' to reduce the output of a command to a single
+      field/property or a list of a single field/property.
+
+   --response-format-type  | --rft (string)
+
+      The command response output format type. Must be one of the following:
+
+      table: Formats output data as a table. Use this option when the output data is
+      an array of homogeneous JSON objects. Each property of the object will become a
+      column in the table.
+
+      list: Formats output data as a list of strings. Can be used on any data type
+      (JSON objects/arrays) are stringified and a new line is added after each entry
+      in an array.
+
+      object: Formats output data as a list of prettified objects (or single object).
+      Can be used in place of \\"table\\" to change from tabular output to a list of
+      prettified objects.
+
+      string: Formats output data as a string. JSON objects/arrays are stringified.
+
+      Allowed values: table, list, object, string
+
+   --response-format-header  | --rfh (boolean)
+
+      If \\"--response-format-type table\\" is specified, include the column headers in
+      the output.
+
+ GLOBAL OPTIONS
+ --------------
+
+   --response-format-json  | --rfj (boolean)
+
+      Produce JSON formatted data from a command
+
+   --help  | -h (boolean)
+
+      Display help text
+
+{
+  \\"success\\": true,
+  \\"exitCode\\": 0,
+  \\"message\\": \\"The help was constructed for command: stdin.\\",
+  \\"stdout\\": \\"\\\\n COMMAND NAME\\\\n ------------\\\\n\\\\n   stdin | in\\\\n\\\\n DESCRIPTION\\\\n -----------\\\\n\\\\n   Submit a job (JCL) passed to the command via the stdin stream. The command\\\\n   presents errors verbatim from the z/OSMF Jobs REST endpoints. For more\\\\n   information about z/OSMF Jobs API errors, see the z/OSMF Jobs API REST\\\\n   documentation.\\\\n\\\\n USAGE\\\\n -----\\\\n\\\\n   zowe zos-jobs submit stdin [options]\\\\n\\\\n OPTIONS\\\\n -------\\\\n\\\\n   --view-all-spool-content  | --vasc (boolean)\\\\n\\\\n      Print all spool output. If you use this option you will wait the job to\\\\n      complete.\\\\n\\\\n   --directory  | -d (string)\\\\n\\\\n      The local directory you would like to download the output of the job. Creates a\\\\n      subdirectory using the jobID as the name and files are titled based on DD names.\\\\n      If you use this option you will wait the job to complete.\\\\n\\\\n   --extension  | -e (string)\\\\n\\\\n      A file extension to save the job output with. Default is '.txt'.\\\\n\\\\n ZOSMF CONNECTION OPTIONS\\\\n ------------------------\\\\n\\\\n   --host  | -H (string)\\\\n\\\\n      The z/OSMF server host name.\\\\n\\\\n   --port  | -P (number)\\\\n\\\\n      The z/OSMF server port.\\\\n\\\\n      Default value: 443\\\\n\\\\n   --user  | -u (string)\\\\n\\\\n      Mainframe (z/OSMF) user name, which can be the same as your TSO login.\\\\n\\\\n   --password  | --pass | --pw (string)\\\\n\\\\n      Mainframe (z/OSMF) password, which can be the same as your TSO password.\\\\n\\\\n   --reject-unauthorized  | --ru (boolean)\\\\n\\\\n      Reject self-signed certificates.\\\\n\\\\n      Default value: true\\\\n\\\\n   --base-path  | --bp (string)\\\\n\\\\n      The base path for your API mediation layer instance. Specify this option to\\\\n      prepend the base path to all z/OSMF resources when making REST requests. Do not\\\\n      specify this option if you are not using an API mediation layer.\\\\n\\\\n PROFILE OPTIONS\\\\n ---------------\\\\n\\\\n   --zosmf-profile  | --zosmf-p (string)\\\\n\\\\n      The name of a (zosmf) profile to load for this command execution.\\\\n\\\\n RESPONSE FORMAT OPTIONS\\\\n -----------------------\\\\n\\\\n   --response-format-filter  | --rff (array)\\\\n\\\\n      Filter (include) fields in the response. Accepts an array of field/property\\\\n      names to include in the output response. You can filter JSON objects properties\\\\n      OR table columns/fields. In addition, you can use this option in conjunction\\\\n      with '--response-format-type' to reduce the output of a command to a single\\\\n      field/property or a list of a single field/property.\\\\n\\\\n   --response-format-type  | --rft (string)\\\\n\\\\n      The command response output format type. Must be one of the following:\\\\n\\\\n      table: Formats output data as a table. Use this option when the output data is\\\\n      an array of homogeneous JSON objects. Each property of the object will become a\\\\n      column in the table.\\\\n\\\\n      list: Formats output data as a list of strings. Can be used on any data type\\\\n      (JSON objects/arrays) are stringified and a new line is added after each entry\\\\n      in an array.\\\\n\\\\n      object: Formats output data as a list of prettified objects (or single object).\\\\n      Can be used in place of \\\\\\"table\\\\\\" to change from tabular output to a list of\\\\n      prettified objects.\\\\n\\\\n      string: Formats output data as a string. JSON objects/arrays are stringified.\\\\n\\\\n      Allowed values: table, list, object, string\\\\n\\\\n   --response-format-header  | --rfh (boolean)\\\\n\\\\n      If \\\\\\"--response-format-type table\\\\\\" is specified, include the column headers in\\\\n      the output.\\\\n\\\\n GLOBAL OPTIONS\\\\n --------------\\\\n\\\\n   --response-format-json  | --rfj (boolean)\\\\n\\\\n      Produce JSON formatted data from a command\\\\n\\\\n   --help  | -h (boolean)\\\\n\\\\n      Display help text\\\\n\\\\n\\",
+  \\"stderr\\": \\"\\",
+  \\"data\\": \\"\\\\n COMMAND NAME\\\\n ------------\\\\n\\\\n   stdin | in\\\\n\\\\n DESCRIPTION\\\\n -----------\\\\n\\\\n   Submit a job (JCL) passed to the command via the stdin stream. The command\\\\n   presents errors verbatim from the z/OSMF Jobs REST endpoints. For more\\\\n   information about z/OSMF Jobs API errors, see the z/OSMF Jobs API REST\\\\n   documentation.\\\\n\\\\n USAGE\\\\n -----\\\\n\\\\n   zowe zos-jobs submit stdin [options]\\\\n\\\\n OPTIONS\\\\n -------\\\\n\\\\n   --view-all-spool-content  | --vasc (boolean)\\\\n\\\\n      Print all spool output. If you use this option you will wait the job to\\\\n      complete.\\\\n\\\\n   --directory  | -d (string)\\\\n\\\\n      The local directory you would like to download the output of the job. Creates a\\\\n      subdirectory using the jobID as the name and files are titled based on DD names.\\\\n      If you use this option you will wait the job to complete.\\\\n\\\\n   --extension  | -e (string)\\\\n\\\\n      A file extension to save the job output with. Default is '.txt'.\\\\n\\\\n ZOSMF CONNECTION OPTIONS\\\\n ------------------------\\\\n\\\\n   --host  | -H (string)\\\\n\\\\n      The z/OSMF server host name.\\\\n\\\\n   --port  | -P (number)\\\\n\\\\n      The z/OSMF server port.\\\\n\\\\n      Default value: 443\\\\n\\\\n   --user  | -u (string)\\\\n\\\\n      Mainframe (z/OSMF) user name, which can be the same as your TSO login.\\\\n\\\\n   --password  | --pass | --pw (string)\\\\n\\\\n      Mainframe (z/OSMF) password, which can be the same as your TSO password.\\\\n\\\\n   --reject-unauthorized  | --ru (boolean)\\\\n\\\\n      Reject self-signed certificates.\\\\n\\\\n      Default value: true\\\\n\\\\n   --base-path  | --bp (string)\\\\n\\\\n      The base path for your API mediation layer instance. Specify this option to\\\\n      prepend the base path to all z/OSMF resources when making REST requests. Do not\\\\n      specify this option if you are not using an API mediation layer.\\\\n\\\\n PROFILE OPTIONS\\\\n ---------------\\\\n\\\\n   --zosmf-profile  | --zosmf-p (string)\\\\n\\\\n      The name of a (zosmf) profile to load for this command execution.\\\\n\\\\n RESPONSE FORMAT OPTIONS\\\\n -----------------------\\\\n\\\\n   --response-format-filter  | --rff (array)\\\\n\\\\n      Filter (include) fields in the response. Accepts an array of field/property\\\\n      names to include in the output response. You can filter JSON objects properties\\\\n      OR table columns/fields. In addition, you can use this option in conjunction\\\\n      with '--response-format-type' to reduce the output of a command to a single\\\\n      field/property or a list of a single field/property.\\\\n\\\\n   --response-format-type  | --rft (string)\\\\n\\\\n      The command response output format type. Must be one of the following:\\\\n\\\\n      table: Formats output data as a table. Use this option when the output data is\\\\n      an array of homogeneous JSON objects. Each property of the object will become a\\\\n      column in the table.\\\\n\\\\n      list: Formats output data as a list of strings. Can be used on any data type\\\\n      (JSON objects/arrays) are stringified and a new line is added after each entry\\\\n      in an array.\\\\n\\\\n      object: Formats output data as a list of prettified objects (or single object).\\\\n      Can be used in place of \\\\\\"table\\\\\\" to change from tabular output to a list of\\\\n      prettified objects.\\\\n\\\\n      string: Formats output data as a string. JSON objects/arrays are stringified.\\\\n\\\\n      Allowed values: table, list, object, string\\\\n\\\\n   --response-format-header  | --rfh (boolean)\\\\n\\\\n      If \\\\\\"--response-format-type table\\\\\\" is specified, include the column headers in\\\\n      the output.\\\\n\\\\n GLOBAL OPTIONS\\\\n --------------\\\\n\\\\n   --response-format-json  | --rfj (boolean)\\\\n\\\\n      Produce JSON formatted data from a command\\\\n\\\\n   --help  | -h (boolean)\\\\n\\\\n      Display help text\\\\n\\\\n\\"
+}"
+`;

--- a/packages/zosjobs/__tests__/__integration__/cli/submit/stdin/cli.zos-jobs.submit.stdin.test.ts
+++ b/packages/zosjobs/__tests__/__integration__/cli/submit/stdin/cli.zos-jobs.submit.stdin.test.ts
@@ -1,0 +1,25 @@
+import { ITestEnvironment } from "../../../../../../../__tests__/__src__/environment/doc/response/ITestEnvironment";
+import { TestEnvironment } from "../../../../../../../__tests__/__src__/environment/TestEnvironment";
+import { runCliScript } from "../../../../../../../__tests__/__src__/TestUtils";
+
+process.env.FORCE_COLOR = "0";
+
+// Test Environment populated in the beforeAll();
+let TEST_ENVIRONMENT: ITestEnvironment;
+
+describe("zos-jobs submit command", () => {
+    // Create the unique test environment
+    beforeAll(async () => {
+        TEST_ENVIRONMENT = await TestEnvironment.setUp({
+            testName: "zos_jobs_submit_command",
+            skipProperties: true
+        });
+    });
+
+    it("should display the help", async () => {
+        const response = runCliScript(__dirname + "/__scripts__/submit_help.sh", TEST_ENVIRONMENT);
+        expect(response.stderr.toString()).toBe("");
+        expect(response.status).toBe(0);
+        expect(response.stdout.toString()).toMatchSnapshot();
+    });
+});

--- a/packages/zosjobs/__tests__/__system__/cli/submit/stdin/__scripts__/submit_valid_stdin.sh
+++ b/packages/zosjobs/__tests__/__system__/cli/submit/stdin/__scripts__/submit_valid_stdin.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# pass the JCL as stdin to this script
+cat $1 | zowe zos-jobs submit stdin
+exit $?

--- a/packages/zosjobs/__tests__/__system__/cli/submit/stdin/__scripts__/submit_valid_stdin_fully_qualified.sh
+++ b/packages/zosjobs/__tests__/__system__/cli/submit/stdin/__scripts__/submit_valid_stdin_fully_qualified.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# pass the JCL as stdin to this script
+cat $1 | zowe zos-jobs submit stdin --host $2 --port $3 --user $4 --password $5 --ru=false
+exit $?

--- a/packages/zosjobs/__tests__/__system__/cli/submit/stdin/__scripts__/submit_valid_stdin_vasc.sh
+++ b/packages/zosjobs/__tests__/__system__/cli/submit/stdin/__scripts__/submit_valid_stdin_vasc.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# pass the JCL as stdin to this script
+cat $1 | zowe zos-jobs submit stdin --vasc
+exit $?

--- a/packages/zosjobs/__tests__/__system__/cli/submit/stdin/__scripts__/submit_valid_stdin_with_directory.sh
+++ b/packages/zosjobs/__tests__/__system__/cli/submit/stdin/__scripts__/submit_valid_stdin_with_directory.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# pass the JCL as stdin to this script
+cat $1 | zowe zos-jobs submit stdin $2 $3
+exit $?

--- a/packages/zosjobs/__tests__/__system__/cli/submit/stdin/cli.zos-jobs.submit.stdin.system.test.ts
+++ b/packages/zosjobs/__tests__/__system__/cli/submit/stdin/cli.zos-jobs.submit.stdin.system.test.ts
@@ -1,0 +1,131 @@
+/*
+* This program and the accompanying materials are made available under the terms of the
+* Eclipse Public License v2.0 which accompanies this distribution, and is available at
+* https://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Copyright Contributors to the Zowe Project.
+*
+*/
+
+import { ITestEnvironment } from "../../../../../../../__tests__/__src__/environment/doc/response/ITestEnvironment";
+import { TestEnvironment } from "../../../../../../../__tests__/__src__/environment/TestEnvironment";
+import { runCliScript } from "../../../../../../../__tests__/__src__/TestUtils";
+import { ITestPropertiesSchema } from "../../../../../../../__tests__/__src__/properties/ITestPropertiesSchema";
+import { IO, Session } from "@zowe/imperative";
+
+
+process.env.FORCE_COLOR = "0";
+
+// Test Environment populated in the beforeAll();
+let TEST_ENVIRONMENT: ITestEnvironment;
+let REAL_SESSION: Session;
+let systemProps: ITestPropertiesSchema;
+let account: string;
+let jcl: string;
+describe("zos-jobs submit stdin command", () => {
+    beforeAll(async () => {
+        TEST_ENVIRONMENT = await TestEnvironment.setUp({
+            testName: "zos_jobs_submit_stdin_command",
+            tempProfileTypes: ["zosmf"]
+        });
+
+        systemProps = TEST_ENVIRONMENT.systemTestProperties;
+
+        REAL_SESSION = TestEnvironment.createZosmfSession(TEST_ENVIRONMENT);
+        account = systemProps.tso.account;
+        const maxJobNamePrefixLength = 5;
+        // JCL to submit
+        jcl = "//" + systemProps.zosmf.user.toUpperCase().substring(0, maxJobNamePrefixLength) + "J JOB  " + account +
+            ",'Brightside Test',MSGLEVEL=(1,1),MSGCLASS=4,CLASS=C\n" +
+            "//EXEC PGM=IEFBR14";
+
+        // Create an local file with JCL to submit
+        const bufferJCL: Buffer = Buffer.from(jcl);
+        IO.createFileSync(__dirname + "/testFileOfLocalJCL.txt");
+        IO.writeFile(__dirname + "/testFileOfLocalJCL.txt", bufferJCL);
+    });
+
+    afterAll(async () => {
+        await TestEnvironment.cleanUp(TEST_ENVIRONMENT);
+
+        // Delete created uss file
+        const localJCL: string = `${__dirname}\\testFileOfLocalJCL.txt`;
+        IO.deleteFile(localJCL);
+    });
+
+    describe("Live system tests", () => {
+        it("should submit a job using JCL on stdin", async () => {
+            const response = runCliScript(__dirname + "/__scripts__/submit_valid_stdin.sh",
+                TEST_ENVIRONMENT, [__dirname + "/testFileOfLocalJCL.txt"]);
+            expect(response.stderr.toString()).toBe("");
+            expect(response.status).toBe(0);
+            expect(response.stdout.toString()).toContain("jobname");
+            expect(response.stdout.toString()).toContain("jobid");
+        });
+
+        it("should subbt a job using JCL on stdin with 'view-all-spool-content' option", async () => {
+            const response = runCliScript(__dirname + "/__scripts__/submit_valid_stdin_vasc.sh",
+                TEST_ENVIRONMENT, [__dirname + "/testFileOfLocalJCL.txt", "--vasc"]);
+            expect(response.stderr.toString()).toBe("");
+            expect(response.status).toBe(0);
+            expect(response.stdout.toString()).toContain("Spool file");
+            expect(response.stdout.toString()).toContain("JES2");
+        });
+
+        it("should submit a job using JCL on stdin with 'directory' option", async () => {
+            const response = runCliScript(__dirname + "/__scripts__/submit_valid_stdin_with_directory.sh",
+                TEST_ENVIRONMENT, [__dirname + "/testFileOfLocalJCL.txt", "--directory", "./"]);
+            expect(response.stderr.toString()).toBe("");
+            expect(response.status).toBe(0);
+            expect(response.stdout.toString()).toContain("jobname");
+            expect(response.stdout.toString()).toContain("jobid");
+            expect(response.stdout.toString()).toContain("Successfully downloaded output to ./");
+            expect(new RegExp("JOB\\d{5}", "g").test(response.stdout.toString())).toBe(true);
+        });
+
+        describe("without profiles", () => {
+
+            // Create a separate test environment for no profiles
+            let TEST_ENVIRONMENT_NO_PROF: ITestEnvironment;
+            let DEFAULT_SYSTEM_PROPS: ITestPropertiesSchema;
+
+            beforeAll(async () => {
+                TEST_ENVIRONMENT_NO_PROF = await TestEnvironment.setUp({
+                    testName: "zos_jobs_submit_local_file_without_profiles"
+                });
+
+                DEFAULT_SYSTEM_PROPS = TEST_ENVIRONMENT_NO_PROF.systemTestProperties;
+            });
+
+            afterAll(async () => {
+                await TestEnvironment.cleanUp(TEST_ENVIRONMENT_NO_PROF);
+            });
+
+            it("should submit a job in an existing valid local file", async () => {
+                const ZOWE_OPT_BASE_PATH = "ZOWE_OPT_BASE_PATH";
+
+                // if API Mediation layer is being used (basePath has a value) then
+                // set an ENVIRONMENT variable to be used by zowe.
+                if (DEFAULT_SYSTEM_PROPS.zosmf.basePath != null) {
+                    TEST_ENVIRONMENT_NO_PROF.env[ZOWE_OPT_BASE_PATH] = DEFAULT_SYSTEM_PROPS.zosmf.basePath;
+                }
+
+                const response = runCliScript(__dirname + "/__scripts__/submit_valid_stdin_fully_qualified.sh",
+                    TEST_ENVIRONMENT_NO_PROF,
+                    [
+                        __dirname + "/testFileOfLocalJCL.txt",
+                        DEFAULT_SYSTEM_PROPS.zosmf.host,
+                        DEFAULT_SYSTEM_PROPS.zosmf.port,
+                        DEFAULT_SYSTEM_PROPS.zosmf.user,
+                        DEFAULT_SYSTEM_PROPS.zosmf.pass
+                    ]);
+                expect(response.stderr.toString()).toBe("");
+                expect(response.status).toBe(0);
+                expect(response.stdout.toString()).toContain("jobname");
+                expect(response.stdout.toString()).toContain("jobid");
+            });
+        });
+    });
+});

--- a/packages/zosjobs/__tests__/cli/submit/Submit.definition.unit.test.ts
+++ b/packages/zosjobs/__tests__/cli/submit/Submit.definition.unit.test.ts
@@ -13,9 +13,10 @@ import { ICommandDefinition } from "@zowe/imperative";
 
 describe("zos-jobs submit group definition", () => {
     it("should not have changed", () => {
+        const CHILDREN = 3;
         const definition: ICommandDefinition = require("../../../src/cli/submit/Submit.definition").SubmitDefinition;
         expect(definition).toBeDefined();
-        expect(definition.children.length).toBe(2);
+        expect(definition.children.length).toBe(CHILDREN);
         delete definition.children;
         expect(definition).toMatchSnapshot();
     });

--- a/packages/zosjobs/__tests__/cli/submit/local-file/__snapshots__/LocalFile.definition.unit.test.ts.snap
+++ b/packages/zosjobs/__tests__/cli/submit/local-file/__snapshots__/LocalFile.definition.unit.test.ts.snap
@@ -18,7 +18,7 @@ Object {
       "aliases": Array [
         "vasc",
       ],
-      "description": "View all spool content for specified job ID",
+      "description": "Print all spool output. If you use this option you will wait the job to complete.",
       "name": "view-all-spool-content",
       "type": "boolean",
     },
@@ -26,7 +26,7 @@ Object {
       "aliases": Array [
         "d",
       ],
-      "description": "The local directory you would like to download the output for the job to. Creates a subdirectory using the jobID as the name and files are titled based on DD names.",
+      "description": "The local directory you would like to download the output of the job. Creates a subdirectory using the jobID as the name and files are titled based on DD names. If you use this option you will wait the job to complete.",
       "name": "directory",
       "type": "string",
     },
@@ -34,7 +34,7 @@ Object {
       "aliases": Array [
         "e",
       ],
-      "description": "A file extension to save the job output with",
+      "description": "A file extension to save the job output with. Default is '.txt'.",
       "name": "extension",
       "type": "string",
     },

--- a/packages/zosjobs/__tests__/cli/submit/stdin/__snapshots__/stdin.definition.unit.test.ts.snap
+++ b/packages/zosjobs/__tests__/cli/submit/stdin/__snapshots__/stdin.definition.unit.test.ts.snap
@@ -1,0 +1,45 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`zos-jobs submit stdin definition should not have changed 1`] = `
+Object {
+  "aliases": Array [
+    "in",
+  ],
+  "description": "Submit a job (JCL) passed to the command via the stdin stream. The command presents errors verbatim from the z/OSMF Jobs REST endpoints. For more information about z/OSMF Jobs API errors, see the z/OSMF Jobs API REST documentation.",
+  "name": "stdin",
+  "options": Array [
+    Object {
+      "aliases": Array [
+        "vasc",
+      ],
+      "description": "Print all spool output. If you use this option you will wait the job to complete.",
+      "name": "view-all-spool-content",
+      "type": "boolean",
+    },
+    Object {
+      "aliases": Array [
+        "d",
+      ],
+      "description": "The local directory you would like to download the output of the job. Creates a subdirectory using the jobID as the name and files are titled based on DD names. If you use this option you will wait the job to complete.",
+      "name": "directory",
+      "type": "string",
+    },
+    Object {
+      "aliases": Array [
+        "e",
+      ],
+      "description": "A file extension to save the job output with. Default is '.txt'.",
+      "name": "extension",
+      "type": "string",
+    },
+  ],
+  "outputFormatOptions": true,
+  "profile": Object {
+    "optional": Array [
+      "zosmf",
+    ],
+  },
+  "summary": "Submit a job read from standard in",
+  "type": "command",
+}
+`;

--- a/packages/zosjobs/__tests__/cli/submit/stdin/stdin.definition.unit.test.ts
+++ b/packages/zosjobs/__tests__/cli/submit/stdin/stdin.definition.unit.test.ts
@@ -1,0 +1,21 @@
+/*
+* This program and the accompanying materials are made available under the terms of the
+* Eclipse Public License v2.0 which accompanies this distribution, and is available at
+* https://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Copyright Contributors to the Zowe Project.
+*
+*/
+
+import { ICommandDefinition } from "@zowe/imperative";
+
+describe("zos-jobs submit stdin definition", () => {
+    it("should not have changed", () => {
+        const definition: ICommandDefinition = require("../../../../src/cli/submit/stdin/stdin.definition").StdinDefinition;
+        expect(definition).toBeDefined();
+        delete definition.handler;
+        expect(definition).toMatchSnapshot();
+    });
+});

--- a/packages/zosjobs/src/cli/submit/Submit.definition.ts
+++ b/packages/zosjobs/src/cli/submit/Submit.definition.ts
@@ -12,6 +12,7 @@
 import { ICommandDefinition } from "@zowe/imperative";
 import { DataSetDefinition } from "./data-set/DataSet.definition";
 import { LocalFileDefinition } from "../../../../zosjobs/src/cli/submit/local-file/localFile.definition";
+import { StdinDefinition } from "./stdin/stdin.definition";
 
 export const SubmitDefinition: ICommandDefinition = {
     name: "submit",
@@ -22,5 +23,6 @@ export const SubmitDefinition: ICommandDefinition = {
     children: [
         DataSetDefinition,
         LocalFileDefinition,
+        StdinDefinition,
     ]
 };

--- a/packages/zosjobs/src/cli/submit/local-file/localFile.definition.ts
+++ b/packages/zosjobs/src/cli/submit/local-file/localFile.definition.ts
@@ -32,18 +32,20 @@ export const LocalFileDefinition: ICommandDefinition = {
     options: ([
         {
             name: "view-all-spool-content", aliases: ["vasc"],
-            description: "View all spool content for specified job ID",
+            description: "Print all spool output." +
+                " If you use this option you will wait the job to complete.",
             type: "boolean"
         },
         {
             name: "directory", aliases: ["d"],
-            description: "The local directory you would like to download the output for the job to. "
-                + "Creates a subdirectory using the jobID as the name and files are titled based on DD names.",
+            description: "The local directory you would like to download the output of the job." +
+                " Creates a subdirectory using the jobID as the name and files are titled based on DD names." +
+                " If you use this option you will wait the job to complete.",
             type: "string"
         },
         {
             name: "extension", aliases: ["e"],
-            description: "A file extension to save the job output with",
+            description: "A file extension to save the job output with. Default is '.txt'.",
             type: "string"
         },
     ]as ICommandOptionDefinition[]),

--- a/packages/zosjobs/src/cli/submit/stdin/stdin.definition.ts
+++ b/packages/zosjobs/src/cli/submit/stdin/stdin.definition.ts
@@ -1,0 +1,45 @@
+/*
+* This program and the accompanying materials are made available under the terms of the
+* Eclipse Public License v2.0 which accompanies this distribution, and is available at
+* https://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Copyright Contributors to the Zowe Project.
+*
+*/
+
+import { ICommandDefinition, ICommandOptionDefinition } from "@zowe/imperative";
+
+export const StdinDefinition: ICommandDefinition = {
+    name: "stdin",
+    aliases: ["in"],
+    type: "command",
+    summary: "Submit a job read from standard in",
+    description: "Submit a job (JCL) passed to the command via the stdin stream. " +
+        "The command presents errors verbatim from the z/OSMF Jobs REST endpoints. " +
+        "For more information about z/OSMF Jobs API errors, see the z/OSMF Jobs API REST documentation.",
+    handler: __dirname + "/../Submit.shared.handler",
+    options: ([
+        {
+            name: "view-all-spool-content", aliases: ["vasc"],
+            description: "View all spool content for specified job ID",
+            type: "boolean"
+        },
+        {
+            name: "directory", aliases: ["d"],
+            description: "The local directory you would like to download the output for the job to. "
+                + "Creates a subdirectory using the jobID as the name and files are titled based on DD names.",
+            type: "string"
+        },
+        {
+            name: "extension", aliases: ["e"],
+            description: "A file extension to save the job output with",
+            type: "string"
+        },
+    ] as ICommandOptionDefinition[]),
+    profile: {
+        optional: ["zosmf"]
+    },
+    outputFormatOptions: true,
+};

--- a/packages/zosjobs/src/cli/submit/stdin/stdin.definition.ts
+++ b/packages/zosjobs/src/cli/submit/stdin/stdin.definition.ts
@@ -23,18 +23,20 @@ export const StdinDefinition: ICommandDefinition = {
     options: ([
         {
             name: "view-all-spool-content", aliases: ["vasc"],
-            description: "View all spool content for specified job ID",
+            description: "Print all spool output." +
+                " If you use this option you will wait the job to complete.",
             type: "boolean"
         },
         {
             name: "directory", aliases: ["d"],
-            description: "The local directory you would like to download the output for the job to. "
-                + "Creates a subdirectory using the jobID as the name and files are titled based on DD names.",
+            description: "The local directory you would like to download the output of the job." +
+                " Creates a subdirectory using the jobID as the name and files are titled based on DD names." +
+                " If you use this option you will wait the job to complete.",
             type: "string"
         },
         {
             name: "extension", aliases: ["e"],
-            description: "A file extension to save the job output with",
+            description: "A file extension to save the job output with. Default is '.txt'.",
             type: "string"
         },
     ] as ICommandOptionDefinition[]),


### PR DESCRIPTION
While working on a project it became clear that being able to supply the JCL to submit on stdin would be useful as it would allow the Zowe-cli program to run as part of a unix pipeline.

The change adds a new `stdin` option which can be used in place of the existing data set or local file options.

Example of usage:
`mustache config.json template.jcl | zowe jobs sub stdin --vasc`

Signed-off-by: Andrew Smithson <smithson@uk.ibm.com>