### PR TITLE
Rust CLI Publish CI:  Upload Rust Code Only

### DIFF
--- a/.github/workflows/rust-cli-publish.yml
+++ b/.github/workflows/rust-cli-publish.yml
@@ -17,11 +17,11 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - run: cd zowex
-
     - name: Get version
-      run: "echo ::set-output name=ZOWEX_VERSION::$(cargo pkgid | cut -d# -f2 | cut -d: -f2)"
       id: get-version
+      run: |
+        cd zowex
+        echo "::set-output name=ZOWEX_VERSION::$(cargo pkgid | cut -d# -f2 | cut -d: -f2)"
 
     - name: Create Release
       id: create_release
@@ -45,7 +45,7 @@ jobs:
       with:
         name: repo
         path: |
-          **
+          zowex/**
           !.git
 
   build-ubuntu-mac:

--- a/.github/workflows/zowe-cli.yml
+++ b/.github/workflows/zowe-cli.yml
@@ -5,9 +5,15 @@ name: Zowe CLI CI
 
 on:
   push:
-    paths-ignore: 'zowex/**'
+    paths-ignore:
+    - 'zowex/**'
+    - '.github/workflows/rust-cli-publish.yml'
+    - '.github/workflows/rust-cli.yml'
   pull_request:
-    paths-ignore: 'zowex/**'
+    paths-ignore:
+    - 'zowex/**'
+    - '.github/workflows/rust-cli-publish.yml'
+    - '.github/workflows/rust-cli.yml'
 
 jobs:
   test:


### PR DESCRIPTION
Rust CLI publish fails because operations are done from the wrong directory - this PR should fix that.  

Signed-off-by: Dan Kelosky <dkelosky@gmail.com>