### PR TITLE
Set exit code to 1 when upload command fails

### DIFF
--- a/packages/zosfiles/src/api/methods/upload/Upload.ts
+++ b/packages/zosfiles/src/api/methods/upload/Upload.ts
@@ -210,6 +210,7 @@ export class Upload {
      * @return {Promise<IZosFilesResponse>} A response indicating the out come
      *
      * @throws {ImperativeError} When encounter error scenarios.
+     * @throws {Error} When the {@link ZosmfRestClient} throws an error
      */
     public static async streamToDataSet(session: AbstractSession,
                                         fileStream: Readable,
@@ -218,7 +219,6 @@ export class Upload {
 
         ImperativeExpect.toNotBeNullOrUndefined(dataSetName, ZosFilesMessages.missingDatasetName.message);
 
-        try {
             // Construct zOSMF REST endpoint.
             let endpoint = path.posix.join(ZosFilesConstants.RESOURCE, ZosFilesConstants.RES_DS_FILES);
             if (options.volume) {
@@ -261,9 +261,6 @@ export class Upload {
                 success: true,
                 commandResponse: ZosFilesMessages.dataSetUploadedSuccessfully.message
             };
-        } catch (error) {
-            throw error;
-        }
     }
 
     /**
@@ -277,6 +274,7 @@ export class Upload {
      * @return {Promise<IZosFilesResponse>} A response indicating the out come
      *
      * @throws {ImperativeError} When encounter error scenarios.
+     * @throws {Error} When the {@link ZosmfRestClient} throws an error
      *
      * @example pathToDataSet(session, "file.txt", "ps.name")
      * @example pathToDataset(session, "file.txt", "psd.name(member)")
@@ -367,7 +365,6 @@ export class Upload {
         // result will random errors when trying to upload to multiple member of the same PDS at the same time.
         // This also allow us to break out as soon as the first error is encounter instead of wait until the
         // entire list is processed.
-        try {
             let uploadError;
             let uploadsInitiated = 0;
             for (const file of uploadFileList) {
@@ -439,14 +436,6 @@ export class Upload {
                 commandResponse: ZosFilesMessages.dataSetUploadedSuccessfully.message,
                 apiResponse: results
             };
-
-        } catch (error) {
-            return {
-                success: false,
-                commandResponse: error.message,
-                apiResponse: results
-            };
-        }
     }
 
     /**


### PR DESCRIPTION
This resolves an issue with the command `zowe files upload ftds`, where if the upload fails, the command reports an error, but the exit code is still 0.

This PR is filed against the `next` branch because it contains a breaking change. It removes the `apiResponse` property from the JSON output of the upload API when it fails.

This change to make the upload handler throw is consistent with the behavior of other commands. I tested commands in the categories `files create`, `files delete`, `files download`, `jobs view`, and `tso stop`. They all throw when a REST API error is encountered and do not return an `apiResponse`.