### PR TITLE
adding option to return Etag on Upload

### DIFF
--- a/packages/rest/src/ZosmfRestClient.ts
+++ b/packages/rest/src/ZosmfRestClient.ts
@@ -13,6 +13,7 @@ import { IImperativeError, Logger, RestClient, TextUtils, Session, HTTP_VERB } f
 import { isNullOrUndefined } from "util";
 import { ZosmfHeaders } from "./ZosmfHeaders";
 import { IBufferWithEtag } from "../../zosfiles/src/api/doc/IBufferWithEtagResponse";
+import { IStringWithEtag } from "../../zosfiles/src/api/doc/IStringWithEtagResponse";
 
 /**
  * Wrapper for invoke z/OSMF API through the RestClient to perform common error
@@ -47,6 +48,28 @@ export class ZosmfRestClient extends RestClient {
         const client = new this(session);
         await client.performRest(resource, HTTP_VERB.GET, reqHeaders);
         const returnValue: IBufferWithEtag = {data: client.data, etag: client.response.headers.etag};
+        return returnValue;
+    }
+
+    /**
+     * REST HTTP PUT operation
+     * @static
+     * @param {AbstractSession} session - representing connection to this api
+     * @param {string} resource - URI for which this request should go against
+     * @param {object[]} reqHeaders - headers to include in the REST request
+     * @param {any} data - payload data
+     * @returns {Promise<IStringWithEtag>} - response body content from http(s) call
+     * @throws  if the request gets a status code outside of the 200 range
+     *          or other connection problems occur (e.g. connection refused)
+     * @memberof RestClient
+     */
+    public static async putExpectStringAndEtag(session: Session, resource: string, reqHeaders: any[] = [], data: any): Promise<IStringWithEtag> {
+        const client = new this(session);
+        await client.performRest(resource, HTTP_VERB.PUT, reqHeaders, data);
+        const returnValue: IStringWithEtag = {
+            data: client.response ,
+            etag: client.response.headers.etag
+        };
         return returnValue;
     }
 

--- a/packages/zosfiles/__tests__/__system__/api/methods/upload/Upload.system.test.ts
+++ b/packages/zosfiles/__tests__/__system__/api/methods/upload/Upload.system.test.ts
@@ -56,6 +56,7 @@ describe("Upload Data Set", () => {
                 let error;
                 let response;
                 uploadOptions.etag = null;
+                uploadOptions.returnEtag = false;
 
                 try {
                     response = await Create.dataSet(REAL_SESSION,
@@ -121,6 +122,35 @@ describe("Upload Data Set", () => {
                 expect(response).toBeTruthy();
                 expect(response.success).toBeTruthy();
                 expect(response.commandResponse).toContain(ZosFilesMessages.dataSetUploadedSuccessfully.message);
+            });
+
+            it("should upload a file to a physical sequential data and return the Etag", async () => {
+                let error;
+                let response: IZosFilesResponse;
+                uploadOptions.returnEtag = true;
+                // // we have to get first the Etag, so we can compare it
+                // await Upload.fileToDataset(REAL_SESSION,
+                //     __dirname + "/testfiles/upload.txt", dsname);
+                // const downloadOptions = {file: __dirname + "/testfiles/upload.txt", returnEtag: true};
+                // const downloadResponse = await Download.dataSet(REAL_SESSION, dsname, downloadOptions) ;
+
+                // // after we have the Etag, we can try to upload the file with etag specified
+                // uploadOptions.etag = downloadResponse.apiResponse.etag;
+
+                try {
+                    // packages/zosfiles/__tests__/__system__/api/methods/upload/
+                    response = await Upload.fileToDataset(REAL_SESSION,
+                        __dirname + "/testfiles/upload.txt", dsname, uploadOptions);
+                    Imperative.console.info("Response: " + inspect(response));
+                } catch (err) {
+                    error = err;
+                    Imperative.console.info("Error: " + inspect(error));
+                }
+                expect(error).toBeFalsy();
+                expect(response).toBeTruthy();
+                expect(response.success).toBeTruthy();
+                expect(response.commandResponse).toContain(ZosFilesMessages.dataSetUploadedSuccessfully.message);
+                expect(response.apiResponse[0].etag).toBeDefined();
             });
 
             it("should upload a file to a physical sequential data set using relative path", async () => {
@@ -531,6 +561,26 @@ describe("Upload USS file", () => {
 
             expect(error).toBeFalsy();
             expect(getResponse.apiResponse).toEqual(Buffer.from(testdata));
+
+        });
+
+        it("should upload a USS file and return Etag", async () => {
+            let error: any;
+            let uploadResponse: IZosFilesResponse;
+            let getResponse: IZosFilesResponse;
+
+            try {
+                uploadResponse = await Upload.fileToUSSFile(REAL_SESSION, inputfile, ussname, false, null, null, true);
+                Imperative.console.info("Response: " + inspect(uploadResponse));
+                getResponse = await Download.ussFile(REAL_SESSION, ussname);
+            } catch (err) {
+                error = err;
+                Imperative.console.info("Error: " + inspect(error));
+            }
+
+            expect(error).toBeFalsy();
+            expect(getResponse.apiResponse).toEqual(Buffer.from(testdata));
+            expect(uploadResponse.apiResponse.etag).toBeDefined();
 
         });
 

--- a/packages/zosfiles/src/api/doc/IStringWithEtagResponse.ts
+++ b/packages/zosfiles/src/api/doc/IStringWithEtagResponse.ts
@@ -1,0 +1,27 @@
+/*
+* This program and the accompanying materials are made available under the terms of the
+* Eclipse Public License v2.0 which accompanies this distribution, and is available at
+* https://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Copyright Contributors to the Zowe Project.
+*
+*/
+
+
+/**
+ * This interface defines the format of the API response which comes from zosmfRestClient when requesting the Etag
+ */
+export interface IStringWithEtag {
+
+    /**
+     * Data returned
+     */
+    data: string;
+
+    /**
+     * Etag value returned
+     */
+    etag: string;
+}

--- a/packages/zosfiles/src/api/methods/upload/doc/IUploadOptions.ts
+++ b/packages/zosfiles/src/api/methods/upload/doc/IUploadOptions.ts
@@ -80,4 +80,12 @@ export interface IUploadOptions {
      * It is used to check if the file was modified on target system before it is updated.
      */
     etag?: string;
+
+    /**
+     * The indicator to force return of ETag.
+     * If set to 'true' it forces the response to include an "ETag" header, regardless of the size of the response data.
+     * If it is not present, the the default is to only send an Etag for data sets smaller than a system determined length,
+     * which is at least 8MB.
+     */
+    returnEtag?: boolean;
 }

--- a/packages/zosfiles/src/api/methods/upload/doc/IUploadResult.ts
+++ b/packages/zosfiles/src/api/methods/upload/doc/IUploadResult.ts
@@ -26,4 +26,8 @@ export interface IUploadResult {
      * Optional, any error encounter while uploading the data
      */
     error?: any;
+    /**
+     * Optional, etag set when writing the file
+     */
+    etag?: string;
 }


### PR DESCRIPTION
- update IUploadResult interface to optionally return the etag
- update IUploadOptions interface to request return of etag
- create IStringWithEtagResponse interface
    - needed to define return object from newly created REST action
- create new zosmfRestClient action
    - needed so that I don't introduce a breaking change
- update Upload method
    - `bufferToDataSet` can now return the etag inside `apiResponse`
    - `pathToDataSet` can now return the etag inside `apiResponse`
    for each member in the list
    - create new action `bufferToUssFileWithEtag`
        - it has an implicit `returnEtag = true`
        - couldn't update `bufferToUssFile` without introducing breaking change
    - `fileToUSSFile` can now return the etag inside `apiResponse`

Signed-off-by: Alexandru-Paul Dumitru <ad670553@broadcom.net>