### PR TITLE
Remove default timeout of 300 sec on wait-for-output

### DIFF
--- a/packages/zosjobs/__tests__/api/__snapshots__/MonitorJobs.unit.test.ts.snap
+++ b/packages/zosjobs/__tests__/api/__snapshots__/MonitorJobs.unit.test.ts.snap
@@ -36,6 +36,6 @@ exports[`MonitorJobs Public Methods waitForStatusCommon expects should error if 
 
 exports[`MonitorJobs constant defaults should have a job status 1`] = `"OUTPUT"`;
 
-exports[`MonitorJobs constant defaults should have a max attempts 1`] = `100`;
+exports[`MonitorJobs constant defaults should have a max attempts 1`] = `Infinity`;
 
 exports[`MonitorJobs constant defaults should have a watch delay interval 1`] = `3000`;

--- a/packages/zosjobs/src/api/MonitorJobs.ts
+++ b/packages/zosjobs/src/api/MonitorJobs.ts
@@ -44,11 +44,11 @@ export class MonitorJobs {
      * @static
      * @memberof MonitorJobs
      */
-    public static readonly DEFAULT_ATTEMPTS = 100;
+    public static readonly DEFAULT_ATTEMPTS = Infinity;
 
     /**
      * Given an IJob (has jobname/jobid), waits for the status of the job to be "OUTPUT". This API will poll for
-     * the OUTPUT status once every 3 seconds for 100 attempts. If the polling interval/duration is NOT sufficient, use
+     * the OUTPUT status once every 3 seconds indefinitely. If the polling interval/duration is NOT sufficient, use
      * "waitForStatusCommon" to adjust.
      *
      * See JSDoc for "waitForStatusCommon" for full details on polling and other logic.
@@ -59,14 +59,14 @@ export class MonitorJobs {
      * @returns {Promise<IJob>} - the promise to be fulfilled with IJob object (or rejected with an ImperativeError)
      * @memberof MonitorJobs
      */
-    public static async waitForJobOutputStatus(session: AbstractSession, job: IJob): Promise<IJob> {
+    public static waitForJobOutputStatus(session: AbstractSession, job: IJob): Promise<IJob> {
         ImperativeExpect.toNotBeNullOrUndefined(job, "IJob object (containing jobname and jobid) required");
         return MonitorJobs.waitForStatusCommon(session, {jobname: job.jobname, jobid: job.jobid, status: JOB_STATUS.OUTPUT});
     }
 
     /**
      * Given the jobname/jobid, waits for the status of the job to be "OUTPUT". This API will poll for the OUTPUT status
-     * once every 3 seconds for 100 attempts. If the polling interval/duration is NOT sufficient, use
+     * once every 3 seconds indefinitely. If the polling interval/duration is NOT sufficient, use
      * "waitForStatusCommon" to adjust.
      *
      * See JSDoc for "waitForStatusCommon" for full details on polling and other logic.

--- a/packages/zosjobs/src/api/doc/input/IMonitorJobWaitForParms.ts
+++ b/packages/zosjobs/src/api/doc/input/IMonitorJobWaitForParms.ts
@@ -34,7 +34,7 @@ export interface IMonitorJobWaitForParms {
      */
     jobname: string;
     /**
-     * Watch delay is the polling delay in milliseconds. MonitorJobs will poll ever "watchDelay" milliseconds for the
+     * Watch delay is the polling delay in milliseconds. MonitorJobs will poll every "watchDelay" milliseconds for the
      * status of the job that is being monitored. Use in conjunction with "attempts" to specify your maximum wait
      * for the expected status.
      * Default: MonitorJobs.DEFAULT_WATCHER_DELAY


### PR DESCRIPTION
Fixes #653 by making the `wait-for-output` option check the job status indefinitely. Previously there was a hard-coded timeout of 5 minutes, so the `submit job` command timed out for long-running jobs.