### PR TITLE
Run GitHub Actions CI on PRs from Forks

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -5,6 +5,9 @@ on:
     branches-ignore:
       - 'master'
       - 'zowe-v1-lts'
+  pull_request:
+    branches:
+      - "**"
 
 jobs:
   lint:

--- a/.github/workflows/zowe-cli.yml
+++ b/.github/workflows/zowe-cli.yml
@@ -3,7 +3,7 @@
 
 name: Zowe CLI CI
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   test:


### PR DESCRIPTION
Changes to run workflows on a pull request instead of just on branches. 

Signed-off-by: Dan Kelosky <dkelosky@gmail.com>