### PR TITLE
Improve performance of zosfiles list handlers

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Zowe CLI package will be documented in this file.
 
+## Recent Changes
+
+- BugFix: Improved performance of `zowe zos-files list` commands when very long lists are printed to console. [#861](https://github.com/zowe/zowe-cli/issues/861)
+
 ## `6.24.5`
 
 - Bugfix: Updated Imperative dependency version to one that does not contain a vulnerable dependency

--- a/packages/cli/__tests__/zosfiles/__unit__/list/ds/__snapshots__/Dataset.handler.unit.test.ts.snap
+++ b/packages/cli/__tests__/zosfiles/__unit__/list/ds/__snapshots__/Dataset.handler.unit.test.ts.snap
@@ -16,6 +16,6 @@ exports[`List Dataset handler process method should list a data set if requested
 
 exports[`List Dataset handler process method should list a data set if requested 3`] = `
 "
-undefined
+
 listed"
 `;

--- a/packages/cli/src/zosfiles/list/am/AllMembers.handler.ts
+++ b/packages/cli/src/zosfiles/list/am/AllMembers.handler.ts
@@ -30,7 +30,8 @@ export default class AllMembersHandler extends ZosFilesBaseHandler {
         if (commandParameters.arguments.attributes && response.apiResponse.items.length > 0) {
             commandParameters.response.console.log(TextUtils.prettyJson(response.apiResponse.items));
         } else {
-            response.apiResponse.items.forEach((mem: any) => commandParameters.response.console.log(mem.member));
+            const memberList = response.apiResponse.items.map((mem: any) => mem.member);
+            commandParameters.response.console.log(memberList.join("\n"));
         }
 
         return response;

--- a/packages/cli/src/zosfiles/list/ds/DataSet.handler.ts
+++ b/packages/cli/src/zosfiles/list/ds/DataSet.handler.ts
@@ -29,7 +29,8 @@ export default class DataSetHandler extends ZosFilesBaseHandler {
         if (commandParameters.arguments.attributes && response.apiResponse.items.length > 0) {
             commandParameters.response.console.log(TextUtils.prettyJson(response.apiResponse.items));
         } else {
-            response.apiResponse.items.forEach((mem: any) => commandParameters.response.console.log(mem.dsname));
+            const dsnameList = response.apiResponse.items.map((mem: any) => mem.dsname);
+            commandParameters.response.console.log(dsnameList.join("\n"));
         }
 
         return response;


### PR DESCRIPTION
This PR addresses the performance issue reported in #861.

When logging a long list to the console, it is much more efficient to print all lines at once rather than one-by-one.

This reduces the time of the command `zowe zos-files list all-members` for a PDS with 300k members, from 2m 10s to about 15s.