### PR TITLE
Add task to build typedoc for Zowe Node.js SDK

### DIFF
--- a/gulp/DevelopmentTasks.ts
+++ b/gulp/DevelopmentTasks.ts
@@ -221,6 +221,25 @@ const doc: ITaskFunction = async () => {
 };
 doc.description = "Create documentation from the CLI help";
 
+const typedoc: ITaskFunction = (done) => {
+    const { version } = require("../lerna.json");
+    const { name } = require("../typedoc.json");
+    let docProcess: SpawnSyncReturns<string>;
+
+    try {
+        docProcess = childProcess.spawnSync(npx, ["typedoc",
+            "--options", "./typedoc.json", "--name", `"${name} - v${version}"`, "./packages/"], {stdio: "inherit"});
+
+    } catch (e) {
+        fancylog(ansiColors.red("Error encountered trying to run typedoc"));
+        done(e);
+        return;
+    }
+    done();
+};
+typedoc.description = "Runs typedoc to generate API docs for the Zowe Node.js SDK";
+
 exports.doc = doc;
 exports.lint = lint;
 exports.license = license;
+exports.typedoc = typedoc;

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -19,6 +19,7 @@ const developmentTasks = require("./gulp/DevelopmentTasks");
 gulp.task("lint", developmentTasks.lint);
 gulp.task("updateLicense", developmentTasks.license);
 gulp.task('doc', developmentTasks.doc);
+gulp.task('typedoc', developmentTasks.typedoc);
 
 /**
  * Cleanup related tasks

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "doc:clean": "rimraf docs/CLIReadme.md",
     "doc:generate": "npm run doc:clean && gulp doc",
     "generateCleanTypedoc": "npm run typedoc && gulp cleanTypedoc",
-    "typedoc": "typedoc --options ./typedoc.json ./packages/",
+    "typedoc": "gulp typedoc",
     "typedocSpecifySrc": "typedoc --options ./typedoc.json",
     "audit:public": "npm audit --registry https://registry.npmjs.org/"
   },

--- a/typedoc.json
+++ b/typedoc.json
@@ -2,13 +2,13 @@
     "out": "./docs/typedoc/",
     "exclude": [
         "**/node_modules/**",
-        "**/__tests__/**"
+        "**/__tests__/**",
+        "packages/cli/**"
     ],
     "disableOutputCheck": true,
     "ignoreCompilerErrors": true,
     "mode": "file",
     "external-modulemap": ".*packages\/([^\/]+)\/.*",
     "readme": "./README.md",
-    "name": "Zowe CLI",
-    "includeVersion": true
+    "name": "Zowe Node.js SDK"
 }


### PR DESCRIPTION
Exclude CLI package from API docs for Zowe Node.js SDK. Also extract SDK version from lerna.json, since it can no longer be found in top-level package.json.