### PR TITLE
Fix compilation error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Zowe CLI package will be documented in this file.
 
+## Recent Changes
+
+- Fix compilation error
+
 ## `6.19.0`
 
 - Add CLI command to delete migrated data sets `zowe zos-files delete migrated-data-sets`.

--- a/packages/provisioning/__tests__/api/ProvisionService.unit.test.ts
+++ b/packages/provisioning/__tests__/api/ProvisionService.unit.test.ts
@@ -19,7 +19,9 @@ const tenantName: string = "tenant_name1";
 const inputProperties: string = "name=CSQ_MQ,value=ABCD";
 const badInputFormat: string = "name:CSQ_MQ. value: ABCD";
 const testFileName: string = "provisioning_prompt_variables.yml";
+const emptyTestFileName: string = "empty.yml";
 const propertiesFilePath: string = Path.resolve(__dirname + "../../../../../__tests__/__resources__/provisioning/" + testFileName);
+const emptyPropertiesFilePath: string = Path.resolve(__dirname + "../../../../../__tests__/__resources__/provisioning/" + emptyTestFileName);
 const parsedArrayOfObjects: IPropertiesInput[] = [{name: "name", value: "CSQ_MQ"}, {name: "value", value: "ABCD"}];
 const readFromFileProperties: IPropertiesInput[] = [{name: "key1", value: "val1"}, {name: "key2", value: "val2"}, {name: "key3", value: "val3"}];
 
@@ -61,6 +63,14 @@ describe("ProvisionService", () => {
 
         expect(parsedObject).toBeDefined();
         expect(parsedObject).toEqual(readFromFileProperties);
+    });
+
+    it("readPropertiesFromYamlFile should read from empty yaml file, parse and return an empty array", () => {
+        const parsedObject: IPropertiesInput[] = ProvisioningService.readPropertiesFromYamlFile(emptyPropertiesFilePath);
+        Imperative.console.info(`Response ${parsedObject}`);
+
+        expect(parsedObject).toBeDefined();
+        expect(parsedObject).toEqual([]);
     });
 
     it("checkForPassedOptionalParms should parse passed optional parameters and return a parsed object", () => {

--- a/packages/provisioning/src/api/ProvisioningService.ts
+++ b/packages/provisioning/src/api/ProvisioningService.ts
@@ -51,6 +51,9 @@ export class ProvisioningService {
         const props = readYaml.safeLoad(fs.readFileSync(path, "utf8"));
         const propsArrayObj: IPropertiesInput[] = [];
 
+        if (typeof props !== "object") {
+            return [];
+        }
         for (const key in props) {
             if (props.hasOwnProperty(key)) {
                 propsArrayObj.push({name: key, value: (props as any)[key]});


### PR DESCRIPTION
When I compile the master branch with `npm run build` I get an error:
```
"Checking that test source compiles..."
packages/provisioning/src/api/ProvisioningService.ts:54:27 - error TS2407: The right-hand side of a 'for...in' statement
must be of type 'any', an object type or a type parameter, but here has type 'string | object'.

54         for (const key in props) {
                             ~~~~~
```

This fix adds a check that `props` is in object.