### PR TITLE
API/CLI Data Set Code Page Support

### DIFF
--- a/packages/rest/src/ZosmfHeaders.ts
+++ b/packages/rest/src/ZosmfHeaders.ts
@@ -38,49 +38,49 @@ export class ZosmfHeaders {
      * @static
      * @memberof ZosmfHeaders
      */
-    public static readonly X_IBM_INTRDR_CLASS_A: IHeaderContent = {"X-IBM-Intrdr-Class": "A"};
+    public static readonly X_IBM_INTRDR_CLASS_A: IHeaderContent = { "X-IBM-Intrdr-Class": "A" };
 
     /**
      * fixed recfm header
      * @static
      * @memberof ZosmfHeaders
      */
-    public static readonly X_IBM_INTRDR_RECFM_F: IHeaderContent = {"X-IBM-Intrdr-Recfm": "F"};
+    public static readonly X_IBM_INTRDR_RECFM_F: IHeaderContent = { "X-IBM-Intrdr-Recfm": "F" };
 
     /**
      * 80 lrecl header
      * @static
      * @memberof ZosmfHeaders
      */
-    public static readonly X_IBM_INTRDR_LRECL_80: IHeaderContent = {"X-IBM-Intrdr-Lrecl": "80"};
+    public static readonly X_IBM_INTRDR_LRECL_80: IHeaderContent = { "X-IBM-Intrdr-Lrecl": "80" };
 
     /**
      * 256 lrecl header
      * @static
      * @memberof ZosmfHeaders
      */
-    public static readonly X_IBM_INTRDR_LRECL_256: IHeaderContent = {"X-IBM-Intrdr-Lrecl": "256"};
+    public static readonly X_IBM_INTRDR_LRECL_256: IHeaderContent = { "X-IBM-Intrdr-Lrecl": "256" };
 
     /**
      * text type header
      * @static
      * @memberof ZosmfHeaders
      */
-    public static readonly X_IBM_INTRDR_MODE_TEXT: IHeaderContent = {"X-IBM-Intrdr-Mode": "TEXT"};
+    public static readonly X_IBM_INTRDR_MODE_TEXT: IHeaderContent = { "X-IBM-Intrdr-Mode": "TEXT" };
 
     /**
      * n/a header
      * @static
      * @memberof ZosmfHeaders
      */
-    public static readonly X_IBM_NOTIFICATION_URL: IHeaderContent = {"X-IBM-Notification-URL": ""};
+    public static readonly X_IBM_NOTIFICATION_URL: IHeaderContent = { "X-IBM-Notification-URL": "" };
 
     /**
      * base header
      * @static
      * @memberof ZosmfHeaders
      */
-    public static readonly X_IBM_ATTRIBUTES_BASE: IHeaderContent = {"X-IBM-Attributes": "base"};
+    public static readonly X_IBM_ATTRIBUTES_BASE: IHeaderContent = { "X-IBM-Attributes": "base" };
 
     /**
      * If you use this header, delete job API will be asynchronous.
@@ -88,56 +88,63 @@ export class ZosmfHeaders {
      * @static
      * @memberof ZosmfHeaders
      */
-    public static readonly X_IBM_JOB_MODIFY_VERSION_1: IHeaderContent = {"X-IBM-Job-Modify-Version": "1.0"};
+    public static readonly X_IBM_JOB_MODIFY_VERSION_1: IHeaderContent = { "X-IBM-Job-Modify-Version": "1.0" };
     /**
      * If you use this header, delete job API will be synchronous.
      * But using it may cause problems for some users depending on their maintenance level and configuration.
      * @static
      * @memberof ZosmfHeaders
      */
-    public static readonly X_IBM_JOB_MODIFY_VERSION_2: IHeaderContent = {"X-IBM-Job-Modify-Version": "2.0"};
+    public static readonly X_IBM_JOB_MODIFY_VERSION_2: IHeaderContent = { "X-IBM-Job-Modify-Version": "2.0" };
 
     /**
      * security header
      * @static
      * @memberof ZosmfHeaders
      */
-    public static readonly X_CSRF_ZOSMF_HEADER: object = {"X-CSRF-ZOSMF-HEADER": true}; // "the value does not matter"
+    public static readonly X_CSRF_ZOSMF_HEADER: object = { "X-CSRF-ZOSMF-HEADER": true }; // "the value does not matter"
 
     /**
      * binary transfer header
      * @static
      * @memberof ZosmfHeaders
      */
-    public static readonly X_IBM_BINARY: IHeaderContent = {"X-IBM-Data-Type": "binary"};
+    public static readonly X_IBM_BINARY: IHeaderContent = { "X-IBM-Data-Type": "binary" };
 
     /**
      * binary by record header
      * @static
      * @memberof ZosmfHeaders
      */
-    public static readonly X_IBM_BINARY_BY_RECORD: IHeaderContent = {"X-IBM-Data-Type": "record"};
+    public static readonly X_IBM_BINARY_BY_RECORD: IHeaderContent = { "X-IBM-Data-Type": "record" };
 
     /**
      * text transfer header
      * @static
      * @memberof ZosmfHeaders
      */
-    public static readonly X_IBM_TEXT: IHeaderContent = {"X-IBM-Data-Type": "text"};
+    public static readonly X_IBM_TEXT: IHeaderContent = { "X-IBM-Data-Type": "text" };
+
+    /**
+     * encoding value for text headers
+     * @static
+     * @memberof ZosmfHeaders
+     */
+    public static readonly X_IBM_TEXT_ENCODING: string = ";fileEncoding=";
 
     /**
      * octet stream header
      * @static
      * @memberof ZosmfHeaders
      */
-    public static readonly OCTET_STREAM: IHeaderContent = {"Content-Type": "application/octet-stream"};
+    public static readonly OCTET_STREAM: IHeaderContent = { "Content-Type": "application/octet-stream" };
 
     /**
      * plain text header
      * @static
      * @memberof ZosmfHeaders
      */
-    public static readonly TEXT_PLAIN: IHeaderContent = {"Content-Type": "text/plain"};
+    public static readonly TEXT_PLAIN: IHeaderContent = { "Content-Type": "text/plain" };
 
     /**
      * This header value specifies the maximum number of items to return.
@@ -146,15 +153,15 @@ export class ZosmfHeaders {
      * @static
      * @memberof ZosmfHeaders
      */
-    public static readonly X_IBM_MAX_ITEMS: IHeaderContent = {"X-IBM-Max-Items": "0"};
+    public static readonly X_IBM_MAX_ITEMS: IHeaderContent = { "X-IBM-Max-Items": "0" };
 
     /**
      * data set migrated recall headers
      * @static
      * @memberof ZosmfHeaders
      */
-    public static readonly X_IBM_MIGRATED_RECALL_WAIT: IHeaderContent = {"X-IBM-Migrated-Recall": "wait"};
-    public static readonly X_IBM_MIGRATED_RECALL_NO_WAIT: IHeaderContent = {"X-IBM-Migrated-Recall": "nowait"};
-    public static readonly X_IBM_MIGRATED_RECALL_ERROR: IHeaderContent = {"X-IBM-Migrated-Recall": "error"};
+    public static readonly X_IBM_MIGRATED_RECALL_WAIT: IHeaderContent = { "X-IBM-Migrated-Recall": "wait" };
+    public static readonly X_IBM_MIGRATED_RECALL_NO_WAIT: IHeaderContent = { "X-IBM-Migrated-Recall": "nowait" };
+    public static readonly X_IBM_MIGRATED_RECALL_ERROR: IHeaderContent = { "X-IBM-Migrated-Recall": "error" };
 
 }

--- a/packages/zosfiles/__tests__/api/methods/download/Download.unit.test.ts
+++ b/packages/zosfiles/__tests__/api/methods/download/Download.unit.test.ts
@@ -434,6 +434,41 @@ describe("z/OS Files - Download", () => {
             });
         });
 
+        it("should download all members specifying directory, volume, extension, and encoding mode", async () => {
+            let response;
+            let caughtError;
+
+            const volume = "testVs";
+            const directory = "my/test/path/";
+            const extension = ".xyz";
+            const encoding = 285;
+
+            try {
+                response = await Download.allMembers(dummySession, dsname, {volume, directory, extension, encoding});
+            } catch (e) {
+                caughtError = e;
+            }
+
+            expect(caughtError).toBeUndefined();
+            expect(response).toEqual({
+                success: true,
+                commandResponse: util.format(ZosFilesMessages.datasetDownloadedSuccessfully.message, directory),
+                apiResponse: listApiResponse
+            });
+
+            expect(listAllMembersSpy).toHaveBeenCalledTimes(1);
+            expect(listAllMembersSpy).toHaveBeenCalledWith(dummySession, dsname, {volume});
+
+            expect(downloadDatasetSpy).toHaveBeenCalledTimes(2);
+            listApiResponse.items.forEach((mem) => {
+                expect(downloadDatasetSpy).toHaveBeenCalledWith(dummySession, `${dsname}(${mem.member})`, {
+                    volume,
+                    file: `${directory}/${mem.member.toLowerCase()}${extension}`,
+                    encoding
+                });
+            });
+        });
+
         it("should download all members with specified \"\" extension", async () => {
             let response;
             let caughtError;

--- a/packages/zosfiles/__tests__/api/methods/download/Download.unit.test.ts
+++ b/packages/zosfiles/__tests__/api/methods/download/Download.unit.test.ts
@@ -225,6 +225,40 @@ describe("z/OS Files - Download", () => {
             expect(ioWriteStreamSpy).toHaveBeenCalledWith(file);
         });
 
+
+        it("should download a data set to the given file in encoding requested mode", async () => {
+            let response;
+            let caughtError;
+            const encoding = 285;
+            const file = "my/test/file.xyz";
+
+            try {
+                response = await Download.dataSet(dummySession, dsname, {encoding, file});
+            } catch (e) {
+                caughtError = e;
+            }
+
+            const endpoint = posix.join(ZosFilesConstants.RESOURCE, ZosFilesConstants.RES_DS_FILES, dsname);
+
+            expect(caughtError).toBeUndefined();
+            expect(response).toEqual({
+                success: true,
+                commandResponse: util.format(ZosFilesMessages.datasetDownloadedSuccessfully.message, file),
+                apiResponse: {}
+            });
+
+            expect(zosmfStreamSpy).toHaveBeenCalledTimes(1);
+            expect(zosmfStreamSpy).toHaveBeenCalledWith(dummySession, endpoint, [{ "X-IBM-Data-Type": "text;fileEncoding=285" }], fakeWriteStream,
+                true, /* normalizing new lines, encoding mode*/
+                undefined /*no progress task*/);
+
+            expect(ioCreateDirSpy).toHaveBeenCalledTimes(1);
+            expect(ioCreateDirSpy).toHaveBeenCalledWith(file);
+
+            expect(ioWriteStreamSpy).toHaveBeenCalledTimes(1);
+            expect(ioWriteStreamSpy).toHaveBeenCalledWith(file);
+        });
+
         it("should handle a z/OS MF error", async () => {
             let response;
             let caughtError;

--- a/packages/zosfiles/__tests__/api/methods/get/Get.unit.test.ts
+++ b/packages/zosfiles/__tests__/api/methods/get/Get.unit.test.ts
@@ -124,6 +124,26 @@ describe("z/OS Files - View", () => {
             expect(zosmfExpectSpy).toHaveBeenCalledWith(dummySession, endpoint, [ZosmfHeaders.X_IBM_BINARY]);
         });
 
+        it("should get data set content with encoding", async () => {
+            let response;
+            let caughtError;
+            const encoding = 285;
+
+            try {
+                response = await Get.dataSet(dummySession, dsname, {encoding});
+            } catch (e) {
+                caughtError = e;
+            }
+
+            const endpoint = posix.join(ZosFilesConstants.RESOURCE, ZosFilesConstants.RES_DS_FILES, dsname);
+
+            expect(caughtError).toBeUndefined();
+            expect(response).toEqual(content);
+
+            expect(zosmfExpectSpy).toHaveBeenCalledTimes(1);
+            expect(zosmfExpectSpy).toHaveBeenCalledWith(dummySession, endpoint, [{ "X-IBM-Data-Type": "text;fileEncoding=285" }]);
+        });
+
         it("should get data set content with volume option", async () => {
             let response;
             let caughtError;

--- a/packages/zosfiles/__tests__/api/methods/upload/Upload.unit.test.ts
+++ b/packages/zosfiles/__tests__/api/methods/upload/Upload.unit.test.ts
@@ -427,6 +427,26 @@ describe("z/OS Files - Upload", () => {
             expect(zosmfExpectSpy).toHaveBeenCalledTimes(1);
             expect(zosmfExpectSpy).toHaveBeenCalledWith(dummySession, endpoint, options, buffer);
         });
+
+        it("should allow uploading a data set with encoding", async () => {
+            const buffer: Buffer = Buffer.from("testing");
+            const endpoint = path.posix.join(ZosFilesConstants.RESOURCE, ZosFilesConstants.RES_DS_FILES, dsName);
+            const options = [{ "X-IBM-Data-Type": "text;fileEncoding=285" }];
+            const uploadOptions: IUploadOptions = {
+                encoding: 285
+            };
+            try {
+                response = await Upload.bufferToDataSet(dummySession, buffer, dsName, uploadOptions);
+            } catch (err) {
+                error = err;
+            }
+
+            expect(error).toBeUndefined();
+            expect(response).toBeDefined();
+
+            expect(zosmfExpectSpy).toHaveBeenCalledTimes(1);
+            expect(zosmfExpectSpy).toHaveBeenCalledWith(dummySession, endpoint, options, buffer);
+        });
     });
 
     describe("pathToDataSet", () => {

--- a/packages/zosfiles/src/api/methods/download/Download.ts
+++ b/packages/zosfiles/src/api/methods/download/Download.ts
@@ -184,7 +184,8 @@ export class Download {
                     volume: options.volume,
                     file: baseDir + IO.FILE_DELIM + mem.member.toLowerCase() +
                         IO.normalizeExtension(extension),
-                    binary: options.binary
+                    binary: options.binary,
+                    encoding: options.encoding
                 });
             };
 

--- a/packages/zosfiles/src/api/methods/download/Download.ts
+++ b/packages/zosfiles/src/api/methods/download/Download.ts
@@ -81,8 +81,15 @@ export class Download {
                 reqHeaders = [ZosmfHeaders.X_IBM_BINARY];
             }
 
-            // Get contents of the data set
+            if (options.encoding) {
+                const keys: string[] = Object.keys(ZosmfHeaders.X_IBM_TEXT);
+                const value = ZosmfHeaders.X_IBM_TEXT[keys[0]] + ZosmfHeaders.X_IBM_TEXT_ENCODING + options.encoding;
+                const header = ZosmfHeaders.X_IBM_TEXT;
+                header[keys[0]] = value;
+                reqHeaders = [header];
+            }
 
+            // Get contents of the data set
             let extension = ZosFilesUtils.DEFAULT_FILE_EXTENSION;
             if (options.extension != null) {
                 extension = options.extension;

--- a/packages/zosfiles/src/api/methods/download/doc/IDownloadOptions.ts
+++ b/packages/zosfiles/src/api/methods/download/doc/IDownloadOptions.ts
@@ -27,6 +27,13 @@ export interface IDownloadOptions {
     binary?: boolean;
 
     /**
+     * Code page encoding
+     * @example 1047
+     * @example 037
+     */
+    encoding?: number;
+
+    /**
      * The local file to download the data set to
      * @example "./path/to/file.txt"
      */
@@ -38,13 +45,6 @@ export interface IDownloadOptions {
      * @example .c
      */
     extension?: string;
-
-    /**
-     * Code page encoding
-     * @example 1047
-     * @example 037
-     */
-    encoding?: number;
 
     /**
      * The local directory to download all members from a pds

--- a/packages/zosfiles/src/api/methods/download/doc/IDownloadOptions.ts
+++ b/packages/zosfiles/src/api/methods/download/doc/IDownloadOptions.ts
@@ -40,6 +40,13 @@ export interface IDownloadOptions {
     extension?: string;
 
     /**
+     * Code page encoding
+     * @example 1047
+     * @example 037
+     */
+    encoding?: number;
+
+    /**
      * The local directory to download all members from a pds
      * @example "./path/to/dir"
      */
@@ -57,7 +64,6 @@ export interface IDownloadOptions {
      * @example cpgm=c,asmpgm=asm
      */
     extensionMap?: { [key: string]: string };
-
 
     /**
      * The maximum REST requests to perform at once

--- a/packages/zosfiles/src/api/methods/get/Get.ts
+++ b/packages/zosfiles/src/api/methods/get/Get.ts
@@ -46,6 +46,14 @@ export class Get {
             reqHeaders = [ZosmfHeaders.X_IBM_BINARY];
         }
 
+        if (options.encoding) {
+            const keys: string[] = Object.keys(ZosmfHeaders.X_IBM_TEXT);
+            const value = ZosmfHeaders.X_IBM_TEXT[keys[0]] + ZosmfHeaders.X_IBM_TEXT_ENCODING + options.encoding;
+            const header = ZosmfHeaders.X_IBM_TEXT;
+            header[keys[0]] = value;
+            reqHeaders = [header];
+        }
+
         if (options.volume) {
             endpoint = posix.join(ZosFilesConstants.RESOURCE, ZosFilesConstants.RES_DS_FILES, `-(${options.volume})`, dataSetName);
         }

--- a/packages/zosfiles/src/api/methods/get/doc/IGetOptions.ts
+++ b/packages/zosfiles/src/api/methods/get/doc/IGetOptions.ts
@@ -30,6 +30,12 @@ export interface IGetOptions {
     volume?: string;
 
     /**
+     * Code page encoding
+     * @type {number}
+     */
+    encoding?: number;
+
+    /**
      * Task status object used by CLI handlers to create progress bars
      * Optional
      * @type {ITaskWithStatus}

--- a/packages/zosfiles/src/api/methods/get/doc/IGetOptions.ts
+++ b/packages/zosfiles/src/api/methods/get/doc/IGetOptions.ts
@@ -24,16 +24,16 @@ export interface IGetOptions {
     binary?: boolean;
 
     /**
-     * The volume on which the data set is stored
-     * @type {string}
-     */
-    volume?: string;
-
-    /**
      * Code page encoding
      * @type {number}
      */
     encoding?: number;
+
+    /**
+     * The volume on which the data set is stored
+     * @type {string}
+     */
+    volume?: string;
 
     /**
      * Task status object used by CLI handlers to create progress bars

--- a/packages/zosfiles/src/api/methods/upload/Upload.ts
+++ b/packages/zosfiles/src/api/methods/upload/Upload.ts
@@ -45,9 +45,9 @@ export class Upload {
      *
      */
     public static async fileToDataset(session: AbstractSession,
-                                      inputFile: string,
-                                      dataSetName: string,
-                                      options: IUploadOptions = {}): Promise<IZosFilesResponse> {
+        inputFile: string,
+        dataSetName: string,
+        options: IUploadOptions = {}): Promise<IZosFilesResponse> {
         this.log.info(`Uploading file ${inputFile} to ${dataSetName}`);
 
         ImperativeExpect.toNotBeNullOrUndefined(inputFile, ZosFilesMessages.missingInputFile.message);
@@ -94,9 +94,9 @@ export class Upload {
      *
      */
     public static async dirToPds(session: AbstractSession,
-                                 inputDir: string,
-                                 dataSetName: string,
-                                 options: IUploadOptions = {}): Promise<IZosFilesResponse> {
+        inputDir: string,
+        dataSetName: string,
+        options: IUploadOptions = {}): Promise<IZosFilesResponse> {
         this.log.info(`Uploading directory ${inputDir} to ${dataSetName}`);
 
         ImperativeExpect.toNotBeNullOrUndefined(inputDir, ZosFilesMessages.missingInputDir.message);
@@ -148,9 +148,9 @@ export class Upload {
      * @throws {ImperativeError} When encounter error scenarios.
      */
     public static async bufferToDataSet(session: AbstractSession,
-                                        fileBuffer: Buffer,
-                                        dataSetName: string,
-                                        options: IUploadOptions = {}): Promise<IZosFilesResponse> {
+        fileBuffer: Buffer,
+        dataSetName: string,
+        options: IUploadOptions = {}): Promise<IZosFilesResponse> {
 
         ImperativeExpect.toNotBeNullOrUndefined(dataSetName, ZosFilesMessages.missingDatasetName.message);
 
@@ -167,7 +167,15 @@ export class Upload {
             if (options.binary) {
                 reqHeader.push(ZosmfHeaders.X_IBM_BINARY);
             } else {
-                reqHeader.push(ZosmfHeaders.X_IBM_TEXT);
+                if (options.encoding) {
+                    const keys: string[] = Object.keys(ZosmfHeaders.X_IBM_TEXT);
+                    const value = ZosmfHeaders.X_IBM_TEXT[keys[0]] + ZosmfHeaders.X_IBM_TEXT_ENCODING + options.encoding;
+                    const header = ZosmfHeaders.X_IBM_TEXT;
+                    header[keys[0]] = value;
+                    reqHeader.push(header);
+                } else {
+                    reqHeader.push(ZosmfHeaders.X_IBM_TEXT);
+                }
                 fileBuffer = ZosFilesUtils.normalizeNewline(fileBuffer);
             }
 
@@ -212,9 +220,9 @@ export class Upload {
      * @throws {ImperativeError} When encounter error scenarios.
      */
     public static async streamToDataSet(session: AbstractSession,
-                                        fileStream: Readable,
-                                        dataSetName: string,
-                                        options: IUploadOptions = {}): Promise<IZosFilesResponse> {
+        fileStream: Readable,
+        dataSetName: string,
+        options: IUploadOptions = {}): Promise<IZosFilesResponse> {
 
         ImperativeExpect.toNotBeNullOrUndefined(dataSetName, ZosFilesMessages.missingDatasetName.message);
 
@@ -231,7 +239,15 @@ export class Upload {
             if (options.binary) {
                 reqHeader.push(ZosmfHeaders.X_IBM_BINARY);
             } else {
-                reqHeader.push(ZosmfHeaders.X_IBM_TEXT);
+                if (options.encoding) {
+                    const keys: string[] = Object.keys(ZosmfHeaders.X_IBM_TEXT);
+                    const value = ZosmfHeaders.X_IBM_TEXT[keys[0]] + ZosmfHeaders.X_IBM_TEXT_ENCODING + options.encoding;
+                    const header = ZosmfHeaders.X_IBM_TEXT;
+                    header[keys[0]] = value;
+                    reqHeader.push(header);
+                } else {
+                    reqHeader.push(ZosmfHeaders.X_IBM_TEXT);
+                }
             }
 
             // Migrated recall options
@@ -289,9 +305,9 @@ export class Upload {
      * upload content to data set.  All you have to specify is a directory and a dsname.
      */
     public static async pathToDataSet(session: AbstractSession,
-                                      inputPath: string,
-                                      dataSetName: string,
-                                      options: IUploadOptions = {}): Promise<IZosFilesResponse> {
+        inputPath: string,
+        dataSetName: string,
+        options: IUploadOptions = {}): Promise<IZosFilesResponse> {
 
         this.log.info(`Uploading path ${inputPath} to ${dataSetName}`);
 
@@ -336,7 +352,7 @@ export class Upload {
 
         // Retrieve the information on the input data set name to determine if it is a
         // sequential data set or PDS.
-        const listResponse = await List.dataSet(session, dataSetName, {attributes: true, maxLength: 1, start: dataSetName, recall: "wait"});
+        const listResponse = await List.dataSet(session, dataSetName, { attributes: true, maxLength: 1, start: dataSetName, recall: "wait" });
         if (listResponse.apiResponse != null && listResponse.apiResponse.returnedRows != null && listResponse.apiResponse.items != null) {
             // Look for the index of the data set in the response from the List API
             const dsnameIndex = listResponse.apiResponse.returnedRows === 0 ? -1 :
@@ -458,10 +474,10 @@ export class Upload {
      * @returns {Promise<object>}
      */
     public static async bufferToUSSFile(session: AbstractSession,
-                                        ussname: string,
-                                        buffer: Buffer,
-                                        binary: boolean = false,
-                                        localEncoding?: string) {
+        ussname: string,
+        buffer: Buffer,
+        binary: boolean = false,
+        localEncoding?: string) {
         ImperativeExpect.toNotBeNullOrUndefined(ussname, ZosFilesMessages.missingUSSFileName.message);
         ussname = ZosFilesUtils.sanitizeUssPathForRestCall(ussname);
         const parameters: string = ZosFilesConstants.RES_USS_FILES + "/" + ussname;
@@ -470,7 +486,7 @@ export class Upload {
             headers.push(ZosmfHeaders.OCTET_STREAM);
             headers.push(ZosmfHeaders.X_IBM_BINARY);
         } else if (localEncoding) {
-            headers.push({"Content-Type": localEncoding});
+            headers.push({ "Content-Type": localEncoding });
             headers.push(ZosmfHeaders.X_IBM_TEXT);
         } else {
             headers.push(ZosmfHeaders.TEXT_PLAIN);
@@ -488,11 +504,11 @@ export class Upload {
      * @returns {Promise<object>}
      */
     public static async streamToUSSFile(session: AbstractSession,
-                                        ussname: string,
-                                        uploadStream: Readable,
-                                        binary: boolean = false,
-                                        localEncoding?: string,
-                                        task?: ITaskWithStatus) {
+        ussname: string,
+        uploadStream: Readable,
+        binary: boolean = false,
+        localEncoding?: string,
+        task?: ITaskWithStatus) {
         ImperativeExpect.toNotBeNullOrUndefined(ussname, ZosFilesMessages.missingUSSFileName.message);
         ussname = path.posix.normalize(ussname);
         ussname = ZosFilesUtils.formatUnixFilepath(ussname);
@@ -503,7 +519,7 @@ export class Upload {
             headers.push(ZosmfHeaders.OCTET_STREAM);
             headers.push(ZosmfHeaders.X_IBM_BINARY);
         } else if (localEncoding) {
-            headers.push({"Content-Type": localEncoding});
+            headers.push({ "Content-Type": localEncoding });
             headers.push(ZosmfHeaders.X_IBM_TEXT);
         } else {
             headers.push(ZosmfHeaders.TEXT_PLAIN);
@@ -515,11 +531,11 @@ export class Upload {
     }
 
     public static async fileToUSSFile(session: AbstractSession,
-                                      inputFile: string,
-                                      ussname: string,
-                                      binary: boolean = false,
-                                      localEncoding?: string,
-                                      task?: ITaskWithStatus): Promise<IZosFilesResponse> {
+        inputFile: string,
+        ussname: string,
+        binary: boolean = false,
+        localEncoding?: string,
+        task?: ITaskWithStatus): Promise<IZosFilesResponse> {
         ImperativeExpect.toNotBeNullOrUndefined(inputFile, ZosFilesMessages.missingInputFile.message);
         ImperativeExpect.toNotBeNullOrUndefined(ussname, ZosFilesMessages.missingUSSFileName.message);
         ImperativeExpect.toNotBeEqual(ussname, "", ZosFilesMessages.missingUSSFileName.message);
@@ -573,9 +589,9 @@ export class Upload {
      * @returns {Promise<IZosFilesResponse>}
      */
     public static async dirToUSSDir(session: AbstractSession,
-                                    inputDirectory: string,
-                                    ussname: string,
-                                    options: IUploadOptions = {}): Promise<IZosFilesResponse> {
+        inputDirectory: string,
+        ussname: string,
+        options: IUploadOptions = {}): Promise<IZosFilesResponse> {
         ImperativeExpect.toNotBeNullOrUndefined(inputDirectory, ZosFilesMessages.missingInputDirectory.message);
         ImperativeExpect.toNotBeEqual(inputDirectory, "", ZosFilesMessages.missingInputDirectory.message);
         ImperativeExpect.toNotBeNullOrUndefined(ussname, ZosFilesMessages.missingUSSDirectoryName.message);
@@ -616,9 +632,9 @@ export class Upload {
                 }
                 // update the array
                 filesArray.push({
-                        binary: tempBinary,
-                        fileName: file
-                    }
+                    binary: tempBinary,
+                    fileName: file
+                }
                 );
             });
 
@@ -633,7 +649,7 @@ export class Upload {
                 }
                 const fileName = path.normalize(path.join(inputDirectory, file.fileName));
                 const ussFilePath = path.posix.join(ussname, file.fileName);
-                return this.uploadFile(fileName,ussFilePath,session,options);
+                return this.uploadFile(fileName, ussFilePath, session, options);
             };
 
             if (maxConcurrentRequests === 0) {
@@ -691,9 +707,9 @@ export class Upload {
      * @return {null}
      */
     public static async dirToUSSDirRecursive(session: AbstractSession,
-                                             inputDirectory: string,
-                                             ussname: string,
-                                             options: IUploadOptions = {}): Promise<IZosFilesResponse> {
+        inputDirectory: string,
+        ussname: string,
+        options: IUploadOptions = {}): Promise<IZosFilesResponse> {
         ImperativeExpect.toNotBeNullOrUndefined(inputDirectory, ZosFilesMessages.missingInputDirectory.message);
         ImperativeExpect.toNotBeEqual(inputDirectory, "", ZosFilesMessages.missingInputDirectory.message);
         ImperativeExpect.toNotBeNullOrUndefined(ussname, ZosFilesMessages.missingUSSDirectoryName.message);
@@ -742,9 +758,9 @@ export class Upload {
             }
             // update the array
             filesArray.push({
-                    binary: tempBinary,
-                    fileName: file
-                }
+                binary: tempBinary,
+                fileName: file
+            }
             );
         });
 
@@ -808,7 +824,7 @@ export class Upload {
     }
 
     private static async uploadFile(localPath: string, ussPath: string,
-                                    session: AbstractSession, options: IUploadOptions) {
+        session: AbstractSession, options: IUploadOptions) {
         let tempBinary;
 
         if (options.attributes) {
@@ -831,9 +847,9 @@ export class Upload {
     }
 
     private static async uploadFileAndTagBasedOnAttributes(localPath: string,
-                                                           ussPath: string,
-                                                           session: AbstractSession,
-                                                           attributes: ZosFilesAttributes) {
+        ussPath: string,
+        session: AbstractSession,
+        attributes: ZosFilesAttributes) {
         if (attributes.fileShouldBeUploaded(localPath)) {
             const binary = attributes.getFileTransferMode(localPath) === TransferMode.BINARY;
             if (binary) {
@@ -843,10 +859,10 @@ export class Upload {
             }
 
             const tag = attributes.getRemoteEncoding(localPath);
-            if (tag === Tag.BINARY.valueOf() ) {
-                await Utilities.chtag(session,ussPath,Tag.BINARY);
+            if (tag === Tag.BINARY.valueOf()) {
+                await Utilities.chtag(session, ussPath, Tag.BINARY);
             } else {
-                await Utilities.chtag(session,ussPath,Tag.TEXT,tag);
+                await Utilities.chtag(session, ussPath, Tag.TEXT, tag);
             }
         }
     }

--- a/packages/zosfiles/src/api/methods/upload/doc/IUploadOptions.ts
+++ b/packages/zosfiles/src/api/methods/upload/doc/IUploadOptions.ts
@@ -29,6 +29,13 @@ export interface IUploadOptions {
     binary?: boolean;
 
     /**
+     * Code page encoding
+     * @example 1047
+     * @example 037
+     */
+    encoding?: number;
+
+    /**
      * The migrated recall option
      * @example "wait, nowait, error"
      */

--- a/packages/zosfiles/src/cli/-strings-/en.ts
+++ b/packages/zosfiles/src/cli/-strings-/en.ts
@@ -297,6 +297,8 @@ export default {
                 "only when the data set is not cataloged on the system. A VOLSER is analogous to a drive name on a PC.",
             BINARY: "Download the file content in binary mode, which means that no data conversion is performed. The data transfer process " +
                 "returns each line as-is, without translation. No delimiters are added between records.",
+            ENCODING: "Download the file content with encoding mode, which means that data conversion is performed using the file encoding " + 
+                "specified.",
             FILE: "The path to the local file where you want to download the content. When you omit the option, the command generates a file " +
                 "name automatically for you.",
             EXTENSION: "Save the local files with a specified file extension. For example, .txt. Or \"\" for no extension.  When no extension " +
@@ -553,6 +555,7 @@ export default {
                 "only when the data set is not cataloged on the system. A VOLSER is analogous to a drive name on a PC.",
             BINARY: "Data content in binary mode, which means that no data conversion is performed. The data transfer process " +
                 "returns each record as-is, without translation. No delimiters are added between records.",
+            ENCODING: "Data content in encoding mode, which means that data conversion is performed according to the encoding specified.",
             RECALL: "The method by which migrated data set is handled. By default, a migrated data set is recalled synchronously. You can " +
                 "specify the following values: wait, nowait, error",
             RECURSIVE: "Upload all directories recursively.",

--- a/packages/zosfiles/src/cli/download/Download.options.ts
+++ b/packages/zosfiles/src/cli/download/Download.options.ts
@@ -45,6 +45,17 @@ export const DownloadOptions: { [key: string]: ICommandOptionDefinition } = {
     },
 
     /**
+     * The encoding option
+     * @type {ICommandOptionDefinition}
+     */
+    encoding: {
+        name: "encoding",
+        aliases: ["ec"],
+        description: strings.ENCODING,
+        type: "number"
+    },
+
+    /**
      * The local file to download the data set to
      * @type {ICommandOptionDefinition}
      */

--- a/packages/zosfiles/src/cli/download/am/AllMembers.definition.ts
+++ b/packages/zosfiles/src/cli/download/am/AllMembers.definition.ts
@@ -44,6 +44,7 @@ export const AllMembersDefinition: ICommandDefinition = {
         DownloadOptions.volume,
         DownloadOptions.directory,
         DownloadOptions.binary,
+        DownloadOptions.encoding,
         DownloadOptions.extension,
         DownloadOptions.maxConcurrentRequests
     ].sort((a, b) => a.name.localeCompare(b.name)),

--- a/packages/zosfiles/src/cli/download/am/AllMembers.handler.ts
+++ b/packages/zosfiles/src/cli/download/am/AllMembers.handler.ts
@@ -29,6 +29,7 @@ export default class AllMembersHandler extends ZosFilesBaseHandler {
         return Download.allMembers(session, commandParameters.arguments.dataSetName, {
             volume: commandParameters.arguments.volumeSerial,
             binary: commandParameters.arguments.binary,
+            encoding: commandParameters.arguments.encoding,
             directory: commandParameters.arguments.directory,
             extension: commandParameters.arguments.extension,
             maxConcurrentRequests: commandParameters.arguments.maxConcurrentRequests,

--- a/packages/zosfiles/src/cli/download/ds/Dataset.definition.ts
+++ b/packages/zosfiles/src/cli/download/ds/Dataset.definition.ts
@@ -44,7 +44,8 @@ export const DatasetDefinition: ICommandDefinition = {
         DownloadOptions.volume,
         DownloadOptions.file,
         DownloadOptions.extension,
-        DownloadOptions.binary
+        DownloadOptions.binary,
+        DownloadOptions.encoding,
     ].sort((a, b) => a.name.localeCompare(b.name)),
     examples: [
         {

--- a/packages/zosfiles/src/cli/download/ds/Dataset.handler.ts
+++ b/packages/zosfiles/src/cli/download/ds/Dataset.handler.ts
@@ -29,6 +29,7 @@ export default class DatasetHandler extends ZosFilesBaseHandler {
         return Download.dataSet(session, commandParameters.arguments.dataSetName, {
                 volume: commandParameters.arguments.volumeSerial,
                 binary: commandParameters.arguments.binary,
+                encoding: commandParameters.arguments.encoding,
                 file: commandParameters.arguments.file,
                 extension: commandParameters.arguments.extension,
                 task

--- a/packages/zosfiles/src/cli/upload/Upload.options.ts
+++ b/packages/zosfiles/src/cli/upload/Upload.options.ts
@@ -45,6 +45,17 @@ export const UploadOptions: {[key: string]: ICommandOptionDefinition} = {
     },
 
     /**
+     * The encoding option
+     * @type {ICommandOptionDefinition}
+     */
+    encoding: {
+        name: "encoding",
+        aliases: ["ec"],
+        description: strings.ENCODING,
+        type: "number"
+    },
+
+    /**
      * The migrated recall option
      * @type {ICommandOptionDefinition}
      */

--- a/packages/zosfiles/src/cli/upload/ftds/FileToDataSet.definition.ts
+++ b/packages/zosfiles/src/cli/upload/ftds/FileToDataSet.definition.ts
@@ -49,7 +49,8 @@ export const FileToDataSetDefinition: ICommandDefinition = {
     options: [
         UploadOptions.volume,
         UploadOptions.binary,
-        UploadOptions.recall
+        UploadOptions.recall,
+        UploadOptions.encoding,
     ].sort((a, b) => a.name.localeCompare(b.name)),
     examples: [
         {

--- a/packages/zosfiles/src/cli/upload/ftds/FileToDataSet.handler.ts
+++ b/packages/zosfiles/src/cli/upload/ftds/FileToDataSet.handler.ts
@@ -34,7 +34,8 @@ export default class FileToDataSetHandler extends ZosFilesBaseHandler {
             {
                 volume: commandParameters.arguments.volumeSerial,
                 binary: commandParameters.arguments.binary,
-                task
+                encoding: commandParameters.arguments.encoding,
+                task,
             });
 
         if (response.apiResponse) {


### PR DESCRIPTION
This PR adds code page support to data set `Download`, `Upload`, and `Get` API methods and download / upload commands to address #632 :

```
$ zowe files download ds "ibmuser.work.jcl(asmtest1)" --encoding=285
Data set downloaded successfully.
Destination: ibmuser/work/jcl/asmtest1.txt

```
And:
```
import { ISession, Session, Logger, LoggingConfigurer } from "@zowe/imperative";
import { Get, Download } from "./zosfiles";

Logger.initLogger(LoggingConfigurer.configureLogger('lib', {name: 'test'}));

const conn: ISession = {
    hostname: "usilca11.lvn.broadcom.net",
    port: 1443,
    rejectUnauthorized: false,
    user: "ibmuser",
    password: "password",
    type: "basic",
};
const session = new Session(conn);

(async () => {
    const resp = (await Get.dataSet(session, "IBMUSER.WORK.JCL(ASMTEST1)", {
        encoding: 285
    })).toString();
    console.log(resp);

    await Download.dataSet(session, "IBMUSER.WORK.JCL(ASMTEST1)", {encoding: 285});

    await Download.allMembers(session, "IBMUSER.PUBLIC.REGSERV.LNKINC", {encoding: 285});
    
})();
```