### PR TITLE
Always send the like parameter regardless of the optional options

### DIFF
--- a/packages/zosfiles/CHANGELOG.md
+++ b/packages/zosfiles/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Zowe z/OS files SDK package will be documented in this file.
 
+## Recent Changes
+
+- Bugfix: Ensured that the `like` field will always be added to all allocate like requests regardless of whether the `options` parameter is defined or not. [#1017](https://github.com/zowe/zowe-cli/pull/1017)
+
 ## `6.29.0`
 
 - Enhancement: Added a standard data set template with no parameters set.

--- a/packages/zosfiles/__tests__/__unit__/methods/create/Create.unit.test.ts
+++ b/packages/zosfiles/__tests__/__unit__/methods/create/Create.unit.test.ts
@@ -165,9 +165,20 @@ describe("Create data set", () => {
         });
 
         it("should be able to allocate like from a sequential data set", async () => {
-            const response = await Create.dataSetLike(dummySession, "testing2", dataSetName);
+            const response = await Create.dataSetLike(dummySession, dataSetName, "testing2");
 
+            expect(response.success).toBe(true);
             expect(response.commandResponse).toContain("created successfully");
+            expect(mySpy).toHaveBeenCalledWith(
+                dummySession,
+                endpoint,
+                [ZosmfHeaders.ACCEPT_ENCODING],
+                JSON.stringify({
+                    ...{
+                        like: "testing2"
+                    }
+                })
+            )
         });
 
         it("should be able to create a sequential data set using the primary allocation and secondary allocation options", async () => {

--- a/packages/zosfiles/src/methods/create/Create.ts
+++ b/packages/zosfiles/src/methods/create/Create.ts
@@ -150,7 +150,7 @@ export class Create {
         ImperativeExpect.toNotBeNullOrUndefined(likeDataSetName, ZosFilesMessages.missingDatasetLikeName.message);
 
         // Removes undefined properties
-        const tempOptions = !isNullOrUndefined(options) ? JSON.parse(JSON.stringify({ like: likeDataSetName, ...(options || {}) })) : {};
+        const tempOptions = JSON.parse(JSON.stringify({ like: likeDataSetName, ...(options || {}) }));
         Create.dataSetValidateOptions(tempOptions);
 
         try {


### PR DESCRIPTION
Signed-off-by: Hartanto Ario Widjaya <tanto259@users.noreply.github.com>

Regardless of what the user passed as the `options`, the like parameter must always be included for allocate like.

My understanding is if options is either null or undefined, it will be caught in `(options || {})`, thus removing the need of `isNullOrUndefined`.

The optional `options` parameter should still be there to allow user to override the obtained parameter from `likeDataSetName`.