### PR TITLE
Fix SSH output sometimes omitting last line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Zowe CLI package will be documented in this file.
 
+## Recent Changes
+
+- Fix output of `zowe zos-uss issue ssh` sometimes omitting last line. [#795](https://github.com/zowe/zowe-cli/issues/795)
+
 ## `6.21.1`
 
 - Rename the `storeclass` z/OS Files API Option to `storclass` to fix defining the storage class on create dataset commands

--- a/packages/zosuss/__tests__/api/Shell.unit.test.ts
+++ b/packages/zosuss/__tests__/api/Shell.unit.test.ts
@@ -34,7 +34,8 @@ mockStream.write = mockStreamWrite;
 
 const mockShell = jest.fn().mockImplementation((callback) => {
     callback(null, mockStream);
-    mockStream.emit("data", `\n${startCmdFlag}stdout data\n\r`);
+    mockStream.emit("data", `\n${startCmdFlag}stdout data\n\rerror$ `);
+    mockStream.emit("exit", 0);
 });
 
 (Client as any).mockImplementation(() => {
@@ -53,9 +54,13 @@ function checkMockFunctionsWithCommand(command: string) {
     expect(mockStreamWrite.mock.calls[0][0]).toMatch(command);
     expect(mockStreamEnd).toHaveBeenCalled();
     expect(stdoutHandler).toHaveBeenCalledWith("stdout data\n");
+    expect(stdoutHandler).toHaveBeenCalledWith("\rerror");
 }
 
 describe("Shell", () => {
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
 
     it("Should execute ssh command", async () => {
         const command = "commandtest";

--- a/packages/zosuss/src/api/Shell.ts
+++ b/packages/zosuss/src/api/Shell.ts
@@ -48,6 +48,12 @@ export class Shell {
 
                     stream.on("exit", (exitcode) => {
                         Logger.getAppLogger().debug("Return Code: " + exitcode);
+                        if (dataBuffer.trim().length > 1) {
+                            // normally the last line is "\r\n$ " and we don't care about it
+                            // but we need to handle the case of an incomplete line at the end
+                            // which can happen when commands terminate abruptly
+                            stdoutHandler(dataBuffer.slice(0, dataBuffer.lastIndexOf("$")));
+                        }
                         rc = exitcode;
                     });
                     stream.on("close", () => {


### PR DESCRIPTION
Fixes #795 where when an SSH command terminates abruptly, the last line of output is not always processed