### PR TITLE
[next] Make cli-test-utils easier to use for extenders

### DIFF
--- a/__tests__/__packages__/cli-test-utils/CHANGELOG.md
+++ b/__tests__/__packages__/cli-test-utils/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Zowe CLI test utils package will be documented in this file.
 
+## Recent Changes
+
+- Change private methods to protected in `TestEnvironment` class for easier extensibility
+
 ## `7.0.0-next.202104121327`
 
 - Initial release

--- a/__tests__/__packages__/cli-test-utils/package.json
+++ b/__tests__/__packages__/cli-test-utils/package.json
@@ -48,6 +48,6 @@
     "typescript": "^4.2.3"
   },
   "peerDependencies": {
-    "@zowe/imperative": "^5.0.0-next"
+    "@zowe/imperative": ">=5.0.0-next.202106041929 <5.0.0"
   }
 }

--- a/__tests__/__packages__/cli-test-utils/src/environment/TestEnvironment.ts
+++ b/__tests__/__packages__/cli-test-utils/src/environment/TestEnvironment.ts
@@ -112,8 +112,8 @@ export class TestEnvironment {
         return path;
     }
 
-    private static readonly DEFAULT_PROPERTIES = "custom_properties.yaml";
-    private static readonly DEFAULT_PROPERTIES_LOCATION = nodePath.resolve(TEST_RESOURCE_DIR + "/properties") + "/";
+    protected static readonly DEFAULT_PROPERTIES = "custom_properties.yaml";
+    protected static readonly DEFAULT_PROPERTIES_LOCATION = nodePath.resolve(TEST_RESOURCE_DIR + "/properties") + "/";
 
     /**
      *  Load the properties file specified with system test configuration information.
@@ -124,7 +124,7 @@ export class TestEnvironment {
      *  @returns {ITestPropertiesSchema} - The parsed test properties.
      *  @memberof TestEnvironment
      */
-    private static loadSystemTestProperties<T>(filePath: string | null = null, testDirectory: string): T {
+    protected static loadSystemTestProperties<T>(filePath: string | null = null, testDirectory: string): T {
         const logger: Logger = this.getMockFileLogger(testDirectory);
         // For now, I'm leaving the option for env specified properties in code. This will not be documented.
         const propfilename: string = process.env.propfile || TestEnvironment.DEFAULT_PROPERTIES;
@@ -160,7 +160,7 @@ export class TestEnvironment {
      * @param {ITestEnvironment} testEnvironment the test environment so far
      * @returns {Promise<void>} - promise that resolves on completion of the install
      */
-    private static async installPlugin(testEnvironment: ITestEnvironment<any>) {
+    protected static async installPlugin(testEnvironment: ITestEnvironment<any>) {
         const pluginRelPath = nodePath.relative(testEnvironment.workingDir, PROJECT_ROOT_DIR).replace(/\\/g, "/");
         const packageJson = require(nodePath.join(PROJECT_ROOT_DIR, "package.json"));
         const pluginConfig = require(nodePath.join(PROJECT_ROOT_DIR, packageJson.imperative.configurationModule));
@@ -189,7 +189,7 @@ export class TestEnvironment {
      * @param {string} workingDir - the working directory to log to
      * @returns {Logger} - a logger that can be used for test environment clean up and set up
      */
-    private static getMockFileLogger(workingDir: string): Logger {
+    protected static getMockFileLogger(workingDir: string): Logger {
         const logFile = workingDir += "/TestEnvironment.log";
         const logFn = (tag: string, message: string, ...args: any[]) => {
             message = TextUtils.formatMessage(message, ...args);

--- a/package-lock.json
+++ b/package-lock.json
@@ -57,7 +57,7 @@
     },
     "__tests__/__packages__/cli-test-utils": {
       "name": "@zowe/cli-test-utils",
-      "version": "7.0.0-next.202106242030",
+      "version": "7.0.0-next.202106291335",
       "license": "EPL-2.0",
       "dependencies": {
         "@types/js-yaml": "^4.0.0",
@@ -74,7 +74,7 @@
         "typescript": "^4.2.3"
       },
       "peerDependencies": {
-        "@zowe/imperative": "^5.0.0-next"
+        "@zowe/imperative": ">=5.0.0-next.202106041929 <5.0.0"
       }
     },
     "__tests__/__packages__/cli-test-utils/node_modules/@types/node": {
@@ -22066,21 +22066,21 @@
     },
     "packages/cli": {
       "name": "@zowe/cli",
-      "version": "7.0.0-next.202106242030",
+      "version": "7.0.0-next.202106291335",
       "hasInstallScript": true,
       "license": "EPL-2.0",
       "dependencies": {
-        "@zowe/core-for-zowe-sdk": "7.0.0-next.202106242030",
+        "@zowe/core-for-zowe-sdk": "7.0.0-next.202106291335",
         "@zowe/imperative": "5.0.0-next.202106221817",
         "@zowe/perf-timing": "1.0.7",
-        "@zowe/provisioning-for-zowe-sdk": "7.0.0-next.202106242030",
-        "@zowe/zos-console-for-zowe-sdk": "7.0.0-next.202106242030",
-        "@zowe/zos-files-for-zowe-sdk": "7.0.0-next.202106242030",
-        "@zowe/zos-jobs-for-zowe-sdk": "7.0.0-next.202106242030",
-        "@zowe/zos-tso-for-zowe-sdk": "7.0.0-next.202106242030",
-        "@zowe/zos-uss-for-zowe-sdk": "7.0.0-next.202106242030",
-        "@zowe/zos-workflows-for-zowe-sdk": "7.0.0-next.202106242030",
-        "@zowe/zosmf-for-zowe-sdk": "7.0.0-next.202106242030",
+        "@zowe/provisioning-for-zowe-sdk": "7.0.0-next.202106291335",
+        "@zowe/zos-console-for-zowe-sdk": "7.0.0-next.202106291335",
+        "@zowe/zos-files-for-zowe-sdk": "7.0.0-next.202106291335",
+        "@zowe/zos-jobs-for-zowe-sdk": "7.0.0-next.202106291335",
+        "@zowe/zos-tso-for-zowe-sdk": "7.0.0-next.202106291335",
+        "@zowe/zos-uss-for-zowe-sdk": "7.0.0-next.202106291335",
+        "@zowe/zos-workflows-for-zowe-sdk": "7.0.0-next.202106291335",
+        "@zowe/zosmf-for-zowe-sdk": "7.0.0-next.202106291335",
         "get-stdin": "7.0.0",
         "minimatch": "3.0.4"
       },
@@ -22090,7 +22090,7 @@
       },
       "devDependencies": {
         "@types/node": "^12.12.24",
-        "@zowe/cli-test-utils": "7.0.0-next.202106242030",
+        "@zowe/cli-test-utils": "7.0.0-next.202106291335",
         "js-yaml": "^3.13.1",
         "madge": "^4.0.1",
         "rimraf": "^2.6.3",
@@ -22115,7 +22115,7 @@
     },
     "packages/core": {
       "name": "@zowe/core-for-zowe-sdk",
-      "version": "7.0.0-next.202106242030",
+      "version": "7.0.0-next.202106291335",
       "license": "EPL-2.0",
       "dependencies": {
         "comment-json": "4.1.0",
@@ -22123,7 +22123,7 @@
       },
       "devDependencies": {
         "@types/node": "^12.12.24",
-        "@zowe/cli-test-utils": "7.0.0-next.202106242030",
+        "@zowe/cli-test-utils": "7.0.0-next.202106291335",
         "@zowe/imperative": "5.0.0-next.202106221817",
         "chalk": "^4.1.0",
         "madge": "^4.0.1",
@@ -22138,7 +22138,7 @@
     },
     "packages/provisioning": {
       "name": "@zowe/provisioning-for-zowe-sdk",
-      "version": "7.0.0-next.202106242030",
+      "version": "7.0.0-next.202106291335",
       "license": "EPL-2.0",
       "dependencies": {
         "js-yaml": "3.13.1"
@@ -22146,8 +22146,8 @@
       "devDependencies": {
         "@types/js-yaml": "^3.12.5",
         "@types/node": "^12.12.24",
-        "@zowe/cli-test-utils": "7.0.0-next.202106242030",
-        "@zowe/core-for-zowe-sdk": "7.0.0-next.202106242030",
+        "@zowe/cli-test-utils": "7.0.0-next.202106291335",
+        "@zowe/core-for-zowe-sdk": "7.0.0-next.202106291335",
         "@zowe/imperative": "5.0.0-next.202106221817",
         "madge": "^4.0.1",
         "rimraf": "^2.6.3",
@@ -22188,15 +22188,15 @@
     },
     "packages/workflows": {
       "name": "@zowe/zos-workflows-for-zowe-sdk",
-      "version": "7.0.0-next.202106242030",
+      "version": "7.0.0-next.202106291335",
       "license": "EPL-2.0",
       "dependencies": {
-        "@zowe/zos-files-for-zowe-sdk": "7.0.0-next.202106242030"
+        "@zowe/zos-files-for-zowe-sdk": "7.0.0-next.202106291335"
       },
       "devDependencies": {
         "@types/node": "^12.12.24",
-        "@zowe/cli-test-utils": "7.0.0-next.202106242030",
-        "@zowe/core-for-zowe-sdk": "7.0.0-next.202106242030",
+        "@zowe/cli-test-utils": "7.0.0-next.202106291335",
+        "@zowe/core-for-zowe-sdk": "7.0.0-next.202106291335",
         "@zowe/imperative": "5.0.0-next.202106221817",
         "madge": "^4.0.1",
         "rimraf": "^2.6.3",
@@ -22211,12 +22211,12 @@
     },
     "packages/zosconsole": {
       "name": "@zowe/zos-console-for-zowe-sdk",
-      "version": "7.0.0-next.202106242030",
+      "version": "7.0.0-next.202106291335",
       "license": "EPL-2.0",
       "devDependencies": {
         "@types/node": "^12.12.24",
-        "@zowe/cli-test-utils": "7.0.0-next.202106242030",
-        "@zowe/core-for-zowe-sdk": "7.0.0-next.202106242030",
+        "@zowe/cli-test-utils": "7.0.0-next.202106291335",
+        "@zowe/core-for-zowe-sdk": "7.0.0-next.202106291335",
         "@zowe/imperative": "5.0.0-next.202106221817",
         "madge": "^4.0.1",
         "rimraf": "^2.6.3",
@@ -22231,17 +22231,17 @@
     },
     "packages/zosfiles": {
       "name": "@zowe/zos-files-for-zowe-sdk",
-      "version": "7.0.0-next.202106242030",
+      "version": "7.0.0-next.202106291335",
       "license": "EPL-2.0",
       "dependencies": {
         "minimatch": "3.0.4"
       },
       "devDependencies": {
         "@types/node": "^12.12.24",
-        "@zowe/cli-test-utils": "7.0.0-next.202106242030",
-        "@zowe/core-for-zowe-sdk": "7.0.0-next.202106242030",
+        "@zowe/cli-test-utils": "7.0.0-next.202106291335",
+        "@zowe/core-for-zowe-sdk": "7.0.0-next.202106291335",
         "@zowe/imperative": "5.0.0-next.202106221817",
-        "@zowe/zos-uss-for-zowe-sdk": "7.0.0-next.202106242030",
+        "@zowe/zos-uss-for-zowe-sdk": "7.0.0-next.202106291335",
         "madge": "^4.0.1",
         "rimraf": "^2.6.3",
         "tslint": "^6.1.3",
@@ -22255,15 +22255,15 @@
     },
     "packages/zosjobs": {
       "name": "@zowe/zos-jobs-for-zowe-sdk",
-      "version": "7.0.0-next.202106242030",
+      "version": "7.0.0-next.202106291335",
       "license": "EPL-2.0",
       "dependencies": {
-        "@zowe/zos-files-for-zowe-sdk": "7.0.0-next.202106242030"
+        "@zowe/zos-files-for-zowe-sdk": "7.0.0-next.202106291335"
       },
       "devDependencies": {
         "@types/node": "^12.12.24",
-        "@zowe/cli-test-utils": "7.0.0-next.202106242030",
-        "@zowe/core-for-zowe-sdk": "7.0.0-next.202106242030",
+        "@zowe/cli-test-utils": "7.0.0-next.202106291335",
+        "@zowe/core-for-zowe-sdk": "7.0.0-next.202106291335",
         "@zowe/imperative": "5.0.0-next.202106221817",
         "madge": "^4.0.1",
         "rimraf": "^2.6.3",
@@ -22278,12 +22278,12 @@
     },
     "packages/zosmf": {
       "name": "@zowe/zosmf-for-zowe-sdk",
-      "version": "7.0.0-next.202106242030",
+      "version": "7.0.0-next.202106291335",
       "license": "EPL-2.0",
       "devDependencies": {
         "@types/node": "^12.12.24",
-        "@zowe/cli-test-utils": "7.0.0-next.202106242030",
-        "@zowe/core-for-zowe-sdk": "7.0.0-next.202106242030",
+        "@zowe/cli-test-utils": "7.0.0-next.202106291335",
+        "@zowe/core-for-zowe-sdk": "7.0.0-next.202106291335",
         "@zowe/imperative": "5.0.0-next.202106221817",
         "madge": "^4.0.1",
         "rimraf": "^2.6.3",
@@ -22298,15 +22298,15 @@
     },
     "packages/zostso": {
       "name": "@zowe/zos-tso-for-zowe-sdk",
-      "version": "7.0.0-next.202106242030",
+      "version": "7.0.0-next.202106291335",
       "license": "EPL-2.0",
       "dependencies": {
-        "@zowe/zosmf-for-zowe-sdk": "7.0.0-next.202106242030"
+        "@zowe/zosmf-for-zowe-sdk": "7.0.0-next.202106291335"
       },
       "devDependencies": {
         "@types/node": "^12.12.24",
-        "@zowe/cli-test-utils": "7.0.0-next.202106242030",
-        "@zowe/core-for-zowe-sdk": "7.0.0-next.202106242030",
+        "@zowe/cli-test-utils": "7.0.0-next.202106291335",
+        "@zowe/core-for-zowe-sdk": "7.0.0-next.202106291335",
         "@zowe/imperative": "5.0.0-next.202106221817",
         "madge": "^4.0.1",
         "rimraf": "^2.6.3",
@@ -22321,7 +22321,7 @@
     },
     "packages/zosuss": {
       "name": "@zowe/zos-uss-for-zowe-sdk",
-      "version": "7.0.0-next.202106242030",
+      "version": "7.0.0-next.202106291335",
       "license": "EPL-2.0",
       "dependencies": {
         "ssh2": "0.8.7"
@@ -22329,7 +22329,7 @@
       "devDependencies": {
         "@types/node": "^12.12.24",
         "@types/ssh2": "^0.5.44",
-        "@zowe/cli-test-utils": "7.0.0-next.202106242030",
+        "@zowe/cli-test-utils": "7.0.0-next.202106291335",
         "@zowe/imperative": "5.0.0-next.202106221817",
         "madge": "^4.0.1",
         "rimraf": "^2.6.3",
@@ -25646,18 +25646,18 @@
       "version": "file:packages/cli",
       "requires": {
         "@types/node": "^12.12.24",
-        "@zowe/cli-test-utils": "7.0.0-next.202106242030",
-        "@zowe/core-for-zowe-sdk": "7.0.0-next.202106242030",
+        "@zowe/cli-test-utils": "7.0.0-next.202106291335",
+        "@zowe/core-for-zowe-sdk": "7.0.0-next.202106291335",
         "@zowe/imperative": "5.0.0-next.202106221817",
         "@zowe/perf-timing": "1.0.7",
-        "@zowe/provisioning-for-zowe-sdk": "7.0.0-next.202106242030",
-        "@zowe/zos-console-for-zowe-sdk": "7.0.0-next.202106242030",
-        "@zowe/zos-files-for-zowe-sdk": "7.0.0-next.202106242030",
-        "@zowe/zos-jobs-for-zowe-sdk": "7.0.0-next.202106242030",
-        "@zowe/zos-tso-for-zowe-sdk": "7.0.0-next.202106242030",
-        "@zowe/zos-uss-for-zowe-sdk": "7.0.0-next.202106242030",
-        "@zowe/zos-workflows-for-zowe-sdk": "7.0.0-next.202106242030",
-        "@zowe/zosmf-for-zowe-sdk": "7.0.0-next.202106242030",
+        "@zowe/provisioning-for-zowe-sdk": "7.0.0-next.202106291335",
+        "@zowe/zos-console-for-zowe-sdk": "7.0.0-next.202106291335",
+        "@zowe/zos-files-for-zowe-sdk": "7.0.0-next.202106291335",
+        "@zowe/zos-jobs-for-zowe-sdk": "7.0.0-next.202106291335",
+        "@zowe/zos-tso-for-zowe-sdk": "7.0.0-next.202106291335",
+        "@zowe/zos-uss-for-zowe-sdk": "7.0.0-next.202106291335",
+        "@zowe/zos-workflows-for-zowe-sdk": "7.0.0-next.202106291335",
+        "@zowe/zosmf-for-zowe-sdk": "7.0.0-next.202106291335",
         "get-stdin": "7.0.0",
         "js-yaml": "^3.13.1",
         "keytar": "7.7.0",
@@ -25731,7 +25731,7 @@
       "version": "file:packages/core",
       "requires": {
         "@types/node": "^12.12.24",
-        "@zowe/cli-test-utils": "7.0.0-next.202106242030",
+        "@zowe/cli-test-utils": "7.0.0-next.202106291335",
         "@zowe/imperative": "5.0.0-next.202106221817",
         "chalk": "^4.1.0",
         "comment-json": "4.1.0",
@@ -25915,8 +25915,8 @@
       "requires": {
         "@types/js-yaml": "^3.12.5",
         "@types/node": "^12.12.24",
-        "@zowe/cli-test-utils": "7.0.0-next.202106242030",
-        "@zowe/core-for-zowe-sdk": "7.0.0-next.202106242030",
+        "@zowe/cli-test-utils": "7.0.0-next.202106291335",
+        "@zowe/core-for-zowe-sdk": "7.0.0-next.202106291335",
         "@zowe/imperative": "5.0.0-next.202106221817",
         "js-yaml": "3.13.1",
         "madge": "^4.0.1",
@@ -25955,8 +25955,8 @@
       "version": "file:packages/zosconsole",
       "requires": {
         "@types/node": "^12.12.24",
-        "@zowe/cli-test-utils": "7.0.0-next.202106242030",
-        "@zowe/core-for-zowe-sdk": "7.0.0-next.202106242030",
+        "@zowe/cli-test-utils": "7.0.0-next.202106291335",
+        "@zowe/core-for-zowe-sdk": "7.0.0-next.202106291335",
         "@zowe/imperative": "5.0.0-next.202106221817",
         "madge": "^4.0.1",
         "rimraf": "^2.6.3",
@@ -25969,10 +25969,10 @@
       "version": "file:packages/zosfiles",
       "requires": {
         "@types/node": "^12.12.24",
-        "@zowe/cli-test-utils": "7.0.0-next.202106242030",
-        "@zowe/core-for-zowe-sdk": "7.0.0-next.202106242030",
+        "@zowe/cli-test-utils": "7.0.0-next.202106291335",
+        "@zowe/core-for-zowe-sdk": "7.0.0-next.202106291335",
         "@zowe/imperative": "5.0.0-next.202106221817",
-        "@zowe/zos-uss-for-zowe-sdk": "7.0.0-next.202106242030",
+        "@zowe/zos-uss-for-zowe-sdk": "7.0.0-next.202106291335",
         "madge": "^4.0.1",
         "minimatch": "3.0.4",
         "rimraf": "^2.6.3",
@@ -25985,10 +25985,10 @@
       "version": "file:packages/zosjobs",
       "requires": {
         "@types/node": "^12.12.24",
-        "@zowe/cli-test-utils": "7.0.0-next.202106242030",
-        "@zowe/core-for-zowe-sdk": "7.0.0-next.202106242030",
+        "@zowe/cli-test-utils": "7.0.0-next.202106291335",
+        "@zowe/core-for-zowe-sdk": "7.0.0-next.202106291335",
         "@zowe/imperative": "5.0.0-next.202106221817",
-        "@zowe/zos-files-for-zowe-sdk": "7.0.0-next.202106242030",
+        "@zowe/zos-files-for-zowe-sdk": "7.0.0-next.202106291335",
         "madge": "^4.0.1",
         "rimraf": "^2.6.3",
         "tslint": "^6.1.3",
@@ -26000,10 +26000,10 @@
       "version": "file:packages/zostso",
       "requires": {
         "@types/node": "^12.12.24",
-        "@zowe/cli-test-utils": "7.0.0-next.202106242030",
-        "@zowe/core-for-zowe-sdk": "7.0.0-next.202106242030",
+        "@zowe/cli-test-utils": "7.0.0-next.202106291335",
+        "@zowe/core-for-zowe-sdk": "7.0.0-next.202106291335",
         "@zowe/imperative": "5.0.0-next.202106221817",
-        "@zowe/zosmf-for-zowe-sdk": "7.0.0-next.202106242030",
+        "@zowe/zosmf-for-zowe-sdk": "7.0.0-next.202106291335",
         "madge": "^4.0.1",
         "rimraf": "^2.6.3",
         "tslint": "^6.1.3",
@@ -26016,7 +26016,7 @@
       "requires": {
         "@types/node": "^12.12.24",
         "@types/ssh2": "^0.5.44",
-        "@zowe/cli-test-utils": "7.0.0-next.202106242030",
+        "@zowe/cli-test-utils": "7.0.0-next.202106291335",
         "@zowe/imperative": "5.0.0-next.202106221817",
         "madge": "^4.0.1",
         "rimraf": "^2.6.3",
@@ -26030,10 +26030,10 @@
       "version": "file:packages/workflows",
       "requires": {
         "@types/node": "^12.12.24",
-        "@zowe/cli-test-utils": "7.0.0-next.202106242030",
-        "@zowe/core-for-zowe-sdk": "7.0.0-next.202106242030",
+        "@zowe/cli-test-utils": "7.0.0-next.202106291335",
+        "@zowe/core-for-zowe-sdk": "7.0.0-next.202106291335",
         "@zowe/imperative": "5.0.0-next.202106221817",
-        "@zowe/zos-files-for-zowe-sdk": "7.0.0-next.202106242030",
+        "@zowe/zos-files-for-zowe-sdk": "7.0.0-next.202106291335",
         "madge": "^4.0.1",
         "rimraf": "^2.6.3",
         "tslint": "^6.1.3",
@@ -26045,8 +26045,8 @@
       "version": "file:packages/zosmf",
       "requires": {
         "@types/node": "^12.12.24",
-        "@zowe/cli-test-utils": "7.0.0-next.202106242030",
-        "@zowe/core-for-zowe-sdk": "7.0.0-next.202106242030",
+        "@zowe/cli-test-utils": "7.0.0-next.202106291335",
+        "@zowe/core-for-zowe-sdk": "7.0.0-next.202106291335",
         "@zowe/imperative": "5.0.0-next.202106221817",
         "madge": "^4.0.1",
         "rimraf": "^2.6.3",


### PR DESCRIPTION
* Update Imperative peer dep in cli-test-utils
* Change private methods to protected in TestEnvironment 