### PR TITLE
Add "Accept-Encoding: gzip" header to all z/OSMF requests

### DIFF
--- a/packages/core/src/rest/ZosmfHeaders.ts
+++ b/packages/core/src/rest/ZosmfHeaders.ts
@@ -195,4 +195,12 @@ export class ZosmfHeaders {
      * @memberof ZosmfHeaders
      */
     public static readonly X_IBM_RETURN_ETAG: IHeaderContent = {"X-IBM-Return-Etag": "true"};
+
+    /**
+     * Header that specifies GZIP compression is supported
+     * Recent versions of z/OSMF issue a warning if this header is omitted
+     * @static
+     * @memberof ZosmfHeaders
+     */
+    public static readonly ACCEPT_ENCODING: IHeaderContent = { "Accept-Encoding": "gzip" };
 }

--- a/packages/core/src/rest/ZosmfRestClient.ts
+++ b/packages/core/src/rest/ZosmfRestClient.ts
@@ -38,9 +38,9 @@ export class ZosmfRestClient extends RestClient {
      */
     protected appendHeaders(headers: any[] | undefined): any[] {
         if (headers == null) {
-            headers = [ZosmfHeaders.X_CSRF_ZOSMF_HEADER];
+            headers = [ZosmfHeaders.X_CSRF_ZOSMF_HEADER, ZosmfHeaders.ACCEPT_ENCODING];
         } else {
-            headers.push(ZosmfHeaders.X_CSRF_ZOSMF_HEADER);
+            headers.push(ZosmfHeaders.X_CSRF_ZOSMF_HEADER, ZosmfHeaders.ACCEPT_ENCODING);
         }
         return headers;
     }

--- a/packages/zosfiles/src/methods/create/Create.ts
+++ b/packages/zosfiles/src/methods/create/Create.ts
@@ -9,7 +9,7 @@
 *
 */
 
-import { AbstractSession, ImperativeError, ImperativeExpect, Logger, TextUtils } from "@zowe/imperative";
+import { AbstractSession, IHeaderContent, ImperativeError, ImperativeExpect, Logger, TextUtils } from "@zowe/imperative";
 import { isNullOrUndefined } from "util";
 import { ZosmfHeaders, ZosmfRestClient } from "@zowe/core-for-zowe-sdk";
 import { ZosFilesConstants } from "../../constants/ZosFiles.constants";
@@ -409,7 +409,7 @@ export class Create {
         ussPath = ussPath.charAt(0) === "/" ? ussPath.substring(1) : ussPath;
         ussPath = encodeURIComponent(ussPath);
         const parameters: string = `${ZosFilesConstants.RESOURCE}${ZosFilesConstants.RES_USS_FILES}/${ussPath}`;
-        const headers: object[] = [ZosmfHeaders.X_CSRF_ZOSMF_HEADER, { "Content-Type": "application/json" }];
+        const headers: IHeaderContent[] = [];
         if (options && options.responseTimeout != null) {
             headers.push({[ZosmfHeaders.X_IBM_RESPONSE_TIMEOUT]: options.responseTimeout.toString()});
         }

--- a/packages/zostso/__tests__/__unit__/PingTso.unit.test.ts
+++ b/packages/zostso/__tests__/__unit__/PingTso.unit.test.ts
@@ -15,7 +15,7 @@ import { ZosmfHeaders, ZosmfRestClient } from "@zowe/core-for-zowe-sdk";
 import { inspect } from "util";
 
 
-const ISSUE_HEADERS: any[] = [ZosmfHeaders.X_CSRF_ZOSMF_HEADER, Headers.APPLICATION_JSON];
+const ISSUE_HEADERS: any[] = [Headers.APPLICATION_JSON];
 const START_RESOURCES = "/zosmf/tsoApp/tso/ping/UZUST01-154-aacaaaaz";
 const servletKey = "UZUST01-154-aacaaaaz";
 

--- a/packages/zostso/__tests__/__unit__/StartTso.unit.test.ts
+++ b/packages/zostso/__tests__/__unit__/StartTso.unit.test.ts
@@ -27,7 +27,7 @@ import { ZosmfHeaders } from "@zowe/core-for-zowe-sdk";
 import { ZosmfRestClient } from "../../../core/lib/rest/ZosmfRestClient";
 import { inspect } from "util";
 
-const START_HEADERS: any[] = [ZosmfHeaders.X_CSRF_ZOSMF_HEADER, Headers.APPLICATION_JSON];
+const START_HEADERS: any[] = [Headers.APPLICATION_JSON];
 
 const ACCOUNT_NUMBER: string = "DEFAULT";
 

--- a/packages/zostso/__tests__/__unit__/StopTso.unit.test.ts
+++ b/packages/zostso/__tests__/__unit__/StopTso.unit.test.ts
@@ -28,7 +28,7 @@ const SERVLET_KEY: string = "ZOSMFAD-SYS2-55-aaakaaac";
 
 const STOP_PARMS: IStopTsoParms = {servletKey: SERVLET_KEY};
 
-const STOP_HEADERS: any[] = [ZosmfHeaders.X_CSRF_ZOSMF_HEADER, Headers.APPLICATION_JSON];
+const STOP_HEADERS: any[] = [Headers.APPLICATION_JSON];
 
 const RESOURCES_QUERY: string = `${TsoConstants.RESOURCE}/${TsoConstants.RES_START_TSO}/${SERVLET_KEY}`;
 

--- a/packages/zostso/src/PingTso.ts
+++ b/packages/zostso/src/PingTso.ts
@@ -31,7 +31,7 @@ export class PingTso {
     public static async ping(session: AbstractSession, servletKey: string) {
         TsoValidator.validatePingParms(session, servletKey, noPingInput.message);
         const res = await ZosmfRestClient.putExpectJSON<IZosmfPingResponse>(session, PingTso.getResource(servletKey),
-            [ZosmfHeaders.X_CSRF_ZOSMF_HEADER, Headers.APPLICATION_JSON], null);
+            [Headers.APPLICATION_JSON], null);
         TsoValidator.validateErrorMessageFromZosmf(res);
         const result: IPingResponse = TsoResponseService.populatePing(res);
         return result;

--- a/packages/zostso/src/SendTso.ts
+++ b/packages/zostso/src/SendTso.ts
@@ -56,7 +56,7 @@ export class SendTso {
         const parameters: string = "/" + TsoConstants.RES_START_TSO + "/" + commandParams.servletKey + TsoConstants.RES_DONT_READ_REPLY;
         const jobObj: any = {"TSO RESPONSE": {VERSION: "0100", DATA: commandParams.data}};
         return ZosmfRestClient.putExpectJSON<IZosmfTsoResponse>
-        (session, TsoConstants.RESOURCE + parameters, [ZosmfHeaders.X_CSRF_ZOSMF_HEADER, Headers.APPLICATION_JSON], jobObj);
+        (session, TsoConstants.RESOURCE + parameters, [Headers.APPLICATION_JSON], jobObj);
 
     }
 
@@ -72,7 +72,7 @@ export class SendTso {
 
         const parameters: string = "/" + TsoConstants.RES_START_TSO + "/" + servletKey;
         return ZosmfRestClient.getExpectJSON<IZosmfTsoResponse>(session, TsoConstants.RESOURCE + parameters,
-            [ZosmfHeaders.X_CSRF_ZOSMF_HEADER, Headers.APPLICATION_JSON]);
+            [Headers.APPLICATION_JSON]);
     }
 
     /**

--- a/packages/zostso/src/StartTso.ts
+++ b/packages/zostso/src/StartTso.ts
@@ -42,7 +42,7 @@ export class StartTso {
         const startResources = this.getResourcesQuery(commandParms);
 
         return ZosmfRestClient.postExpectJSON<IZosmfTsoResponse>(session, startResources,
-            [ZosmfHeaders.X_CSRF_ZOSMF_HEADER, Headers.APPLICATION_JSON]);
+            [Headers.APPLICATION_JSON]);
     }
     /**
      * Start TSO address space with provided parameters.

--- a/packages/zostso/src/StopTso.ts
+++ b/packages/zostso/src/StopTso.ts
@@ -41,7 +41,7 @@ export class StopTso {
         const resources = this.getResources(commandParms.servletKey);
 
         return ZosmfRestClient.deleteExpectJSON<IZosmfTsoResponse>(session, resources,
-            [ZosmfHeaders.X_CSRF_ZOSMF_HEADER, Headers.APPLICATION_JSON]);
+            [Headers.APPLICATION_JSON]);
     }
 
     /**


### PR DESCRIPTION
Fixes #905. Also removed "X_CSRF_ZOSMF_HEADER" from places where it was being added twice.