### PR TITLE
feat: add API of replace option for copy

### DIFF
--- a/packages/zosfiles/__tests__/__system__/api/methods/copy/Copy.system.test.ts
+++ b/packages/zosfiles/__tests__/__system__/api/methods/copy/Copy.system.test.ts
@@ -216,5 +216,72 @@ describe("Copy", () => {
                 });
             });
         });
+        describe("Replace option", () => {
+            beforeEach(async () => {
+                try {
+                    await Create.dataSet(REAL_SESSION, CreateDataSetTypeEnum.DATA_SET_PARTITIONED, fromDataSetName);
+                    await Create.dataSet(REAL_SESSION, CreateDataSetTypeEnum.DATA_SET_SEQUENTIAL, toDataSetName);
+                    await Upload.fileToDataset(REAL_SESSION, fileLocation, fromDataSetName);
+                    await Copy.dataSet(
+                        REAL_SESSION,
+                        { dataSetName: fromDataSetName, memberName: file1 },
+                        { dataSetName: toDataSetName, memberName: file2 },
+                    );
+                } catch (err) {
+                    Imperative.console.info(`Error: ${inspect(err)}`);
+                }
+            });
+            it("Should result in error without replace option", async () => {
+                let error;
+                let response;
+
+                try {
+                    response = await Copy.dataSet(
+                        REAL_SESSION,
+                        { dataSetName: fromDataSetName, memberName: file1 },
+                        { dataSetName: toDataSetName, memberName: file2 },
+                        { replace: false }
+                    );
+                    Imperative.console.info(`Response: ${inspect(response)}`);
+                } catch (err) {
+                    error = err;
+                    Imperative.console.info(`Error: ${inspect(err)}`);
+                }
+
+                expect(error).toBeTruthy();
+                expect(response).toBeNull();
+            });
+            it("Should succeed with replace option", async () => {
+                let error;
+                let response;
+                let contents1;
+                let contents2;
+
+                try {
+                    response = await Copy.dataSet(
+                        REAL_SESSION,
+                        { dataSetName: fromDataSetName, memberName: file1 },
+                        { dataSetName: toDataSetName, memberName: file2 },
+                        { replace: true }
+                    );
+                    contents1 = await Get.dataSet(REAL_SESSION, `${fromDataSetName}(${file1})`);
+                    contents2 = await Get.dataSet(REAL_SESSION, `${toDataSetName}(${file2})`);
+                    Imperative.console.info(`Response: ${inspect(response)}`);
+                } catch (err) {
+                    error = err;
+                    Imperative.console.info(`Error: ${inspect(err)}`);
+                }
+
+                expect(error).toBeFalsy();
+
+                expect(response).toBeTruthy();
+                expect(response.success).toBe(true);
+                expect(response.commandResponse).toContain(ZosFilesMessages.datasetCopiedSuccessfully.message);
+
+                expect(contents1).toBeTruthy();
+                expect(contents2).toBeTruthy();
+                expect(contents1.toString()).toEqual(contents2.toString());
+            });
+        });
     });
 });

--- a/packages/zosfiles/__tests__/__system__/api/methods/copy/Copy.system.test.ts
+++ b/packages/zosfiles/__tests__/__system__/api/methods/copy/Copy.system.test.ts
@@ -220,7 +220,7 @@ describe("Copy", () => {
             beforeEach(async () => {
                 try {
                     await Create.dataSet(REAL_SESSION, CreateDataSetTypeEnum.DATA_SET_PARTITIONED, fromDataSetName);
-                    await Create.dataSet(REAL_SESSION, CreateDataSetTypeEnum.DATA_SET_SEQUENTIAL, toDataSetName);
+                    await Create.dataSet(REAL_SESSION, CreateDataSetTypeEnum.DATA_SET_PARTITIONED, toDataSetName);
                     await Upload.fileToDataset(REAL_SESSION, fileLocation, fromDataSetName);
                     await Copy.dataSet(
                         REAL_SESSION,
@@ -249,7 +249,8 @@ describe("Copy", () => {
                 }
 
                 expect(error).toBeTruthy();
-                expect(response).toBeNull();
+                expect(error.message).toContain("Like-named member already exists");
+                expect(response).toBeFalsy();
             });
             it("Should succeed with replace option", async () => {
                 let error;

--- a/packages/zosfiles/__tests__/api/methods/copy/Copy.unit.test.ts
+++ b/packages/zosfiles/__tests__/api/methods/copy/Copy.unit.test.ts
@@ -189,6 +189,46 @@ describe("Copy", () => {
                     );
                 });
             });
+            describe("Replace option", () => {
+                it("should not contain replace in payload", async () => {
+                    await Copy.dataSet(
+                        dummySession,
+                        { dataSetName: fromDataSetName },
+                        { dataSetName: toDataSetName }
+                    );
+
+                    expect(copyExpectStringSpy).toHaveBeenCalledTimes(1);
+                    const argumentsOfCall = copyExpectStringSpy.mock.calls[0];
+                    const lastArgumentOfCall = argumentsOfCall[argumentsOfCall.length - 1];
+                    expect(lastArgumentOfCall).not.toHaveProperty("replace");
+                });
+                it("should contain replace with value true in payload", async () => {
+                    await Copy.dataSet(
+                        dummySession,
+                        { dataSetName: fromDataSetName },
+                        { dataSetName: toDataSetName },
+                        { replace: true }
+                    );
+
+                    expect(copyExpectStringSpy).toHaveBeenCalledTimes(1);
+                    const argumentsOfCall = copyExpectStringSpy.mock.calls[0];
+                    const lastArgumentOfCall = argumentsOfCall[argumentsOfCall.length - 1];
+                    expect(lastArgumentOfCall).toHaveProperty("replace", true);
+                });
+                it("should contain replace with value false in payload", async () => {
+                    await Copy.dataSet(
+                        dummySession,
+                        { dataSetName: fromDataSetName },
+                        { dataSetName: toDataSetName },
+                        { replace: false }
+                    );
+
+                    expect(copyExpectStringSpy).toHaveBeenCalledTimes(1);
+                    const argumentsOfCall = copyExpectStringSpy.mock.calls[0];
+                    const lastArgumentOfCall = argumentsOfCall[argumentsOfCall.length - 1];
+                    expect(lastArgumentOfCall).toHaveProperty("replace", false);
+                });
+            });
         });
         describe("Failure Scenarios", () => {
             it("should fail if the zOSMF REST client fails", async () => {

--- a/packages/zosfiles/src/api/methods/copy/Copy.ts
+++ b/packages/zosfiles/src/api/methods/copy/Copy.ts
@@ -39,7 +39,7 @@ export class Copy {
      */
     public static async dataSet(
         session: AbstractSession,
-        { dataSetName: fromDataSetName, memberName: fromMemberName }: ICopyDataSet,
+        { dataSetName: fromDataSetName, memberName: fromMemberName, replace }: ICopyDataSet,
         { dataSetName: toDataSetName, memberName: toMemberName }: ICopyDataSet,
     ): Promise<IZosFilesResponse> {
         ImperativeExpect.toNotBeNullOrUndefined(fromDataSetName, ZosFilesMessages.missingDatasetName.message);
@@ -59,6 +59,7 @@ export class Copy {
             "from-dataset": {
                 dsn: fromDataSetName,
             },
+            "replace": replace
         };
 
         if(fromMemberName != null) {

--- a/packages/zosfiles/src/api/methods/copy/Copy.ts
+++ b/packages/zosfiles/src/api/methods/copy/Copy.ts
@@ -18,6 +18,7 @@ import { ZosFilesMessages } from "../../constants/ZosFiles.messages";
 import { IZosFilesResponse } from "../../doc/IZosFilesResponse";
 import { IHeaderContent } from "../../../../../rest/src/doc/IHeaderContent";
 import { ICopyDataSet } from ".";
+import { ICopyDatasetOptions } from "./doc/ICopyDatasetOptions";
 /**
  * This class holds helper functions that are used to copy the contents of datasets through the
  * z/OSMF APIs.
@@ -39,8 +40,9 @@ export class Copy {
      */
     public static async dataSet(
         session: AbstractSession,
-        { dataSetName: fromDataSetName, memberName: fromMemberName, replace }: ICopyDataSet,
+        { dataSetName: fromDataSetName, memberName: fromMemberName }: ICopyDataSet,
         { dataSetName: toDataSetName, memberName: toMemberName }: ICopyDataSet,
+        options: ICopyDatasetOptions = {}
     ): Promise<IZosFilesResponse> {
         ImperativeExpect.toNotBeNullOrUndefined(fromDataSetName, ZosFilesMessages.missingDatasetName.message);
         ImperativeExpect.toNotBeEqual(fromDataSetName, "", ZosFilesMessages.missingDatasetName.message);
@@ -58,12 +60,15 @@ export class Copy {
             "request": "copy",
             "from-dataset": {
                 dsn: fromDataSetName,
-            },
-            "replace": replace
+            }
         };
 
         if(fromMemberName != null) {
             payload["from-dataset"].member = fromMemberName;
+        }
+
+        if (options.replace !== undefined) {
+            payload["replace"] = options.replace;
         }
 
         const reqHeaders: IHeaderContent[] = [

--- a/packages/zosfiles/src/api/methods/copy/doc/ICopyDataSet.ts
+++ b/packages/zosfiles/src/api/methods/copy/doc/ICopyDataSet.ts
@@ -27,10 +27,4 @@ export interface ICopyDataSet {
      * @type {string}
      */
     memberName?: string;
-
-    /**
-     * Replace option
-     * @type {boolean}
-     */
-    replace?: boolean;
 }

--- a/packages/zosfiles/src/api/methods/copy/doc/ICopyDataSet.ts
+++ b/packages/zosfiles/src/api/methods/copy/doc/ICopyDataSet.ts
@@ -27,4 +27,10 @@ export interface ICopyDataSet {
      * @type {string}
      */
     memberName?: string;
+
+    /**
+     * Replace option
+     * @type {boolean}
+     */
+    replace?: boolean;
 }

--- a/packages/zosfiles/src/api/methods/copy/doc/ICopyDatasetOptions.ts
+++ b/packages/zosfiles/src/api/methods/copy/doc/ICopyDatasetOptions.ts
@@ -1,0 +1,21 @@
+/*
+* This program and the accompanying materials are made available under the terms of the
+* Eclipse Public License v2.0 which accompanies this distribution, and is available at
+* https://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Copyright Contributors to the Zowe Project.
+*
+*/
+
+/**
+ * This interface defines the options that can be sent into the copy data set function.
+ */
+export interface ICopyDatasetOptions {
+    /**
+     * Replace option
+     * @type {boolean}
+     */
+    replace?: boolean;
+}


### PR DESCRIPTION
Add API functionality to specify replace option when copying dataset.

If implementation is okay, I can also add for enq option in the same way.

Related to #579 