### PR TITLE
Use the correct argument name for storclass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Zowe CLI package will be documented in this file.
 
+## Recent Changes
+
+- Rename the `storeclass` z/OS Files API Option to `storclass` to fix defining the storage class on create dataset commands
+
 ## `6.21.0`
 
 - Added optional responseTimeout option to zosFiles APIs and CLI

--- a/packages/zosfiles/__tests__/api/methods/create/Create.unit.test.ts
+++ b/packages/zosfiles/__tests__/api/methods/create/Create.unit.test.ts
@@ -1038,14 +1038,14 @@ describe("Create VSAM Data Set", () => {
             expect(mySpy).toHaveBeenCalledWith(dummySession, expectedCommand, options);
         });
 
-        it("should be able to create a VSAM data set with storeclass, mgntclass and dataclass provided",async () => {
+        it("should be able to create a VSAM data set with storclass, mgntclass and dataclass provided",async () => {
 
             const expectedCommand: string[] =
                 [`DEFINE CLUSTER -\n(NAME('${dataSetName}') -\nINDEXED -\nKB(${primary} ${secondary}) -\nVOLUMES(STG100) -` +
                 `\nSTORAGECLASS(STORE) -\nMANAGEMENTCLASS(MANAGEMENT) -\nDATACLASS(DATA) -\n)`];
             const options: IZosFilesOptions = {responseTimeout: undefined};
 
-            dsOptions.storeclass = "STORE";
+            dsOptions.storclass = "STORE";
             dsOptions.mgntclass = "MANAGEMENT";
             dsOptions.dataclass = "DATA";
             dsOptions.volumes = "STG100";

--- a/packages/zosfiles/src/api/methods/create/Create.ts
+++ b/packages/zosfiles/src/api/methods/create/Create.ts
@@ -281,7 +281,7 @@ export class Create {
 
                     // SMS class values
                     case "mgntclass":
-                    case "storeclass":
+                    case "storclass":
                     case "dataclass":
                         // no validation
 
@@ -521,7 +521,7 @@ export class Create {
             (options.retainTo ? "TO(" + options.retainTo + ") -\n" : "") +
             (options.retainFor ? "FOR(" + options.retainFor + ") -\n" : "") +
             (options.volumes ? "VOLUMES(" + options.volumes.toUpperCase() + ") -\n" : "") +
-            (options.storeclass ? "STORAGECLASS(" + options.storeclass + ") -\n" : "") +
+            (options.storclass ? "STORAGECLASS(" + options.storclass + ") -\n" : "") +
             (options.mgntclass ? "MANAGEMENTCLASS(" + options.mgntclass + ") -\n" : "") +
             (options.dataclass ? "DATACLASS(" + options.dataclass + ") -\n" : "") +
             ")"
@@ -603,7 +603,7 @@ export class Create {
 
                     case "retainTo":
                     case "volumes":
-                    case "storeclass":
+                    case "storclass":
                     case "mgntclass":
                     case "dataclass":
                     case "responseTimeout":
@@ -672,7 +672,7 @@ export class Create {
 
                     case "owner":
                     case "group":
-                    case "storeclass":
+                    case "storclass":
                     case "mgntclass":
                     case "dataclass":
                     case "volumes":

--- a/packages/zosfiles/src/api/methods/create/doc/ICreateDataSetOptions.ts
+++ b/packages/zosfiles/src/api/methods/create/doc/ICreateDataSetOptions.ts
@@ -88,7 +88,7 @@ export interface ICreateDataSetOptions extends IZosFilesOptions {
      * The storage class
      * @type {string}
      */
-    storeclass?: string;
+    storclass?: string;
 
     /**
      * The management class

--- a/packages/zosfiles/src/api/methods/create/doc/ICreateVsamOptions.ts
+++ b/packages/zosfiles/src/api/methods/create/doc/ICreateVsamOptions.ts
@@ -52,7 +52,7 @@ export interface ICreateVsamOptions extends IZosFilesOptions {
      * The storage class
      * @type {string}
      */
-    storeclass?: string;
+    storclass?: string;
 
     /**
      * The management class

--- a/packages/zosfiles/src/api/methods/create/doc/ICreateZfsOptions.ts
+++ b/packages/zosfiles/src/api/methods/create/doc/ICreateZfsOptions.ts
@@ -52,7 +52,7 @@ export interface ICreateZfsOptions extends IZosFilesOptions {
      * The storage class
      * @type {string}
      */
-    storeclass?: string;
+    storclass?: string;
 
     /**
      * The management class

--- a/packages/zosfiles/src/cli/-strings-/en.ts
+++ b/packages/zosfiles/src/cli/-strings-/en.ts
@@ -151,7 +151,7 @@ export default {
             RECFM: `The record format for the data set (for example, FB for "Fixed Block")`,
             BLKSIZE: "The block size for the data set (for example, 6160)",
             LRECL: "The logical record length. Analogous to the length of a line (for example, 80)",
-            STORECLASS: "The SMS storage class to use for the allocation",
+            STORCLASS: "The SMS storage class to use for the allocation",
             MGNTCLASS: "The SMS management class to use for the allocation",
             DATACLASS: "The SMS data class to use for the allocation",
             DSNTYPE: "The data set type",

--- a/packages/zosfiles/src/cli/create/Create.options.ts
+++ b/packages/zosfiles/src/cli/create/Create.options.ts
@@ -183,10 +183,10 @@ export const ZosFilesCreateOptions: { [key: string]: ICommandOptionDefinition } 
      * The storage class
      * @type {ICommandOptionDefinition}
      */
-    storeclass: {
+    storclass: {
         name: "storage-class",
         aliases: ["sc"],
-        description: strings.STORECLASS,
+        description: strings.STORCLASS,
         type: "string"
     },
 

--- a/packages/zosfiles/src/cli/create/Create.utils.ts
+++ b/packages/zosfiles/src/cli/create/Create.utils.ts
@@ -30,7 +30,7 @@ export function generateZosmfOptions(commandArguments: Arguments): ICreateDataSe
         recfm: commandArguments.recordFormat,
         blksize: commandArguments.blockSize,
         lrecl: commandArguments.recordLength,
-        storeclass: commandArguments.storageClass,
+        storclass: commandArguments.storageClass,
         mgntclass: commandArguments.managementClass,
         dataclass: commandArguments.dataClass,
         dsntype: commandArguments.dataSetType,

--- a/packages/zosfiles/src/cli/create/binaryPds/BinaryPDS.definition.ts
+++ b/packages/zosfiles/src/cli/create/binaryPds/BinaryPDS.definition.ts
@@ -49,7 +49,7 @@ export const BinaryPDSDefinition: ICommandDefinition = {
         {...ZosFilesCreateOptions.recfm, defaultValue: CreateDefaults.DATA_SET.BINARY.recfm},
         {...ZosFilesCreateOptions.blksize, defaultValue: CreateDefaults.DATA_SET.BINARY.blksize},
         {...ZosFilesCreateOptions.lrecl, defaultValue: CreateDefaults.DATA_SET.BINARY.lrecl},
-        ZosFilesCreateOptions.storeclass,
+        ZosFilesCreateOptions.storclass,
         ZosFilesCreateOptions.mgntclass,
         ZosFilesCreateOptions.dataclass,
         ZosFilesCreateOptions.unit,

--- a/packages/zosfiles/src/cli/create/cPds/CPDS.definition.ts
+++ b/packages/zosfiles/src/cli/create/cPds/CPDS.definition.ts
@@ -49,7 +49,7 @@ export const CPDSDefinition: ICommandDefinition = {
         {...ZosFilesCreateOptions.recfm, defaultValue: CreateDefaults.DATA_SET.C.recfm},
         {...ZosFilesCreateOptions.blksize, defaultValue: CreateDefaults.DATA_SET.C.blksize},
         {...ZosFilesCreateOptions.lrecl, defaultValue: CreateDefaults.DATA_SET.C.lrecl},
-        ZosFilesCreateOptions.storeclass,
+        ZosFilesCreateOptions.storclass,
         ZosFilesCreateOptions.mgntclass,
         ZosFilesCreateOptions.dataclass,
         ZosFilesCreateOptions.unit,

--- a/packages/zosfiles/src/cli/create/classicPds/ClassicPDS.definition.ts
+++ b/packages/zosfiles/src/cli/create/classicPds/ClassicPDS.definition.ts
@@ -49,7 +49,7 @@ export const ClassicPDSDefinition: ICommandDefinition = {
         {...ZosFilesCreateOptions.recfm, defaultValue: CreateDefaults.DATA_SET.CLASSIC.recfm},
         {...ZosFilesCreateOptions.blksize, defaultValue: CreateDefaults.DATA_SET.CLASSIC.blksize},
         {...ZosFilesCreateOptions.lrecl, defaultValue: CreateDefaults.DATA_SET.CLASSIC.lrecl},
-        ZosFilesCreateOptions.storeclass,
+        ZosFilesCreateOptions.storclass,
         ZosFilesCreateOptions.mgntclass,
         ZosFilesCreateOptions.dataclass,
         ZosFilesCreateOptions.unit,

--- a/packages/zosfiles/src/cli/create/pds/Pds.definition.ts
+++ b/packages/zosfiles/src/cli/create/pds/Pds.definition.ts
@@ -49,7 +49,7 @@ export const PdsDefinition: ICommandDefinition = {
         {...ZosFilesCreateOptions.recfm, defaultValue: CreateDefaults.DATA_SET.PARTITIONED.recfm},
         {...ZosFilesCreateOptions.blksize, defaultValue: CreateDefaults.DATA_SET.PARTITIONED.blksize},
         {...ZosFilesCreateOptions.lrecl, defaultValue: CreateDefaults.DATA_SET.PARTITIONED.lrecl},
-        ZosFilesCreateOptions.storeclass,
+        ZosFilesCreateOptions.storclass,
         ZosFilesCreateOptions.mgntclass,
         ZosFilesCreateOptions.dataclass,
         ZosFilesCreateOptions.unit,

--- a/packages/zosfiles/src/cli/create/ps/Ps.definition.ts
+++ b/packages/zosfiles/src/cli/create/ps/Ps.definition.ts
@@ -49,7 +49,7 @@ export const PsDefinition: ICommandDefinition = {
         {...ZosFilesCreateOptions.recfm, defaultValue: CreateDefaults.DATA_SET.SEQUENTIAL.recfm},
         {...ZosFilesCreateOptions.blksize, defaultValue: CreateDefaults.DATA_SET.SEQUENTIAL.blksize},
         {...ZosFilesCreateOptions.lrecl, defaultValue: CreateDefaults.DATA_SET.SEQUENTIAL.lrecl},
-        ZosFilesCreateOptions.storeclass,
+        ZosFilesCreateOptions.storclass,
         ZosFilesCreateOptions.mgntclass,
         ZosFilesCreateOptions.dataclass,
         ZosFilesCreateOptions.unit,

--- a/packages/zosfiles/src/cli/create/vsam/vsam.definition.ts
+++ b/packages/zosfiles/src/cli/create/vsam/vsam.definition.ts
@@ -67,7 +67,7 @@ export const VsamDefinition: ICommandDefinition = {
         vsamSize,
         vsamSecondary,
         VsamCreateOptions.volumes,
-        ZosFilesCreateOptions.storeclass,
+        ZosFilesCreateOptions.storclass,
         ZosFilesCreateOptions.mgntclass,
         ZosFilesCreateOptions.dataclass,
         vsamRetainFor,

--- a/packages/zosfiles/src/cli/create/vsam/vsam.handler.ts
+++ b/packages/zosfiles/src/cli/create/vsam/vsam.handler.ts
@@ -26,7 +26,7 @@ export default class VsamHandler extends ZosFilesBaseHandler {
             size: commandParameters.arguments.size,
             secondary: commandParameters.arguments.secondarySpace,
             volumes: commandParameters.arguments.volumes,
-            storeclass: commandParameters.arguments.storageClass,
+            storclass: commandParameters.arguments.storageClass,
             mgntclass: commandParameters.arguments.managementClass,
             dataclass: commandParameters.arguments.dataClass,
             retainFor: commandParameters.arguments.retainFor,

--- a/packages/zosfiles/src/cli/create/zfs/zfs.definition.ts
+++ b/packages/zosfiles/src/cli/create/zfs/zfs.definition.ts
@@ -46,7 +46,7 @@ export const ZfsDefinition: ICommandDefinition = {
         ZfsCreateOptions.perms,
         ZfsCreateOptions.cylsPri,
         ZfsCreateOptions.cylsSec,
-        ZosFilesCreateOptions.storeclass,
+        ZosFilesCreateOptions.storclass,
         ZosFilesCreateOptions.mgntclass,
         ZosFilesCreateOptions.dataclass,
         ZfsCreateOptions.volumes,

--- a/packages/zosfiles/src/cli/create/zfs/zfs.handler.ts
+++ b/packages/zosfiles/src/cli/create/zfs/zfs.handler.ts
@@ -27,7 +27,7 @@ export default class ZfsHandler extends ZosFilesBaseHandler {
             perms: commandParameters.arguments.perms,
             cylsPri: commandParameters.arguments.cylsPri,
             cylsSec: commandParameters.arguments.cylsSec,
-            storeclass: commandParameters.arguments.storageClass,
+            storclass: commandParameters.arguments.storageClass,
             mgntclass: commandParameters.arguments.managementClass,
             dataclass: commandParameters.arguments.dataClass,
             volumes: commandParameters.arguments.volumes,


### PR DESCRIPTION
Rename storeclass -> storclass, as that is the proper field name per [IBM z/OSMF documentation](https://www.ibm.com/support/knowledgecenter/SSLTBW_2.3.0/com.ibm.zos.v2r3.izua700/IZUHPINFO_API_CreateDataSet.htm)

Resolves #503 

Signed-off-by: Andrew W. Harn <andrew.harn@broadcom.com>