### PR TITLE
[json-config-next] Define values for Imperative to generate config template

### DIFF
--- a/packages/cli/scripts/copyPrebuilds.js
+++ b/packages/cli/scripts/copyPrebuilds.js
@@ -1,12 +1,13 @@
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Eclipse Public License v2.0 which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
- *
- * SPDX-License-Identifier: EPL-2.0
- *
- * Copyright Contributors to the Zowe Project.
- */
+* This program and the accompanying materials are made available under the terms of the
+* Eclipse Public License v2.0 which accompanies this distribution, and is available at
+* https://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Copyright Contributors to the Zowe Project.
+*
+*/
 
 const fs = require("fs");
 const join = require("path").join;

--- a/packages/cli/src/imperative.ts
+++ b/packages/cli/src/imperative.ts
@@ -66,16 +66,19 @@ const config: IImperativeConfig = {
                 user: {
                     type: "string",
                     secure: true,
-                    optionDefinition: Constants.BASE_OPTION_USER
+                    optionDefinition: Constants.BASE_OPTION_USER,
+                    includeInTemplate: true
                 },
                 password: {
                     type: "string",
                     secure: true,
-                    optionDefinition: Constants.BASE_OPTION_PASSWORD
+                    optionDefinition: Constants.BASE_OPTION_PASSWORD,
+                    includeInTemplate: true
                 },
                 rejectUnauthorized: {
                     type: "boolean",
-                    optionDefinition: Constants.BASE_OPTION_REJECT_UNAUTHORIZED
+                    optionDefinition: Constants.BASE_OPTION_REJECT_UNAUTHORIZED,
+                    includeInTemplate: true
                 },
                 tokenType: {
                     type: "string",
@@ -169,11 +172,13 @@ const config: IImperativeConfig = {
                 properties: {
                     host: {
                         type: "string",
-                        optionDefinition: ZosmfSession.ZOSMF_OPTION_HOST_PROFILE
+                        optionDefinition: ZosmfSession.ZOSMF_OPTION_HOST_PROFILE,
+                        includeInTemplate: true
                     },
                     port: {
                         type: "number",
-                        optionDefinition: ZosmfSession.ZOSMF_OPTION_PORT
+                        optionDefinition: ZosmfSession.ZOSMF_OPTION_PORT,
+                        includeInTemplate: true
                     },
                     user: {
                         type: "string",
@@ -252,7 +257,8 @@ const config: IImperativeConfig = {
                 properties: {
                     account: {
                         type: "string",
-                        optionDefinition: TSO_OPTION_ACCOUNT_PROFILE
+                        optionDefinition: TSO_OPTION_ACCOUNT_PROFILE,
+                        includeInTemplate: true
                     },
                     characterSet: {
                         type: "string",
@@ -312,11 +318,13 @@ const config: IImperativeConfig = {
                 properties: {
                     host: {
                         type: "string",
-                        optionDefinition: SshSession.SSH_OPTION_HOST_PROFILE
+                        optionDefinition: SshSession.SSH_OPTION_HOST_PROFILE,
+                        includeInTemplate: true
                     },
                     port: {
                         type: "number",
-                        optionDefinition: SshSession.SSH_OPTION_PORT
+                        optionDefinition: SshSession.SSH_OPTION_PORT,
+                        includeInTemplate: true
                     },
                     user: {
                         type: "string",

--- a/packages/cli/src/imperative.ts
+++ b/packages/cli/src/imperative.ts
@@ -162,6 +162,7 @@ const config: IImperativeConfig = {
             description: Constants.AUTH_GROUP_DESCRIPTION
         }
     },
+    templateProfileName: "lpar1",
     profiles: [
         {
             type: "zosmf",


### PR DESCRIPTION
This PR enhances the config templates generated by https://github.com/zowe/imperative/pull/466
- Set `includeInTemplate` to true for profile properties that should be included in the template
- Define `templateProfileName` to change the name of the root profile that wraps zosmf, tso, & ssh to `lpar1`