### PR TITLE
60 - Removed 'z/OS' from zos-files help upload and download commands

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21434,7 +21434,7 @@
     },
     "packages/cli": {
       "name": "@zowe/cli",
-      "version": "6.31.1",
+      "version": "6.31.2",
       "hasInstallScript": true,
       "license": "EPL-2.0",
       "dependencies": {

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,10 +1,12 @@
 # Change Log
 
+## Recent Changes
+
+- Removed 'z/OS' from zos-files help upload and download commands. [#60](https://github.com/zowe/zowe-cli/issues/60)
+
 ## `6.31.2`
 
 All notable changes to the Zowe CLI package will be documented in this file.
-
-- Removed 'z/OS' from zos-files help upload and download commands. [#60](https://github.com/zowe/zowe-cli/issues/60)
 
 - Enhancement: Added new aliases for zos-files commands in delete, download, and list relating to USS files. You can now interact with `uf` or `uss`.  [#983](https://github.com/zowe/zowe-cli/issues/983)
 

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 All notable changes to the Zowe CLI package will be documented in this file.
 
-- Removed 'z/OS' from zos-files help upload and download methods. [#60](https://github.com/zowe/zowe-cli/issues/60)
+- Removed 'z/OS' from zos-files help upload and download commands. [#60](https://github.com/zowe/zowe-cli/issues/60)
 
 - Enhancement: Added new aliases for zos-files commands in delete, download, and list relating to USS files. You can now interact with `uf` or `uss`.  [#983](https://github.com/zowe/zowe-cli/issues/983)
 

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 All notable changes to the Zowe CLI package will be documented in this file.
 
+- Removed 'z/OS' from zos-files help upload and download methods. [#60](https://github.com/zowe/zowe-cli/issues/60)
+
 - Enhancement: Added new aliases for zos-files commands in delete, download, and list relating to USS files. You can now interact with `uf` or `uss`.  [#983](https://github.com/zowe/zowe-cli/issues/983)
 
 ## `6.31.0`

--- a/packages/cli/src/zosfiles/-strings-/en.ts
+++ b/packages/cli/src/zosfiles/-strings-/en.ts
@@ -271,7 +271,7 @@ export default {
         }
     },
     DOWNLOAD: {
-        SUMMARY: "Download content from z/OS data sets and USS files",
+        SUMMARY: "Download content from data sets and USS files",
         DESCRIPTION: "Download content from z/OS data sets and USS files to your PC",
         ACTIONS: {
             ALL_MEMBERS: {
@@ -509,7 +509,7 @@ export default {
         }
     },
     UPLOAD: {
-        DESCRIPTION: "Upload the contents of a file to z/OS data sets",
+        DESCRIPTION: "Upload the contents of a file to data sets",
         ACTIONS: {
             DIR_TO_PDS: {
                 DESCRIPTION: "Upload files from a local directory to a partitioned data set (PDS)",


### PR DESCRIPTION
Fixed #60 

Updated text for zos-files upload and download commands:
![image](https://user-images.githubusercontent.com/17503994/121591204-33f1d280-ca07-11eb-8832-d7171d338cfd.png)
