### PR TITLE
Describe Node APIs in Readme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the Zowe CLI package will be documented in this file.
 
+```
+## Recent Changes
+
+- Added documentation about leveraging the Zowe Node APIs to the Readme.
+```
+
 ## `6.18.0`
 
 - Add the --fail-fast option to the `zowe zos-files download all-members` command

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 [![codecov](https://codecov.io/gh/zowe/zowe-cli/branch/master/graph/badge.svg)](https://codecov.io/gh/zowe/zowe-cli)
 
-Zowe CLI is a command-line interface that lets you interact with the mainframe in a familiar format. Zowe CLI helps to increase overall productivity, reduce the learning curve for developing mainframe applications, and exploit the ease-of-use of off-platform tools. Zowe CLI lets application developers use common tools such as Integrated Development Environments (IDEs), shell commands, bash scripts, and build tools for mainframe development. Through its ecosystem of plug-ins, you can automate actions on systems such as IBM Db2, IBM CICS, and more. It provides a set of utilities and services that help developers, DevOps engineers, and more become efficient in supporting and building z/OS applications quickly.
+Zowe CLI is a command-line interface that lets you interact with the mainframe in a familiar format. Zowe CLI helps to increase overall productivity, reduce the learning curve for developing mainframe applications, and exploit the ease-of-use of off-platform tools. Zowe CLI lets you use common tools such as Integrated Development Environments (IDEs), shell commands, bash scripts, and build tools for mainframe development. Through its ecosystem of plug-ins, you can automate actions on systems such as IBM Db2, IBM CICS, and more. It provides a set of utilities and services that help developers, DevOps engineers, and more become efficient in supporting and building z/OS applications quickly.
 
-You can also leverage the underlying APIs in this repository to build applications that interface with the mainframe. For more information, see [Leveraging the Zowe Node APIs](#leveraging-the-zowe-node-apis).
+You can also leverage the underlying Zowe Node APIs in this repository to build applications that interface with the mainframe. For more information, see [Leveraging the Zowe Node APIs](#leveraging-the-zowe-node-apis).
 
 ## Contents  <!-- omit in toc -->
 
@@ -14,7 +14,7 @@ You can also leverage the underlying APIs in this repository to build a
  - [Install Zowe CLI from source](#install-zowe-cli-from-source)
  - [Uninstall Zowe CLI](#uninstall-zowe-cli)
  - [Configure Zowe CLI](#configure-zowe-cli)
- - [Leveraging the Zowe Node APIs](#leveraging-the-zowe-node-apis)
+ - [Using the Zowe Node APIs](#leveraging-the-zowe-node-apis)
  - [Run system tests](#run-system-tests)
  - [FAQs](#frequently-asked-questions)
 
@@ -97,31 +97,32 @@ zowe zosmf check status
 
 **Tip:** When you confirm that your profile connects to and communicates with your mainframe system successfully, you can issue the same command at any time to verify the availability and status of the z/OSMF subsystem on your mainframe.
 
-## Leveraging the Zowe Node APIs
+For detailed information about creating service profiles, creating base profiles, or integrating with Zowe API ML, see [Using Zowe CLI](https://docs.zowe.org/stable/user-guide/cli-usingcli.html).
 
-The Zowe Node APIs are programmatic APIs that enable Zowe CLI to interface with the mainframe. Use the APIs to build your own applications (or automation) independent of Zowe CLI.
+## Using the Zowe Node APIs
+
+The Zowe Node APIs are programamatic APIs that enable Zowe CLI to interface with the mainframe. You can use the APIs to build your own applications or automation scripts independent of Zowe CLI.
 
 ### Accessing the APIs
 
-Import Zowe CLI into your project and call the individual APIs to perform actions on the mainframe.
+The Zowe Node APIs are maintained in this repository. Each set of functionality, such as z/OS Jobs, is stored in a folder that contains the API and CLI code.
 
-The APIs are maintained in this repository. Each set of functionality, such as `zos-jobs` or `zos-files`, is organized in a separate folder that contains the API and CLI code.
-
-Each API has a Readme file that provides API usage examples:
+To perform actions on the mainframe, import Zowe CLI into your project and call the individual APIs. We provide usage examples for each API in the package Readme files:
 
 ```
 zowe-cli/packages/<package-name>/README.md
 ```
 
-Refer to the following examples to learn about calling and using each API:
-- [Provisioning](): test blah blah
-- [z/OS Console](): test blah blah
-- [z/OS Files](): test blah blah
-- [z/OS Jobs](): test blah blah
-- [z/OSMF](): test blah blah
-- [z/OS TSO](): test blah blah
-- [z/OS USS](): test blah blah
-- [z/OS Workflows](): test blah blah
+Refer to each package Readme for more information:
+
+- [Provisioning](): Provision middleware and resources such as IBM CICS, IBM Db2, IBM MQ, and more.
+- [z/OS Console](): Perform z/OS console operations.
+- [z/OS Data Sets and Files](): Work with data sets on z/OS.
+- [z/OS Jobs](): Work with batch jobs on z/OS.
+- [z/OSMF](): Return data about z/OSMF, such as connection status or a list of available systems.
+- [z/OS TSO](): Interact with TSO/E adress spaces on z/OS.
+- [z/OS USS](): Work with UNIX system services (USS) files on z/OS.
+- [z/OS Workflows](): Create and manage z/OSMF workflows on z/OS.
 
 ## Run system tests
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Zowe CLI is a command-line interface that lets you interact with the mainframe in a familiar format. Zowe CLI helps to increase overall productivity, reduce the learning curve for developing mainframe applications, and exploit the ease-of-use of off-platform tools. Zowe CLI lets application developers use common tools such as Integrated Development Environments (IDEs), shell commands, bash scripts, and build tools for mainframe development. Through its ecosystem of plug-ins, you can automate actions on systems such as IBM Db2, IBM CICS, and more. It provides a set of utilities and services that help developers, DevOps engineers, and more become efficient in supporting and building z/OS applications quickly.
 
-You can also leverage the underlying APIs to build applications that interface with the mainframe. For more information, see [Leveraging the Zowe Node APIs](#leveraging-the-zowe-node-apis).
+You can also leverage the underlying APIs in this repository to build applications that interface with the mainframe. For more information, see [Leveraging the Zowe Node APIs](#leveraging-the-zowe-node-apis).
 
 ## Contents  <!-- omit in toc -->
 

--- a/README.md
+++ b/README.md
@@ -115,14 +115,14 @@ zowe-cli/packages/<package-name>/README.md
 
 Refer to each package Readme for more information:
 
-- [Provisioning](): Provision middleware and resources such as IBM CICS, IBM Db2, IBM MQ, and more.
-- [z/OS Console](): Perform z/OS console operations.
-- [z/OS Data Sets and Files](): Work with data sets on z/OS.
-- [z/OS Jobs](): Work with batch jobs on z/OS.
-- [z/OSMF](): Return data about z/OSMF, such as connection status or a list of available systems.
-- [z/OS TSO](): Interact with TSO/E adress spaces on z/OS.
-- [z/OS USS](): Work with UNIX system services (USS) files on z/OS.
-- [z/OS Workflows](): Create and manage z/OSMF workflows on z/OS.
+- [Provisioning](https://github.com/zowe/zowe-cli/tree/master/packages/provisioning): Provision middleware and resources such as IBM CICS, IBM Db2, IBM MQ, and more.
+- [z/OS Console](https://github.com/zowe/zowe-cli/tree/master/packages/zosconsole): Perform z/OS console operations.
+- [z/OS Data Sets](https://github.com/zowe/zowe-cli/tree/master/packages/zosfiles): Work with data sets on z/OS.
+- [z/OS Jobs](https://github.com/zowe/zowe-cli/tree/master/packages/zosjobs): Work with batch jobs on z/OS.
+- [z/OSMF](https://github.com/zowe/zowe-cli/tree/master/packages/zosmf): Return data about z/OSMF, such as connection status or a list of available systems.
+- [z/OS TSO](https://github.com/zowe/zowe-cli/tree/master/packages/zostso): Interact with TSO/E adress spaces on z/OS.
+- [z/OS USS](https://github.com/zowe/zowe-cli/tree/master/packages/zosuss): Work with UNIX system services (USS) files on z/OS.
+- [z/OS Workflows](https://github.com/zowe/zowe-cli/tree/master/packages/workflows): Create and manage z/OSMF workflows on z/OS.
 
 ## Run system tests
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Zowe CLI is a command-line interface that lets you interact with the mainframe in a familiar format. Zowe CLI helps to increase overall productivity, reduce the learning curve for developing mainframe applications, and exploit the ease-of-use of off-platform tools. Zowe CLI lets you use common tools such as Integrated Development Environments (IDEs), shell commands, bash scripts, and build tools for mainframe development. Through its ecosystem of plug-ins, you can automate actions on systems such as IBM Db2, IBM CICS, and more. It provides a set of utilities and services that help developers, DevOps engineers, and more become efficient in supporting and building z/OS applications quickly.
 
-You can also leverage the underlying Zowe Node APIs in this repository to build applications that interface with the mainframe. For more information, see [Leveraging the Zowe Node APIs](#leveraging-the-zowe-node-apis).
+You can also leverage the underlying Zowe Node APIs in this repository to build applications that interface with the mainframe. For more information, see [Using the Zowe Node APIs](#using-the-zowe-node-apis).
 
 ## Contents  <!-- omit in toc -->
 
@@ -14,7 +14,7 @@ You can also leverage the underlying Zowe Node APIs in this repository to
  - [Install Zowe CLI from source](#install-zowe-cli-from-source)
  - [Uninstall Zowe CLI](#uninstall-zowe-cli)
  - [Configure Zowe CLI](#configure-zowe-cli)
- - [Using the Zowe Node APIs](#leveraging-the-zowe-node-apis)
+ - [Using the Zowe Node APIs](#using-the-zowe-node-apis)
  - [Run system tests](#run-system-tests)
  - [FAQs](#frequently-asked-questions)
 
@@ -107,13 +107,13 @@ The Zowe Node APIs are programamatic APIs that enable Zowe CLI to interface with
 
 The Zowe Node APIs are maintained in this repository. Each set of functionality, such as z/OS Jobs, is stored in a folder that contains the API and CLI code.
 
-To perform actions on the mainframe, import Zowe CLI into your project and call the individual APIs. We provide usage examples for each API in the package Readme files:
+To get started, import Zowe CLI into your project and call the individual APIs. We provide a Readme with usage examples for each API package:
 
 ```
 zowe-cli/packages/<package-name>/README.md
 ```
 
-Refer to each package Readme for more information:
+Refer to each Readme for more information:
 
 - [Provisioning](https://github.com/zowe/zowe-cli/tree/master/packages/provisioning): Provision middleware and resources such as IBM CICS, IBM Db2, IBM MQ, and more.
 - [z/OS Console](https://github.com/zowe/zowe-cli/tree/master/packages/zosconsole): Perform z/OS console operations.

--- a/README.md
+++ b/README.md
@@ -9,23 +9,24 @@ You can also leverage the underlying APIs in this repository to build a
 ## Contents  <!-- omit in toc -->
 
  - [Documentation](#documentation)
- - [Contribution Guidelines](#contribution-guidelines)
- - [Build Zowe CLI from Source](#build-zowe-cli-from-source)
- - [Install Zowe CLI from Source](#install-zowe-cli-from-source)
+ - [Contribution guidelines](#contribution-guidelines)
+ - [Build Zowe CLI from source](#build-zowe-cli-from-source)
+ - [Install Zowe CLI from source](#install-zowe-cli-from-source)
  - [Uninstall Zowe CLI](#uninstall-zowe-cli)
  - [Configure Zowe CLI](#configure-zowe-cli)
- - [Run System Tests](#run-system-tests)
+ - [Leveraging the Zowe Node APIs](#leveraging-the-zowe-node-apis)
+ - [Run system tests](#run-system-tests)
  - [FAQs](#frequently-asked-questions)
 
 ## Documentation
 
-For more information about how to install, configure, and use Zowe CLI, see [Zowe CLI Documentation](https://docs.zowe.org/stable/). The documentation also includes examples and tutorials for how to contribute to Zowe CLI and develop CLI plug-ins.
+For detailed information about how to install, configure, and use Zowe CLI, see [Zowe CLI Documentation](https://docs.zowe.org/stable/). The documentation includes examples and tutorials for how to contribute to Zowe CLI and develop CLI plug-ins.
 
 The `docs` directory in this repository contains auto-generated typescript documentation under the `docs/typedoc` directory. To access the typescript documentation locally, navigate to the local `node_modules` directory that contains the installed package and access the `docs` directory after you install the Zowe CLI package.
 
 **Note:** Some links in the auto-generated typescript documentation are not functional at this time.
 
-## Contribution Guidelines
+## Contribution guidelines
 
 The following information is critical to working with the code, running/writing/maintaining automated tests, developing consistent syntax in your plug-in, and ensuring that your plug-in integrates with Zowe CLI properly:
 
@@ -43,7 +44,7 @@ Versioning conventions for Zowe CLI and Plug-ins| [Versioning Guidelines](./docs
 
 **Tip:** Visit our [Sample Plug-in repository](https://github.com/zowe/zowe-cli-sample-plugin) for example plug-in code. You can follow developer tutorials [here](https://docs.zowe.org/stable/extend/extend-cli/cli-devTutorials.html).
 
-## Build Zowe CLI from Source
+## Build Zowe CLI from source
 The first time that you download Zowe CLI from the GitHub repository, issue the following command to install the required Zowe CLI dependencies and several development tools:
 
 ```
@@ -60,7 +61,7 @@ npm run build
 
 When you update `package.json` to include new dependencies, or when you pull changes that affect `package.json`, issue the `npm update` command to download the dependencies.
 
-## Install Zowe CLI from Source
+## Install Zowe CLI from source
 From your copy of this repository, after a build, issue the following command to install Zowe CLI from source:
 
 ```
@@ -96,14 +97,33 @@ zowe zosmf check status
 
 **Tip:** When you confirm that your profile connects to and communicates with your mainframe system successfully, you can issue the same command at any time to verify the availability and status of the z/OSMF subsystem on your mainframe.
 
-## Leveraging the Zowe Node APIs
+## Leveraging the Zowe Node APIs
 
-outline:
-- overview/business value
-- structure of the repo
-- list of links to each API and use case described
+The Zowe Node APIs are programmatic APIs that enable Zowe CLI to interface with the mainframe. Use the APIs to build your own applications (or automation) independent of Zowe CLI.
 
-## Run System Tests
+### Accessing the APIs
+
+Import Zowe CLI into your project and call the individual APIs to perform actions on the mainframe.
+
+The APIs are maintained in this repository. Each set of functionality, such as `zos-jobs` or `zos-files`, is organized in a separate folder that contains the API and CLI code.
+
+Each API has a Readme file that provides API usage examples:
+
+```
+zowe-cli/packages/<package-name>/README.md
+```
+
+Refer to the following examples to learn about calling and using each API:
+- [Provisioning](): test blah blah
+- [z/OS Console](): test blah blah
+- [z/OS Files](): test blah blah
+- [z/OS Jobs](): test blah blah
+- [z/OSMF](): test blah blah
+- [z/OS TSO](): test blah blah
+- [z/OS USS](): test blah blah
+- [z/OS Workflows](): test blah blah
+
+## Run system tests
 
 In addition to Node.js, you must have a means to execute `.sh` (bash) scripts, which are required for running integration tests. On Windows, you can install "Git Bash" (bundled with the standard [Git](https://git-scm.com/downloads) installation - check "Use Git and Unix Tools from Windows Command Prompt" installation option).
 
@@ -125,7 +145,7 @@ npm run test:system
 
 If the `custom_properties.yaml` file cannot be found or loaded, an error with relevant details is thrown.
 
-## Frequently Asked Questions
+## Frequently asked questions
 
 - **How can I install Zowe CLI as a root user on Mac/Linux?**
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 [![codecov](https://codecov.io/gh/zowe/zowe-cli/branch/master/graph/badge.svg)](https://codecov.io/gh/zowe/zowe-cli)
 
-Zowe CLI is a command-line interface that lets application developers interact with the mainframe in a familiar format. Zowe CLI helps to increase overall productivity, reduce the learning curve for developing mainframe applications, and exploit the ease-of-use of off-platform tools. Zowe CLI lets application developers use common tools such as Integrated Development Environments (IDEs), shell commands, bash scripts, and build tools for mainframe development. It provides a set of utilities and services for application developers that want to become efficient in supporting and building z/OS applications quickly.
+Zowe CLI is a command-line interface that lets you interact with the mainframe in a familiar format. Zowe CLI helps to increase overall productivity, reduce the learning curve for developing mainframe applications, and exploit the ease-of-use of off-platform tools. Zowe CLI lets application developers use common tools such as Integrated Development Environments (IDEs), shell commands, bash scripts, and build tools for mainframe development. Through its ecosystem of plug-ins, you can automate actions on systems such as IBM Db2, IBM CICS, and more. It provides a set of utilities and services that help developers, DevOps engineers, and more become efficient in supporting and building z/OS applications quickly.
+
+You can also leverage the underlying APIs to build applications that interface with the mainframe. For more information, see [Leveraging the Zowe Node APIs](#leveraging-the-zowe-node-apis).
 
 ## Contents  <!-- omit in toc -->
 
@@ -93,6 +95,13 @@ zowe zosmf check status
 ```
 
 **Tip:** When you confirm that your profile connects to and communicates with your mainframe system successfully, you can issue the same command at any time to verify the availability and status of the z/OSMF subsystem on your mainframe.
+
+## Leveraging the Zowe Node APIs
+
+outline:
+- overview/business value
+- structure of the repo
+- list of links to each API and use case described
 
 ## Run System Tests
 


### PR DESCRIPTION
Addresses #751 when combined with the `add-api-example` branch. 

**Question:* Do we need instruction about how to import the CLI in the main readme? Or is that covered in every package readme? Anything else I didn't consider?

**Added:** 
- Small blurb at beginning of readme. 
- Section about what the APIs are for and accessing the APIs.
- List of links to readme examples. 

**Misc:** 
- Linked to more complete info about profiles in Create a Profile section.
- Random minor grammar changes. 