### PR TITLE
Remove build hacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to the Zowe CLI package will be documented in this file.
 
 ## Recent Changes
 
+- Remove temporary build modifications that were used to enable zowe-cli to build with an unpublished imperative.
 - Upgrade Zowe commands to prompt for missing user and password.
 - Add ability to log into and out of the APIML, getting and using a token
 - Add `--base-profile` option to all commands that use profiles, allowing them to make use of base profiles containing shared values.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@ All notable changes to the Zowe CLI package will be documented in this file.
 
 ## Recent Changes
 
-- Remove temporary build modifications that were used to enable zowe-cli to build with an unpublished imperative.
 - Upgrade Zowe commands to prompt for missing user and password.
 - Add ability to log into and out of the APIML, getting and using a token
 - Add `--base-profile` option to all commands that use profiles, allowing them to make use of base profiles containing shared values.

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -61,12 +61,18 @@ node('ca-jenkins-agent') {
     ]
 
     // Initialize the pipeline library, should create 5 steps.
-    // We need lots of time to install imperative, since imperative
-    // is also built when installing from a Git Repo.
-    pipeline.setup(installDependencies: [
-        time: 15,
-        unit: 'MINUTES'
-    ])
+    pipeline.setup()
+    
+    // When we need to build the CLI with imperative from Github repo source,
+    // we need lots of time to install imperative, since imperative
+    // is also built from source during the NPM install.
+    // When building from GitHub source, commment out the setup
+    // command above, and uncomment the setup command below:
+    //
+    // pipeline.setup(installDependencies: [
+    //     time: 15,
+    //     unit: 'MINUTES'
+    // ])
 
     // Create a custom lint stage that runs immediately after the setup.
     pipeline.createStage(

--- a/package.json
+++ b/package.json
@@ -64,10 +64,8 @@
     "typedocSpecifySrc": "typedoc --options ./typedoc.json",
     "audit:public": "npm audit --registry https://registry.npmjs.org/"
   },
-  "delete_before_npm_publish": "Delete the dependency of imperative from GitHub. Restore the standard version number dependency.",
-  "restore_before_npm_publish_@zowe/imperative": "4.7.0",
   "dependencies": {
-    "@zowe/imperative": "git+https://github.com/zowe/imperative.git#tokens",
+    "@zowe/imperative": "4.7.0",
     "@zowe/perf-timing": "1.0.7",
     "get-stdin": "7.0.0",
     "js-yaml": "3.13.1",


### PR DESCRIPTION
Remove temporary build modifications that were used to enable zowe-cli to build with an unpublished imperative.

This token-enabled version of Zowe-CLI will not be able to build until:
- Imperative PR 411 is merged into the "tokens" branch
- The "tokens" imperative branch is merged into the imperative "master" branch
- And imperative is published to NPM.