### PR TITLE
Add Encoding Setting to z/OSMF Profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Zowe CLI package will be documented in this file.
 
+## Recent Changes
+
+- Add `encoding` option to `zosmf` profile type.
+
 ## `6.14.0`
 
 - Add encoding / code page support for data set upload and download operations in library and CLI.

--- a/packages/imperative.ts
+++ b/packages/imperative.ts
@@ -71,6 +71,16 @@ const config: IImperativeConfig = {
                     basePath: {
                         type: "string",
                         optionDefinition: ZosmfSession.ZOSMF_OPTION_BASE_PATH
+                    },
+                    encoding: {
+                        type: "number",
+                        optionDefinition: {
+                            name: "encoding",
+                            aliases: ["ec"],
+                            description: "The encoding for download and upload of z/OS data set and USS files." +
+                                " The default encoding if not specified is 1047.",
+                            type: "number"
+                        }
                     }
                 },
                 required: []
@@ -93,7 +103,7 @@ const config: IImperativeConfig = {
                 {
                     options: "zos126 --reject-unauthorized false",
                     description: "Create a zosmf profile called 'zos126' to connect to z/OSMF on the default port 443 and allow self-signed certificates, " +
-                    "not specifying a username, password, or host so they are not stored on disk; these will need to be specified on every command"
+                        "not specifying a username, password, or host so they are not stored on disk; these will need to be specified on every command"
                 },
                 {
                     options: "zosAPIML --host zosAPIML --port 2020 --user ibmuser --password myp4ss --reject-unauthorized false --base-path basePath",
@@ -220,13 +230,13 @@ const config: IImperativeConfig = {
                 {
                     options: "ssh333 --host sshhost --user ibmuser --privateKey /path/to/privatekey --keyPassphrase privateKeyPassphrase",
                     description: "Create a ssh profile called 'ssh333' to connect to z/OS SSH server at host 'zos123' " +
-                                 "using a privatekey '/path/to/privatekey' and its decryption passphrase 'privateKeyPassphrase' " +
-                                 "for privatekey authentication"
+                        "using a privatekey '/path/to/privatekey' and its decryption passphrase 'privateKeyPassphrase' " +
+                        "for privatekey authentication"
                 },
                 {
                     options: "ssh444 --privateKey /path/to/privatekey",
                     description: "Create a ssh profile called 'ssh444' to connect to z/OS SSH server on default port 22, without specifying " +
-                    "username, host, or password, preventing those values from being stored on disk"
+                        "username, host, or password, preventing those values from being stored on disk"
                 }
             ]
         }


### PR DESCRIPTION
Encoding will be an option when creating the profile:
![image](https://user-images.githubusercontent.com/14940561/83557478-bcc65c00-a4df-11ea-85d1-3498c4b755cb.png)


