### PR TITLE
Fixed typo in ZosmfHeaders + added recall option to List

### DIFF
--- a/packages/rest/src/ZosmfHeaders.ts
+++ b/packages/rest/src/ZosmfHeaders.ts
@@ -153,8 +153,8 @@ export class ZosmfHeaders {
      * @static
      * @memberof ZosmfHeaders
      */
-    public static readonly X_IBM_MIGRATED_RECALL_WAIT: IHeaderContent = {"X-IBM-Migrated-Reacall": "wait"};
-    public static readonly X_IBM_MIGRATED_RECALL_NO_WAIT: IHeaderContent = {"X-IBM-Migrated-Reacall": "nowait"};
-    public static readonly X_IBM_MIGRATED_RECALL_ERROR: IHeaderContent = {"X-IBM-Migrated-Reacall": "error"};
+    public static readonly X_IBM_MIGRATED_RECALL_WAIT: IHeaderContent = {"X-IBM-Migrated-Recall": "wait"};
+    public static readonly X_IBM_MIGRATED_RECALL_NO_WAIT: IHeaderContent = {"X-IBM-Migrated-Recall": "nowait"};
+    public static readonly X_IBM_MIGRATED_RECALL_ERROR: IHeaderContent = {"X-IBM-Migrated-Recall": "error"};
 
 }

--- a/packages/zosfiles/__tests__/api/methods/list/List.unit.test.ts
+++ b/packages/zosfiles/__tests__/api/methods/list/List.unit.test.ts
@@ -334,6 +334,69 @@ describe("z/OS Files - List", () => {
             expect(expectJsonSpy).toHaveBeenCalledTimes(1);
             expect(expectJsonSpy).toHaveBeenCalledWith(dummySession, endpoint, [ZosmfHeaders.X_IBM_ATTRIBUTES_BASE, ZosmfHeaders.X_IBM_MAX_ITEMS]);
         });
+
+        it("should return with data when specify recall and attributes options", async () => {
+            let response;
+            let error;
+            const testApiResponse = {
+                items: ["test"]
+            };
+            const endpoint = posix.join(ZosFilesConstants.RESOURCE,
+                `${ZosFilesConstants.RES_DS_FILES}?${ZosFilesConstants.RES_DS_LEVEL}=${dsname}`);
+
+            expectJsonSpy.mockResolvedValue(testApiResponse);
+
+            // Unit test for wait option
+            try {
+                response = await List.dataSet(dummySession, dsname, {attributes: true, recall: "wait"});
+            } catch (err) {
+                error = err;
+            }
+
+            expect(error).toBeFalsy();
+            expect(response).toBeTruthy();
+            expect(response.success).toBeTruthy();
+            expect(response.commandResponse).toBe(null);
+            expect(response.apiResponse).toBe(testApiResponse);
+            expect(expectJsonSpy).toHaveBeenCalledTimes(1);
+            expect(expectJsonSpy).toHaveBeenCalledWith(dummySession, endpoint, [ZosmfHeaders.X_IBM_ATTRIBUTES_BASE, ZosmfHeaders.X_IBM_MAX_ITEMS,
+                                                                                ZosmfHeaders.X_IBM_MIGRATED_RECALL_WAIT]);
+            expectJsonSpy.mockClear();
+
+            // Unit test for nowait option
+            try {
+                response = await List.dataSet(dummySession, dsname, {attributes: true, recall: "nowait"});
+            } catch (err) {
+                error = err;
+            }
+
+            expect(error).toBeFalsy();
+            expect(response).toBeTruthy();
+            expect(response.success).toBeTruthy();
+            expect(response.commandResponse).toBe(null);
+            expect(response.apiResponse).toBe(testApiResponse);
+            expect(expectJsonSpy).toHaveBeenCalledTimes(1);
+            expect(expectJsonSpy).toHaveBeenCalledWith(dummySession, endpoint, [ZosmfHeaders.X_IBM_ATTRIBUTES_BASE, ZosmfHeaders.X_IBM_MAX_ITEMS,
+                                                                                ZosmfHeaders.X_IBM_MIGRATED_RECALL_NO_WAIT]);
+            expectJsonSpy.mockClear();
+
+            // Unit test for error option
+            try {
+                response = await List.dataSet(dummySession, dsname, {attributes: true, recall: "error"});
+            } catch (err) {
+                error = err;
+            }
+
+            expect(error).toBeFalsy();
+            expect(response).toBeTruthy();
+            expect(response.success).toBeTruthy();
+            expect(response.commandResponse).toBe(null);
+            expect(response.apiResponse).toBe(testApiResponse);
+            expect(expectJsonSpy).toHaveBeenCalledTimes(1);
+            expect(expectJsonSpy).toHaveBeenCalledWith(dummySession, endpoint, [ZosmfHeaders.X_IBM_ATTRIBUTES_BASE, ZosmfHeaders.X_IBM_MAX_ITEMS,
+                                                                                ZosmfHeaders.X_IBM_MIGRATED_RECALL_ERROR]);
+            expectJsonSpy.mockClear();
+        });
     });
 
     describe("fileList", () => {

--- a/packages/zosfiles/src/api/doc/types/ZosmfMigratedRecallOptions.ts
+++ b/packages/zosfiles/src/api/doc/types/ZosmfMigratedRecallOptions.ts
@@ -1,0 +1,17 @@
+/*
+* This program and the accompanying materials are made available under the terms of the
+* Eclipse Public License v2.0 which accompanies this distribution, and is available at
+* https://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Copyright Contributors to the Zowe Project.
+*
+*/
+
+/**
+ * z/OSMF options for recall of migrated data sets. See the z/OSMF REST API publication for complete details.
+ * @export
+ * @type ZosmfMigratedRecallOptions
+ */
+export type ZosmfMigratedRecallOptions = "wait" | "nowait" | "error";

--- a/packages/zosfiles/src/api/index.ts
+++ b/packages/zosfiles/src/api/index.ts
@@ -24,6 +24,7 @@ export * from "./utils/ZosFilesAttributes";
 export * from "./utils/ZosFilesUtils";
 
 export * from "./doc/IZosFilesResponse";
+export * from "./doc/types/ZosmfMigratedRecallOptions";
 
 export * from "./constants/ZosFiles.constants";
 export * from "./constants/ZosFiles.messages";

--- a/packages/zosfiles/src/api/methods/list/List.ts
+++ b/packages/zosfiles/src/api/methods/list/List.ts
@@ -108,6 +108,24 @@ export class List {
                 reqHeaders.push(ZosmfHeaders.X_IBM_MAX_ITEMS);
             }
 
+            // Migrated recall options
+            if (options.recall) {
+                switch (options.recall.toLowerCase()) {
+                    case "wait":
+                        reqHeaders.push(ZosmfHeaders.X_IBM_MIGRATED_RECALL_WAIT);
+                        break;
+                    case "nowait":
+                        reqHeaders.push(ZosmfHeaders.X_IBM_MIGRATED_RECALL_NO_WAIT);
+                        break;
+                    case "error":
+                        reqHeaders.push(ZosmfHeaders.X_IBM_MIGRATED_RECALL_ERROR);
+                        break;
+                    default:
+                        reqHeaders.push(ZosmfHeaders.X_IBM_MIGRATED_RECALL_NO_WAIT);
+                        break;
+                }
+            }
+
             this.log.debug(`Endpoint: ${endpoint}`);
 
             const response: any = await ZosmfRestClient.getExpectJSON(session, endpoint, reqHeaders);

--- a/packages/zosfiles/src/api/methods/list/List.ts
+++ b/packages/zosfiles/src/api/methods/list/List.ts
@@ -120,9 +120,6 @@ export class List {
                     case "error":
                         reqHeaders.push(ZosmfHeaders.X_IBM_MIGRATED_RECALL_ERROR);
                         break;
-                    default:
-                        reqHeaders.push(ZosmfHeaders.X_IBM_MIGRATED_RECALL_NO_WAIT);
-                        break;
                 }
             }
 

--- a/packages/zosfiles/src/api/methods/list/doc/IListOptions.ts
+++ b/packages/zosfiles/src/api/methods/list/doc/IListOptions.ts
@@ -33,4 +33,10 @@ export interface IListOptions {
      * An optional search parameter that specifies the first data set name to return in the response document
      */
     start?: string;
+
+    /**
+     * An optional parameter that specifies how to handle migrated data sets
+     * @example "wait, nowait, error"
+     */
+    recall?: string;
 }

--- a/packages/zosfiles/src/api/methods/list/doc/IListOptions.ts
+++ b/packages/zosfiles/src/api/methods/list/doc/IListOptions.ts
@@ -1,3 +1,5 @@
+import { ZosmfMigratedRecallOptions } from "../../../doc/types/ZosmfMigratedRecallOptions";
+
 /*
 * This program and the accompanying materials are made available under the terms of the
 * Eclipse Public License v2.0 which accompanies this distribution, and is available at
@@ -36,7 +38,6 @@ export interface IListOptions {
 
     /**
      * An optional parameter that specifies how to handle migrated data sets
-     * @example "wait, nowait, error"
      */
-    recall?: string;
+    recall?: ZosmfMigratedRecallOptions;
 }

--- a/packages/zosfiles/src/api/methods/list/doc/IListOptions.ts
+++ b/packages/zosfiles/src/api/methods/list/doc/IListOptions.ts
@@ -1,5 +1,3 @@
-import { ZosmfMigratedRecallOptions } from "../../../doc/types/ZosmfMigratedRecallOptions";
-
 /*
 * This program and the accompanying materials are made available under the terms of the
 * Eclipse Public License v2.0 which accompanies this distribution, and is available at
@@ -10,6 +8,8 @@ import { ZosmfMigratedRecallOptions } from "../../../doc/types/ZosmfMigratedReca
 * Copyright Contributors to the Zowe Project.
 *
 */
+
+import { ZosmfMigratedRecallOptions } from "../../../doc/types/ZosmfMigratedRecallOptions";
 
 /**
  * This interface defines the options that can be sent into the dwanload data set function

--- a/packages/zosfiles/src/api/methods/upload/Upload.ts
+++ b/packages/zosfiles/src/api/methods/upload/Upload.ts
@@ -336,7 +336,7 @@ export class Upload {
 
         // Retrieve the information on the input data set name to determine if it is a
         // sequential data set or PDS.
-        const listResponse = await List.dataSet(session, dataSetName, {attributes: true, maxLength: 1, start: dataSetName});
+        const listResponse = await List.dataSet(session, dataSetName, {attributes: true, maxLength: 1, start: dataSetName, recall: "wait"});
         if (listResponse.apiResponse != null && listResponse.apiResponse.returnedRows != null && listResponse.apiResponse.items != null) {
             // Look for the index of the data set in the response from the List API
             const dsnameIndex = listResponse.apiResponse.returnedRows === 0 ? -1 :


### PR DESCRIPTION
Still doesn't fix #493, but might be addressed in the future on the CA Disk-side