### PR TITLE
Make zowex Linux binary compatible with more distros

### DIFF
--- a/.github/workflows/rust-cli-publish.yml
+++ b/.github/workflows/rust-cli-publish.yml
@@ -118,6 +118,13 @@ jobs:
 
     steps:
 
+    - name: Install Rust toolchain
+      uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: stable
+        override: true
+
     - uses: actions/download-artifact@v2
       with:
         name: repo

--- a/.github/workflows/rust-cli-publish.yml
+++ b/.github/workflows/rust-cli-publish.yml
@@ -50,65 +50,17 @@ jobs:
           zowex/**
           !.git
 
-  build-macos:
+
+  build-linux:
     name: Build
 
     needs: release
 
-    runs-on: ${{ matrix.os }}
-
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [macos-latest]
-
-    steps:
-
-    - uses: actions/download-artifact@v2
-      with:
-        name: repo
-
-    - name: Build
-      run: cargo build --verbose --release
-
-    - name: Get Upload URL
-      id: get_upload_url
-      run: echo "::set-output name=upload_url::$(cat release_url.txt)"
-
-    - run: echo ${{ steps.get_upload_url.outputs.upload_url }}
-
-    - name: Create Archive
-      run: |
-        cd target/release
-        tar -cvzf zowex.tgz zowex
-
-    - name: Upload Release Asset
-      id: upload-release-asset
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.get_upload_url.outputs.upload_url }}
-        asset_path: target/release/zowex.tgz
-        asset_name: "${{matrix.os}}/zowex.tgz"
-        asset_content_type: application/octet-stream
-
-
-  build-ubuntu:
-    name: Build
-
-    needs: release
-
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
 
     # Need to build in container with old version of GLIBC to support RHEL 7
     # https://kobzol.github.io/rust/ci/2021/05/07/building-rust-binaries-in-ci-that-work-with-older-glibc.html
     container: quay.io/pypa/manylinux2014_x86_64
-
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest]
 
     steps:
 
@@ -145,7 +97,46 @@ jobs:
       with:
         upload_url: ${{ steps.get_upload_url.outputs.upload_url }}
         asset_path: target/release/zowex.tgz
-        asset_name: "${{matrix.os}}/zowex.tgz"
+        asset_name: zowex-linux.tgz
+        asset_content_type: application/octet-stream
+
+
+  build-macos:
+    name: Build
+
+    needs: release
+
+    runs-on: macos-latest
+
+    steps:
+
+    - uses: actions/download-artifact@v2
+      with:
+        name: repo
+
+    - name: Build
+      run: cargo build --verbose --release
+
+    - name: Get Upload URL
+      id: get_upload_url
+      run: echo "::set-output name=upload_url::$(cat release_url.txt)"
+
+    - run: echo ${{ steps.get_upload_url.outputs.upload_url }}
+
+    - name: Create Archive
+      run: |
+        cd target/release
+        tar -cvzf zowex.tgz zowex
+
+    - name: Upload Release Asset
+      id: upload-release-asset
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.get_upload_url.outputs.upload_url }}
+        asset_path: target/release/zowex.tgz
+        asset_name: zowex-macos.tgz
         asset_content_type: application/octet-stream
 
 
@@ -154,12 +145,7 @@ jobs:
 
     needs: release
 
-    runs-on: ${{ matrix.os }}
-
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [windows-latest]
+    runs-on: windows-latest
 
     steps:
 
@@ -189,5 +175,5 @@ jobs:
       with:
         upload_url: ${{ steps.get_upload_url.outputs.upload_url }}
         asset_path: target\release\zowex.tgz
-        asset_name: "${{matrix.os}}/zowex.tgz"
+        asset_name: zowex-windows.tgz
         asset_content_type: application/octet-stream

--- a/.github/workflows/rust-cli-publish.yml
+++ b/.github/workflows/rust-cli-publish.yml
@@ -5,6 +5,7 @@ on:
     branches:
         - "master"
         - "next"
+        - "next-zowex-rhel7"  # TODO Delete me
     paths:
     - 'zowex/**'
     - '.github/workflows/rust-cli*.yml'
@@ -25,21 +26,22 @@ jobs:
         cd zowex
         echo "::set-output name=ZOWEX_VERSION::$(cargo pkgid | cut -d# -f2 | cut -d: -f2)"
 
-    - name: Create Release
-      id: create_release
-      uses: actions/create-release@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        tag_name: native-v${{ steps.get-version.outputs.ZOWEX_VERSION }}
-        release_name: Native Client Release ${{ steps.get-version.outputs.ZOWEX_VERSION }}
-        body: |
-          Native Zowe CLI client which communicates with a "daemon" version of Zowe CLI.
-        draft: false
-        prerelease: false
+    # - name: Create Release
+    #   id: create_release
+    #   uses: actions/create-release@v1
+    #   env:
+    #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    #   with:
+    #     tag_name: native-v${{ steps.get-version.outputs.ZOWEX_VERSION }}
+    #     release_name: Native Client Release ${{ steps.get-version.outputs.ZOWEX_VERSION }}
+    #     body: |
+    #       Native Zowe CLI client which communicates with a "daemon" version of Zowe CLI.
+    #     draft: false
+    #     prerelease: false
 
     - name: Output Release URL File
-      run: echo "${{ steps.create_release.outputs.upload_url }}" > zowex/release_url.txt
+      # run: echo "${{ steps.create_release.outputs.upload_url }}" > zowex/release_url.txt
+      run: echo "fake_release_url" > zowex/release_url.txt
 
     - run: "ls -la"
 
@@ -50,7 +52,7 @@ jobs:
           zowex/**
           !.git
 
-  build-ubuntu-mac:
+  build-macos:
     name: Build
 
     needs: release
@@ -60,7 +62,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [macos-latest]
 
     steps:
 
@@ -82,16 +84,72 @@ jobs:
         cd target/release
         tar -cvzf zowex.tgz zowex
 
-    - name: Upload Release Asset
-      id: upload-release-asset
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    # - name: Upload Release Asset
+    #   id: upload-release-asset
+    #   uses: actions/upload-release-asset@v1
+    #   env:
+    #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    #   with:
+    #     upload_url: ${{ steps.get_upload_url.outputs.upload_url }}
+    #     asset_path: target/release/zowex.tgz
+    #     asset_name: "${{matrix.os}}/zowex.tgz"
+    #     asset_content_type: application/octet-stream
+    - uses: actions/upload-artifact@v2
       with:
-        upload_url: ${{ steps.get_upload_url.outputs.upload_url }}
-        asset_path: target/release/zowex.tgz
-        asset_name: "${{matrix.os}}/zowex.tgz"
-        asset_content_type: application/octet-stream
+        name: "zowex-${{matrix.os}}"
+        path: target/release/zowex.tgz
+
+
+  build-ubuntu:
+    name: Build
+
+    needs: release
+
+    runs-on: ${{ matrix.os }}
+
+    # Need to build in container with old version of GLIBC to support RHEL 7
+    # https://kobzol.github.io/rust/ci/2021/05/07/building-rust-binaries-in-ci-that-work-with-older-glibc.html
+    container: quay.io/pypa/manylinux2014_x86_64
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+
+    steps:
+
+    - uses: actions/download-artifact@v2
+      with:
+        name: repo
+
+    - name: Build
+      run: cargo build --verbose --release
+
+    - name: Get Upload URL
+      id: get_upload_url
+      run: echo "::set-output name=upload_url::$(cat release_url.txt)"
+
+    - run: echo ${{ steps.get_upload_url.outputs.upload_url }}
+
+    - name: Create Archive
+      run: |
+        cd target/release
+        tar -cvzf zowex.tgz zowex
+
+    # - name: Upload Release Asset
+    #   id: upload-release-asset
+    #   uses: actions/upload-release-asset@v1
+    #   env:
+    #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    #   with:
+    #     upload_url: ${{ steps.get_upload_url.outputs.upload_url }}
+    #     asset_path: target/release/zowex.tgz
+    #     asset_name: "${{matrix.os}}/zowex.tgz"
+    #     asset_content_type: application/octet-stream
+    - uses: actions/upload-artifact@v2
+      with:
+        name: "zowex-${{matrix.os}}"
+        path: target/release/zowex.tgz
 
 
   build-windows:
@@ -126,13 +184,17 @@ jobs:
         cd target/release
         tar -cvzf zowex.tgz zowex.exe
 
-    - name: Upload Release Asset
-      id: upload-release-asset
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    # - name: Upload Release Asset
+    #   id: upload-release-asset
+    #   uses: actions/upload-release-asset@v1
+    #   env:
+    #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    #   with:
+    #     upload_url: ${{ steps.get_upload_url.outputs.upload_url }}
+    #     asset_path: target\release\zowex.tgz
+    #     asset_name: "${{matrix.os}}/zowex.tgz"
+    #     asset_content_type: application/octet-stream
+    - uses: actions/upload-artifact@v2
       with:
-        upload_url: ${{ steps.get_upload_url.outputs.upload_url }}
-        asset_path: target\release\zowex.tgz
-        asset_name: "${{matrix.os}}/zowex.tgz"
-        asset_content_type: application/octet-stream
+        name: "zowex-${{matrix.os}}"
+        path: target/release/zowex.tgz

--- a/.github/workflows/rust-cli-publish.yml
+++ b/.github/workflows/rust-cli-publish.yml
@@ -5,7 +5,6 @@ on:
     branches:
         - "master"
         - "next"
-        - "next-zowex-rhel7"  # TODO Delete me
     paths:
     - 'zowex/**'
     - '.github/workflows/rust-cli*.yml'
@@ -26,22 +25,21 @@ jobs:
         cd zowex
         echo "::set-output name=ZOWEX_VERSION::$(cargo pkgid | cut -d# -f2 | cut -d: -f2)"
 
-    # - name: Create Release
-    #   id: create_release
-    #   uses: actions/create-release@v1
-    #   env:
-    #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    #   with:
-    #     tag_name: native-v${{ steps.get-version.outputs.ZOWEX_VERSION }}
-    #     release_name: Native Client Release ${{ steps.get-version.outputs.ZOWEX_VERSION }}
-    #     body: |
-    #       Native Zowe CLI client which communicates with a "daemon" version of Zowe CLI.
-    #     draft: false
-    #     prerelease: false
+    - name: Create Release
+      id: create_release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: native-v${{ steps.get-version.outputs.ZOWEX_VERSION }}
+        release_name: Native Client Release ${{ steps.get-version.outputs.ZOWEX_VERSION }}
+        body: |
+          Native Zowe CLI client which communicates with a "daemon" version of Zowe CLI.
+        draft: false
+        prerelease: false
 
     - name: Output Release URL File
-      # run: echo "${{ steps.create_release.outputs.upload_url }}" > zowex/release_url.txt
-      run: echo "fake_release_url" > zowex/release_url.txt
+      run: echo "${{ steps.create_release.outputs.upload_url }}" > zowex/release_url.txt
 
     - run: "ls -la"
 
@@ -84,20 +82,16 @@ jobs:
         cd target/release
         tar -cvzf zowex.tgz zowex
 
-    # - name: Upload Release Asset
-    #   id: upload-release-asset
-    #   uses: actions/upload-release-asset@v1
-    #   env:
-    #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    #   with:
-    #     upload_url: ${{ steps.get_upload_url.outputs.upload_url }}
-    #     asset_path: target/release/zowex.tgz
-    #     asset_name: "${{matrix.os}}/zowex.tgz"
-    #     asset_content_type: application/octet-stream
-    - uses: actions/upload-artifact@v2
+    - name: Upload Release Asset
+      id: upload-release-asset
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        name: "zowex-${{matrix.os}}"
-        path: target/release/zowex.tgz
+        upload_url: ${{ steps.get_upload_url.outputs.upload_url }}
+        asset_path: target/release/zowex.tgz
+        asset_name: "${{matrix.os}}/zowex.tgz"
+        asset_content_type: application/octet-stream
 
 
   build-ubuntu:
@@ -143,20 +137,16 @@ jobs:
         cd target/release
         tar -cvzf zowex.tgz zowex
 
-    # - name: Upload Release Asset
-    #   id: upload-release-asset
-    #   uses: actions/upload-release-asset@v1
-    #   env:
-    #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    #   with:
-    #     upload_url: ${{ steps.get_upload_url.outputs.upload_url }}
-    #     asset_path: target/release/zowex.tgz
-    #     asset_name: "${{matrix.os}}/zowex.tgz"
-    #     asset_content_type: application/octet-stream
-    - uses: actions/upload-artifact@v2
+    - name: Upload Release Asset
+      id: upload-release-asset
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        name: "zowex-${{matrix.os}}"
-        path: target/release/zowex.tgz
+        upload_url: ${{ steps.get_upload_url.outputs.upload_url }}
+        asset_path: target/release/zowex.tgz
+        asset_name: "${{matrix.os}}/zowex.tgz"
+        asset_content_type: application/octet-stream
 
 
   build-windows:
@@ -191,17 +181,13 @@ jobs:
         cd target/release
         tar -cvzf zowex.tgz zowex.exe
 
-    # - name: Upload Release Asset
-    #   id: upload-release-asset
-    #   uses: actions/upload-release-asset@v1
-    #   env:
-    #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    #   with:
-    #     upload_url: ${{ steps.get_upload_url.outputs.upload_url }}
-    #     asset_path: target\release\zowex.tgz
-    #     asset_name: "${{matrix.os}}/zowex.tgz"
-    #     asset_content_type: application/octet-stream
-    - uses: actions/upload-artifact@v2
+    - name: Upload Release Asset
+      id: upload-release-asset
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        name: "zowex-${{matrix.os}}"
-        path: target/release/zowex.tgz
+        upload_url: ${{ steps.get_upload_url.outputs.upload_url }}
+        asset_path: target\release\zowex.tgz
+        asset_name: "${{matrix.os}}/zowex.tgz"
+        asset_content_type: application/octet-stream

--- a/zowex/Cargo.lock
+++ b/zowex/Cargo.lock
@@ -40,7 +40,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "zowex"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "rpassword",
 ]

--- a/zowex/Cargo.toml
+++ b/zowex/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zowex"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Zowe Project"]
 edition = "2018"
 


### PR DESCRIPTION
Python/PIP/PyPI provides ManyLinux Docker images which can be used to build binaries that support as many Linux distros as possible.

Building the zowex Linux binary in a ManyLinux Docker container (as suggested [here](https://kobzol.github.io/rust/ci/2021/05/07/building-rust-binaries-in-ci-that-work-with-older-glibc.html)) relaxes the GLIBC version requirement, which makes it compatible with CentOS/RHEL 7.

I've tested the binary generated by the GitHub workflow to verify that it works on both Ubuntu 20.04 and RHEL 7: https://github.com/zowe/zowe-cli/actions/runs/1052534508

When this PR is merged, it will publish a patch release (v0.2.1) of "zowex", and we can mention in the release notes that you don't need to update if running on a system where the "zowex" binary already worked 🙂 