### PR TITLE
Remove SDK typedoc build

### DIFF
--- a/gulp/DevelopmentTasks.ts
+++ b/gulp/DevelopmentTasks.ts
@@ -221,25 +221,6 @@ const doc: ITaskFunction = async () => {
 };
 doc.description = "Create documentation from the CLI help";
 
-const typedoc: ITaskFunction = (done) => {
-    const { version } = require("../lerna.json");
-    const { name } = require("../typedoc.json");
-    let docProcess: SpawnSyncReturns<string>;
-
-    try {
-        docProcess = childProcess.spawnSync(npx, ["typedoc",
-            "--options", "./typedoc.json", "--name", `"${name} - v${version}"`, "./packages/"], {stdio: "inherit"});
-
-    } catch (e) {
-        fancylog(ansiColors.red("Error encountered trying to run typedoc"));
-        done(e);
-        return;
-    }
-    done();
-};
-typedoc.description = "Runs typedoc to generate API docs for the Zowe Node.js SDK";
-
 exports.doc = doc;
 exports.lint = lint;
 exports.license = license;
-exports.typedoc = typedoc;

--- a/package-lock.json
+++ b/package-lock.json
@@ -13748,7 +13748,7 @@
     "repeat-element": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.3.tgz",
-      "integrity": "sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g==",
+      "integrity": "sha1-eC4NglwMWjuzlzH4Tv7mt0Lmsc4=",
       "dev": true
     },
     "repeat-string": {

--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
     "doc:clean": "rimraf docs/CLIReadme.md",
     "doc:generate": "npm run doc:clean && gulp doc",
     "generateCleanTypedoc": "npm run typedoc && gulp cleanTypedoc",
-    "typedoc": "gulp typedoc",
-    "typedocSpecifySrc": "typedoc --options ./typedoc.json",
+    "typedoc": "typedoc",
+    "typedoc:packages": "lerna run --parallel typedoc",
     "audit:public": "npm audit --registry https://registry.npmjs.org/",
     "prepare": "husky install"
   },

--- a/typedoc.json
+++ b/typedoc.json
@@ -2,13 +2,10 @@
     "out": "./docs/typedoc/",
     "exclude": [
         "**/node_modules/**",
-        "**/__tests__/**",
-        "packages/cli/**"
+        "**/__tests__/**"
     ],
     "disableOutputCheck": true,
     "ignoreCompilerErrors": true,
     "mode": "file",
-    "external-modulemap": ".*packages\/([^\/]+)\/.*",
-    "readme": "none",
-    "name": "Zowe Node.js SDK"
+    "external-modulemap": ".*packages\/([^\/]+)\/.*"
 }


### PR DESCRIPTION
Since the SDK typedoc on Zowe docs site should include Imperative along with the SDK packages, building it is outside the scope of this repo and has been moved into the zowe-cli-standalone-package repo (https://github.com/zowe/zowe-cli-standalone-package/pull/22).