### PR TITLE
Add dco signoff file

### DIFF
--- a/dco_signoffs/Timothy-Johnson-zowe-cli.txt
+++ b/dco_signoffs/Timothy-Johnson-zowe-cli.txt
@@ -1,0 +1,3 @@
+I, Timothy Johnson hereby sign-off-by all of my past commits to this repo subject to the Developer Certificate of Origin (DCO), Version 1.1. In the past I have used emails: timothy.johnson@broadcom.com
+
+2db47d8f871159fdf0b9891eabc373de0daf2066 Update package lock file


### PR DESCRIPTION
The DCO bot won't detect this file 😢 However it ensures that the commit is recorded as signed off 🙂