### PR TITLE
Update the Token Support to use the APIML endpoint

### DIFF
--- a/packages/auth/src/api/Login.ts
+++ b/packages/auth/src/api/Login.ts
@@ -9,9 +9,8 @@
 *
 */
 
-import { AbstractSession, ImperativeExpect, Logger, ImperativeError, RestConstants, SessConstants } from "@zowe/imperative";
+import { AbstractSession, ImperativeExpect, Logger, ImperativeError, RestConstants, SessConstants, HTTP_VERB } from "@zowe/imperative";
 import { ZosmfRestClient } from "../../../rest";
-import { LoginConstants } from "./LoginConstants";
 
 /**
  * Class to handle logging onto z/OSMF.
@@ -27,7 +26,7 @@ export class Login {
      * @returns
      * @memberof Login
      */
-    public static async login(session: AbstractSession) {
+    public static async login(session: AbstractSession, request: HTTP_VERB, resource: string) {
         Logger.getAppLogger().trace("Login.login()");
         ImperativeExpect.toNotBeNullOrUndefined(session, "Required session must be defined");
 
@@ -35,8 +34,8 @@ export class Login {
         // get client instance and perform a get on /zosmf/info
         const client = new ZosmfRestClient(session);
         await client.request({
-            request: "GET",
-            resource: LoginConstants.RESOURCE
+            request,
+            resource
         });
 
         // NOTE(Kelosky): since this endpoint doesn't require authentication, we treat a missing LTPA2 token

--- a/packages/auth/src/api/LoginConstants.ts
+++ b/packages/auth/src/api/LoginConstants.ts
@@ -24,6 +24,6 @@ export class LoginConstants {
      * @type {string}
      * @memberof LoginConstants
      */
-    public static readonly RESOURCE: string = "/zosmf/info";
+    public static readonly APIML_V1_RESOURCE: string = "/api/v1/gateway/auth/login";
 
 }

--- a/packages/auth/src/cli/login/apiml/Apiml.definition.ts
+++ b/packages/auth/src/cli/login/apiml/Apiml.definition.ts
@@ -29,6 +29,11 @@ export const ApimlCommand: ICommandDefinition = {
             name: "json-web-token", aliases: ["jwt"],
             description: "Login and obtain JWT token instead of default APIML.",
             type: "boolean"
+        },
+        {
+            name: "show-token", aliases: ["st"],
+            description: "Show the token when login is successful.",
+            type: "boolean"
         }
     ],
     examples: [

--- a/packages/auth/src/cli/login/apiml/Apiml.definition.ts
+++ b/packages/auth/src/cli/login/apiml/Apiml.definition.ts
@@ -27,7 +27,7 @@ export const ApimlCommand: ICommandDefinition = {
         ...ZosmfSession.ZOSMF_CONNECTION_OPTIONS,
         {
             name: "json-web-token", aliases: ["jwt"],
-            description: "Login and obtain JWT token instead of default LTPA2.",
+            description: "Login and obtain JWT token instead of default APIML.",
             type: "boolean"
         }
     ],

--- a/packages/auth/src/cli/login/apiml/Apiml.handler.ts
+++ b/packages/auth/src/cli/login/apiml/Apiml.handler.ts
@@ -58,8 +58,14 @@ export default class ApimlHandler extends ZosmfBaseHandler {
         });
 
         params.response.console.log(
-            "Login successful.\nReceived a token of type = " + this.mSession.ISession.tokenType +
-            ".\nThe following token was stored in your profile:\n" + tokenValue
+            "Login successful.\n"
         );
+
+        if (params.arguments.showToken) {
+            params.response.console.log(
+                "Received a token of type = " + this.mSession.ISession.tokenType +
+                ".\nThe following token was stored in your profile:\n" + tokenValue
+            );
+        }
     }
 }

--- a/packages/auth/src/cli/login/apiml/Apiml.handler.ts
+++ b/packages/auth/src/cli/login/apiml/Apiml.handler.ts
@@ -15,6 +15,7 @@ import {
     SessConstants
 } from "@zowe/imperative";
 import { ZosmfBaseHandler } from "../../../../../zosmf/src/ZosmfBaseHandler";
+import { LoginConstants } from "../../../api/LoginConstants";
 import { Login } from "../../../api/Login";
 
 /**
@@ -40,11 +41,11 @@ export default class ApimlHandler extends ZosmfBaseHandler {
             this.mSession.ISession.tokenType = params.arguments.tokenType;
         } else {
             // use our default token
-            this.mSession.ISession.tokenType = SessConstants.TOKEN_TYPE_LTPA;
+            this.mSession.ISession.tokenType = SessConstants.TOKEN_TYPE_APIML;
         }
 
         // login to obtain a token
-        const tokenValue = await Login.login(this.mSession);
+        const tokenValue = await Login.login(this.mSession, "POST", LoginConstants.APIML_V1_RESOURCE);
 
         // update the profile given
         await Imperative.api.profileManager(`zosmf`).update({


### PR DESCRIPTION
Use the APIML endpoint
Modify the login function to allow for different request types and endpoints
Default the zowe auth login apiml command to use the APIML token
Add a 'show token' option to the zowe auth login apiml command