### PR TITLE
Update next

### DIFF
--- a/packages/cli/__tests__/help/__integration__/__snapshots__/BrightHelpTests.integration.test.ts.snap
+++ b/packages/cli/__tests__/help/__integration__/__snapshots__/BrightHelpTests.integration.test.ts.snap
@@ -26,9 +26,10 @@ exports[`Root level help tests top level help should contain support link 1`] = 
  ------
 
    auth                          Connect to Zowe API ML authentication service
-   config                        Manage configuration and overrides           
+   config                        Manage JSON project and global configuration 
    plugins                       Install and manage plug-ins                  
-   profiles                      Create and manage configuration profiles (deprecated)
+   profiles                      Create and manage configuration profiles     
+                                 (deprecated)                                 
    provisioning | pv             Perform z/OSMF provisioning tasks            
    zos-console | console         Issue z/OS console commands and collect      
                                  responses                                    


### PR DESCRIPTION
The only changes in this PR are updates to snapshots that had incorrectly resolved merge conflicts.

Most of the changes from master were accidentally merged directly into next without a PR, and can be viewed [here](https://github.com/zowe/zowe-cli/compare/88fe2c126e85d3b9d34ed992cbd8e6756f79c8e7...next).