### PR TITLE
Update Imperative dependency to 4.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Zowe CLI package will be documented in this file.
 
+## Recent Changes
+
+- Update Imperative version to fix issue "Can't use service profile after storing token in base profile"
+
 ## `6.16.0`
 
 - Upgrade Zowe commands to prompt for any of the following values if the option is missing: host, port, user, and password.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@zowe/cli",
-  "version": "6.15.0",
+  "version": "6.16.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -730,9 +730,9 @@
       }
     },
     "@zowe/imperative": {
-      "version": "4.7.0",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@zowe/imperative/-/@zowe/imperative-4.7.0.tgz",
-      "integrity": "sha1-Zizu85RNzP3GUg2FXE3nt+ZnHPc=",
+      "version": "4.7.1",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@zowe/imperative/-/@zowe/imperative-4.7.1.tgz",
+      "integrity": "sha1-+ZW+Uwvn7nThIj1VeF5ShN1MX5s=",
       "requires": {
         "@types/lodash-deep": "2.0.0",
         "@types/yargs": "13.0.4",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "audit:public": "npm audit --registry https://registry.npmjs.org/"
   },
   "dependencies": {
-    "@zowe/imperative": "4.7.0",
+    "@zowe/imperative": "4.7.1",
     "@zowe/perf-timing": "1.0.7",
     "get-stdin": "7.0.0",
     "js-yaml": "3.13.1",


### PR DESCRIPTION
This addresses https://github.com/zowe/imperative/issues/413 which was resolved in Imperative in https://github.com/zowe/imperative/pull/414.