### PR TITLE
Update Imperative package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
         "packages/*"
       ],
       "dependencies": {
-        "@zowe/imperative": "4.13.4",
+        "@zowe/imperative": "4.15.0",
         "@zowe/perf-timing": "1.0.7"
       },
       "devDependencies": {
@@ -4001,9 +4001,9 @@
       "link": true
     },
     "node_modules/@zowe/imperative": {
-      "version": "4.13.4",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@zowe/imperative/-/@zowe/imperative-4.13.4.tgz",
-      "integrity": "sha1-tx0jS5N8Yy4gVrft47/rLTW2ah4=",
+      "version": "4.15.0",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@zowe/imperative/-/@zowe/imperative-4.15.0.tgz",
+      "integrity": "sha1-pEgdDXSIKU2KEtnSAA9LxsVm95o=",
       "license": "EPL-2.0",
       "dependencies": {
         "@types/lodash-deep": "2.0.0",
@@ -4013,13 +4013,13 @@
         "cli-table3": "0.5.1",
         "dataobject-parser": "1.2.1",
         "deepmerge": "3.0.0",
+        "fastest-levenshtein": "1.0.12",
         "find-up": "2.1.0",
         "fs-extra": "8.1.0",
         "glob": "7.1.6",
         "js-yaml": "3.13.1",
         "jsonfile": "4.0.0",
         "jsonschema": "1.1.1",
-        "levenshtein": "1.0.5",
         "lodash-deep": "2.0.0",
         "log4js": "6.3.0",
         "markdown-it": "12.0.4",
@@ -7839,6 +7839,11 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
+    },
+    "node_modules/fastest-levenshtein": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.12.tgz",
+      "integrity": "sha512-On2N+BpYJ15xIC974QNVuYGMOlEVt4s0EOI3wwMqOmK1fdDY+FN/zltPV8vosq4ad4c/gJ1KHScUn/6AWIgiow=="
     },
     "node_modules/fastq": {
       "version": "1.11.0",
@@ -13971,14 +13976,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/levenshtein": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/levenshtein/-/levenshtein-1.0.5.tgz",
-      "integrity": "sha1-ORFzepy1baNF0Aj1V4LG8TiXm6M=",
-      "engines": [
-        "node >=0.2.0"
-      ]
     },
     "node_modules/levn": {
       "version": "0.3.0",
@@ -21590,12 +21587,12 @@
     },
     "packages/cli": {
       "name": "@zowe/cli",
-      "version": "6.32.1",
+      "version": "6.32.2",
       "hasInstallScript": true,
       "license": "EPL-2.0",
       "dependencies": {
         "@zowe/core-for-zowe-sdk": "6.32.1",
-        "@zowe/imperative": "4.13.4",
+        "@zowe/imperative": "4.15.0",
         "@zowe/perf-timing": "1.0.7",
         "@zowe/provisioning-for-zowe-sdk": "6.32.1",
         "@zowe/zos-console-for-zowe-sdk": "6.32.1",
@@ -21642,7 +21639,7 @@
       },
       "devDependencies": {
         "@types/node": "^12.12.24",
-        "@zowe/imperative": "4.13.4",
+        "@zowe/imperative": "4.15.0",
         "chalk": "^4.1.0",
         "madge": "^4.0.1",
         "rimraf": "^2.6.3",
@@ -21665,7 +21662,7 @@
         "@types/js-yaml": "^3.12.5",
         "@types/node": "^12.12.24",
         "@zowe/core-for-zowe-sdk": "6.32.1",
-        "@zowe/imperative": "4.13.4",
+        "@zowe/imperative": "4.15.0",
         "madge": "^4.0.1",
         "rimraf": "^2.6.3",
         "tslint": "^6.1.3",
@@ -21699,7 +21696,7 @@
       "devDependencies": {
         "@types/node": "^12.12.24",
         "@zowe/core-for-zowe-sdk": "6.32.1",
-        "@zowe/imperative": "4.13.4",
+        "@zowe/imperative": "4.15.0",
         "madge": "^4.0.1",
         "rimraf": "^2.6.3",
         "tslint": "^6.1.3",
@@ -21718,7 +21715,7 @@
       "devDependencies": {
         "@types/node": "^12.12.24",
         "@zowe/core-for-zowe-sdk": "6.32.1",
-        "@zowe/imperative": "4.13.4",
+        "@zowe/imperative": "4.15.0",
         "madge": "^4.0.1",
         "rimraf": "^2.6.3",
         "tslint": "^6.1.3",
@@ -21740,7 +21737,7 @@
       "devDependencies": {
         "@types/node": "^12.12.24",
         "@zowe/core-for-zowe-sdk": "6.32.1",
-        "@zowe/imperative": "4.13.4",
+        "@zowe/imperative": "4.15.0",
         "@zowe/zos-uss-for-zowe-sdk": "6.32.1",
         "madge": "^4.0.1",
         "rimraf": "^2.6.3",
@@ -21763,7 +21760,7 @@
       "devDependencies": {
         "@types/node": "^12.12.24",
         "@zowe/core-for-zowe-sdk": "6.32.1",
-        "@zowe/imperative": "4.13.4",
+        "@zowe/imperative": "4.15.0",
         "madge": "^4.0.1",
         "rimraf": "^2.6.3",
         "tslint": "^6.1.3",
@@ -21782,7 +21779,7 @@
       "devDependencies": {
         "@types/node": "^12.12.24",
         "@zowe/core-for-zowe-sdk": "6.32.1",
-        "@zowe/imperative": "4.13.4",
+        "@zowe/imperative": "4.15.0",
         "madge": "^4.0.1",
         "rimraf": "^2.6.3",
         "tslint": "^6.1.3",
@@ -21804,7 +21801,7 @@
       "devDependencies": {
         "@types/node": "^12.12.24",
         "@zowe/core-for-zowe-sdk": "6.32.1",
-        "@zowe/imperative": "4.13.4",
+        "@zowe/imperative": "4.15.0",
         "madge": "^4.0.1",
         "rimraf": "^2.6.3",
         "tslint": "^6.1.3",
@@ -21826,7 +21823,7 @@
       "devDependencies": {
         "@types/node": "^12.12.24",
         "@types/ssh2": "^0.5.44",
-        "@zowe/imperative": "4.13.4",
+        "@zowe/imperative": "4.15.0",
         "madge": "^4.0.1",
         "rimraf": "^2.6.3",
         "tslint": "^6.1.3",
@@ -25142,7 +25139,7 @@
       "requires": {
         "@types/node": "^12.12.24",
         "@zowe/core-for-zowe-sdk": "6.32.1",
-        "@zowe/imperative": "4.13.4",
+        "@zowe/imperative": "4.15.0",
         "@zowe/perf-timing": "1.0.7",
         "@zowe/provisioning-for-zowe-sdk": "6.32.1",
         "@zowe/zos-console-for-zowe-sdk": "6.32.1",
@@ -25173,7 +25170,7 @@
       "version": "file:packages/core",
       "requires": {
         "@types/node": "^12.12.24",
-        "@zowe/imperative": "4.13.4",
+        "@zowe/imperative": "4.15.0",
         "chalk": "^4.1.0",
         "madge": "^4.0.1",
         "rimraf": "^2.6.3",
@@ -25184,9 +25181,9 @@
       }
     },
     "@zowe/imperative": {
-      "version": "4.13.4",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@zowe/imperative/-/@zowe/imperative-4.13.4.tgz",
-      "integrity": "sha1-tx0jS5N8Yy4gVrft47/rLTW2ah4=",
+      "version": "4.15.0",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@zowe/imperative/-/@zowe/imperative-4.15.0.tgz",
+      "integrity": "sha1-pEgdDXSIKU2KEtnSAA9LxsVm95o=",
       "requires": {
         "@types/lodash-deep": "2.0.0",
         "@types/yargs": "13.0.4",
@@ -25195,13 +25192,13 @@
         "cli-table3": "0.5.1",
         "dataobject-parser": "1.2.1",
         "deepmerge": "3.0.0",
+        "fastest-levenshtein": "1.0.12",
         "find-up": "2.1.0",
         "fs-extra": "8.1.0",
         "glob": "7.1.6",
         "js-yaml": "3.13.1",
         "jsonfile": "4.0.0",
         "jsonschema": "1.1.1",
-        "levenshtein": "1.0.5",
         "lodash-deep": "2.0.0",
         "log4js": "6.3.0",
         "markdown-it": "12.0.4",
@@ -25313,7 +25310,7 @@
         "@types/js-yaml": "^3.12.5",
         "@types/node": "^12.12.24",
         "@zowe/core-for-zowe-sdk": "6.32.1",
-        "@zowe/imperative": "4.13.4",
+        "@zowe/imperative": "4.15.0",
         "js-yaml": "3.13.1",
         "madge": "^4.0.1",
         "rimraf": "^2.6.3",
@@ -25338,7 +25335,7 @@
       "requires": {
         "@types/node": "^12.12.24",
         "@zowe/core-for-zowe-sdk": "6.32.1",
-        "@zowe/imperative": "4.13.4",
+        "@zowe/imperative": "4.15.0",
         "madge": "^4.0.1",
         "rimraf": "^2.6.3",
         "tslint": "^6.1.3",
@@ -25351,7 +25348,7 @@
       "requires": {
         "@types/node": "^12.12.24",
         "@zowe/core-for-zowe-sdk": "6.32.1",
-        "@zowe/imperative": "4.13.4",
+        "@zowe/imperative": "4.15.0",
         "@zowe/zos-uss-for-zowe-sdk": "6.32.1",
         "madge": "^4.0.1",
         "minimatch": "3.0.4",
@@ -25366,7 +25363,7 @@
       "requires": {
         "@types/node": "^12.12.24",
         "@zowe/core-for-zowe-sdk": "6.32.1",
-        "@zowe/imperative": "4.13.4",
+        "@zowe/imperative": "4.15.0",
         "@zowe/zos-files-for-zowe-sdk": "6.32.1",
         "madge": "^4.0.1",
         "rimraf": "^2.6.3",
@@ -25380,7 +25377,7 @@
       "requires": {
         "@types/node": "^12.12.24",
         "@zowe/core-for-zowe-sdk": "6.32.1",
-        "@zowe/imperative": "4.13.4",
+        "@zowe/imperative": "4.15.0",
         "@zowe/zosmf-for-zowe-sdk": "6.32.1",
         "madge": "^4.0.1",
         "rimraf": "^2.6.3",
@@ -25394,7 +25391,7 @@
       "requires": {
         "@types/node": "^12.12.24",
         "@types/ssh2": "^0.5.44",
-        "@zowe/imperative": "4.13.4",
+        "@zowe/imperative": "4.15.0",
         "madge": "^4.0.1",
         "rimraf": "^2.6.3",
         "ssh2": "0.8.7",
@@ -25408,7 +25405,7 @@
       "requires": {
         "@types/node": "^12.12.24",
         "@zowe/core-for-zowe-sdk": "6.32.1",
-        "@zowe/imperative": "4.13.4",
+        "@zowe/imperative": "4.15.0",
         "@zowe/zos-files-for-zowe-sdk": "6.32.1",
         "madge": "^4.0.1",
         "rimraf": "^2.6.3",
@@ -25422,7 +25419,7 @@
       "requires": {
         "@types/node": "^12.12.24",
         "@zowe/core-for-zowe-sdk": "6.32.1",
-        "@zowe/imperative": "4.13.4",
+        "@zowe/imperative": "4.15.0",
         "madge": "^4.0.1",
         "rimraf": "^2.6.3",
         "tslint": "^6.1.3",
@@ -28336,6 +28333,11 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
+    },
+    "fastest-levenshtein": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.12.tgz",
+      "integrity": "sha512-On2N+BpYJ15xIC974QNVuYGMOlEVt4s0EOI3wwMqOmK1fdDY+FN/zltPV8vosq4ad4c/gJ1KHScUn/6AWIgiow=="
     },
     "fastq": {
       "version": "1.11.0",
@@ -33196,11 +33198,6 @@
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
       "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
       "dev": true
-    },
-    "levenshtein": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/levenshtein/-/levenshtein-1.0.5.tgz",
-      "integrity": "sha1-ORFzepy1baNF0Aj1V4LG8TiXm6M="
     },
     "levn": {
       "version": "0.3.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "prepare": "husky install"
   },
   "dependencies": {
-    "@zowe/imperative": "4.13.4",
+    "@zowe/imperative": "4.15.0",
     "@zowe/perf-timing": "1.0.7"
   },
   "devDependencies": {

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the Zowe CLI package will be documented in this file.
 
+## Recent Changes
+
+- Enhancement: Update Imperative to add the following features:
+  - Enhancement: Improved command suggestions for mistyped commands, add aliases to command suggestions
+  - Enhancement: The `plugins validate` command will return an error code when plugins have errors if the new `--fail-on-error` option is specified. Also adds `--fail-on-warning` option to return with an error code when plugins have warnings. [#463](https://github.com/zowe/imperative/issues/463)
+  - BugFix: Fixed regression where characters are not correctly escaped in web help causing extra slashes ("\") to appear. [#644](https://github.com/zowe/imperative/issues/644)
+
 ## `6.32.2`
 
 - Fixed inconsistencies in punctuation for command descriptions by adding missing periods. [#66](https://github.com/zowe/zowe-cli/issues/66)

--- a/packages/cli/__tests__/provisioning/__integration__/delete/__snapshots__/cli.provisioning.delete.integration.test.ts.snap
+++ b/packages/cli/__tests__/provisioning/__integration__/delete/__snapshots__/cli.provisioning.delete.integration.test.ts.snap
@@ -52,7 +52,9 @@ exports[`provisioning delete should fail with invalid option 1`] = `
 "Command Error:
 Unknown arguments: foo-bar, fooBar
 Command failed due to improper syntax
-Command entered: \\"zowe provisioning delete instance --foo-bar\\"
+Did you mean:  provisioning delete instance?
+
+Command entered: \\"provisioning delete instance --foo-bar\\"
 Available commands are \\"instance\\".
 Use \\"zowe provisioning delete --help\\" to view groups, commands, and options.
 Error Details:
@@ -66,7 +68,9 @@ exports[`provisioning delete should fail with invalid parameter 1`] = `
 "Command Error:
 Unknown argument: foobar
 Command failed due to improper syntax
-Command entered: \\"zowe provisioning delete foobar\\"
+Did you mean:  provisioning delete i?
+
+Command entered: \\"provisioning delete foobar\\"
 Available commands are \\"instance\\".
 Use \\"zowe provisioning delete --help\\" to view groups, commands, and options.
 Error Details:

--- a/packages/cli/__tests__/provisioning/__integration__/provision/__snapshots__/cli.provisioning.provision.integration.test.ts.snap
+++ b/packages/cli/__tests__/provisioning/__integration__/provision/__snapshots__/cli.provisioning.provision.integration.test.ts.snap
@@ -52,7 +52,9 @@ exports[`provisioning provision should fail with invalid option 1`] = `
 "Command Error:
 Unknown arguments: foo-bar, fooBar
 Command failed due to improper syntax
-Command entered: \\"zowe provisioning provision template --foo-bar\\"
+Did you mean:  provisioning provision template?
+
+Command entered: \\"provisioning provision template --foo-bar\\"
 Available commands are \\"template\\".
 Use \\"zowe provisioning provision --help\\" to view groups, commands, and options.
 Error Details:
@@ -66,7 +68,9 @@ exports[`provisioning provision should fail with invalid parameter 1`] = `
 "Command Error:
 Unknown argument: foobar
 Command failed due to improper syntax
-Command entered: \\"zowe provisioning provision foobar\\"
+Did you mean:  provisioning provision tem?
+
+Command entered: \\"provisioning provision foobar\\"
 Available commands are \\"template\\".
 Use \\"zowe provisioning provision --help\\" to view groups, commands, and options.
 Error Details:

--- a/packages/cli/__tests__/zosconsole/__integration__/root/__snapshots__/cli.zos-console.integration.test.ts.snap
+++ b/packages/cli/__tests__/zosconsole/__integration__/root/__snapshots__/cli.zos-console.integration.test.ts.snap
@@ -61,7 +61,9 @@ exports[`zos-console should fail with invalid option 1`] = `
 "Command Error:
 Unknown arguments: foo-bar, fooBar
 Command failed due to improper syntax
-Command entered: \\"zowe zos-console --foo-bar\\"
+Did you mean:  zos-console collect?
+
+Command entered: \\"zos-console --foo-bar\\"
 Use \\"zowe zos-console --help\\" to view groups, commands, and options.
 Error Details:
 Unknown arguments: foo-bar, fooBar
@@ -77,7 +79,9 @@ exports[`zos-console should fail with invalid parameter 1`] = `
 "Command Error:
 Unknown argument: foobar
 Command failed due to improper syntax
-Command entered: \\"zowe zos-console foobar\\"
+Did you mean:  zos-console collect?
+
+Command entered: \\"zos-console foobar\\"
 Use \\"zowe zos-console --help\\" to view groups, commands, and options.
 Error Details:
 Unknown argument: foobar

--- a/packages/cli/__tests__/zosjobs/__integration__/submit/data-set/__snapshots__/cli.zos-jobs.submit.data-set.integration.test.ts.snap
+++ b/packages/cli/__tests__/zosjobs/__integration__/submit/data-set/__snapshots__/cli.zos-jobs.submit.data-set.integration.test.ts.snap
@@ -213,7 +213,9 @@ exports[`zos-jobs submit data-set command syntax errors should occur if an extra
 "Command Error:
 Unknown argument: blah
 Command failed due to improper syntax
-Command entered: \\"zowe zos-jobs submit data-set DATA.SET blah\\"
+Did you mean:  zos-jobs submit data-set?
+
+Command entered: \\"zos-jobs submit data-set DATA.SET blah\\"
 Available commands are \\"data-set, local-file, stdin\\".
 Use \\"zowe zos-jobs submit --help\\" to view groups, commands, and options.
 Error Details:

--- a/packages/cli/__tests__/zosjobs/__integration__/submit/local-file/__snapshots__/cli.zos-jobs.submit.local-file.integration.test.ts.snap
+++ b/packages/cli/__tests__/zosjobs/__integration__/submit/local-file/__snapshots__/cli.zos-jobs.submit.local-file.integration.test.ts.snap
@@ -233,7 +233,9 @@ exports[`zos-jobs submit local-file command syntax errors should occur if an ext
 "Command Error:
 Unknown argument: blah
 Command failed due to improper syntax
-Command entered: \\"zowe zos-jobs submit local-file ../../../../packages/cli/__tests__/zosjobs/__integration__/submit/local-file/testFileOfLocalJCL.txt blah\\"
+Did you mean:  zos-jobs submit local-file?
+
+Command entered: \\"zos-jobs submit local-file ../../../../packages/cli/__tests__/zosjobs/__integration__/submit/local-file/testFileOfLocalJCL.txt blah\\"
 Available commands are \\"data-set, local-file, stdin\\".
 Use \\"zowe zos-jobs submit --help\\" to view groups, commands, and options.
 Error Details:

--- a/packages/cli/__tests__/zosjobs/__integration__/view/__snapshots__/cli.zos-jobs.view.job-status-by-jobid.integration.test.ts.snap
+++ b/packages/cli/__tests__/zosjobs/__integration__/view/__snapshots__/cli.zos-jobs.view.job-status-by-jobid.integration.test.ts.snap
@@ -172,7 +172,9 @@ exports[`zos-jobs view job-status-by-jobid command syntax errors should occur if
 "Command Error:
 Unknown argument: blah
 Command failed due to improper syntax
-Command entered: \\"zowe zos-jobs view job-status-by-jobid JOB123 blah --host fakehost --user fakeuser --password fakepass\\"
+Did you mean:  zos-jobs view job-status-by-jobid?
+
+Command entered: \\"zos-jobs view job-status-by-jobid JOB123 blah --host fakehost --user fakeuser --password fakepass\\"
 Available commands are \\"job-status-by-jobid, spool-file-by-id\\".
 Use \\"zowe zos-jobs view --help\\" to view groups, commands, and options.
 Error Details:

--- a/packages/cli/__tests__/zostso/__integration__/root/__snapshots__/cli.zos-tso.integration.test.ts.snap
+++ b/packages/cli/__tests__/zostso/__integration__/root/__snapshots__/cli.zos-tso.integration.test.ts.snap
@@ -56,7 +56,9 @@ exports[`zos-tso should fail with invalid option 1`] = `
 "Command Error:
 Unknown arguments: not-valid-option, notValidOption
 Command failed due to improper syntax
-Command entered: \\"zowe zos-tso --not-valid-option\\"
+Did you mean:  zos-tso start?
+
+Command entered: \\"zos-tso --not-valid-option\\"
 Use \\"zowe zos-tso --help\\" to view groups, commands, and options.
 Error Details:
 Unknown arguments: not-valid-option, notValidOption
@@ -67,7 +69,9 @@ exports[`zos-tso should fail with invalid parameter 1`] = `
 "Command Error:
 Unknown argument: examine
 Command failed due to improper syntax
-Command entered: \\"zowe zos-tso examine\\"
+Did you mean:  zos-tso ping?
+
+Command entered: \\"zos-tso examine\\"
 Use \\"zowe zos-tso --help\\" to view groups, commands, and options.
 Error Details:
 Unknown argument: examine

--- a/packages/cli/__tests__/zostso/__integration__/start/__snapshots__/cli.zos-tso.start.integration.test.ts.snap
+++ b/packages/cli/__tests__/zostso/__integration__/start/__snapshots__/cli.zos-tso.start.integration.test.ts.snap
@@ -54,7 +54,9 @@ exports[`zos-tso start should fail with invalid option 1`] = `
 "Command Error:
 Unknown arguments: foo-bar, fooBar
 Command failed due to improper syntax
-Command entered: \\"zowe zos-tso start --foo-bar\\"
+Did you mean:  zos-tso start as?
+
+Command entered: \\"zos-tso start --foo-bar\\"
 Available commands are \\"address-space\\".
 Use \\"zowe zos-tso start --help\\" to view groups, commands, and options.
 Error Details:
@@ -71,7 +73,9 @@ exports[`zos-tso start should fail with invalid parameter 1`] = `
 "Command Error:
 Unknown argument: foobar
 Command failed due to improper syntax
-Command entered: \\"zowe zos-tso start foobar\\"
+Did you mean:  zos-tso start as?
+
+Command entered: \\"zos-tso start foobar\\"
 Available commands are \\"address-space\\".
 Use \\"zowe zos-tso start --help\\" to view groups, commands, and options.
 Error Details:

--- a/packages/cli/__tests__/zostso/__integration__/stop/__snapshots__/cli.zos-tso.stop.integration.test.ts.snap
+++ b/packages/cli/__tests__/zostso/__integration__/stop/__snapshots__/cli.zos-tso.stop.integration.test.ts.snap
@@ -53,7 +53,9 @@ exports[`zos-tso stop should fail with invalid option 1`] = `
 "Command Error:
 Unknown arguments: foo-bar, fooBar
 Command failed due to improper syntax
-Command entered: \\"zowe zos-tso start as --foo-bar\\"
+Did you mean:  zos-tso start as?
+
+Command entered: \\"zos-tso start as --foo-bar\\"
 Available commands are \\"address-space\\".
 Use \\"zowe zos-tso start --help\\" to view groups, commands, and options.
 Error Details:
@@ -70,7 +72,9 @@ exports[`zos-tso stop should fail with invalid parameter 1`] = `
 "Command Error:
 Unknown argument: foobar
 Command failed due to improper syntax
-Command entered: \\"zowe zos-tso stop foobar\\"
+Did you mean:  zos-tso stop as?
+
+Command entered: \\"zos-tso stop foobar\\"
 Available commands are \\"address-space\\".
 Use \\"zowe zos-tso stop --help\\" to view groups, commands, and options.
 Error Details:

--- a/packages/cli/__tests__/zosuss/__integration__/issue/__snapshots__/cli.zos-uss.issue.ssh.integration.test.ts.snap
+++ b/packages/cli/__tests__/zosuss/__integration__/issue/__snapshots__/cli.zos-uss.issue.ssh.integration.test.ts.snap
@@ -134,7 +134,9 @@ exports[`zos-uss issue ssh command should fail due to invalid ssh command 1`] = 
 "Command Error:
 Unknown argument: ss
 Command failed due to improper syntax
-Command entered: \\"zowe zos-uss issue ss\\"
+Did you mean:  zos-uss issue ssh?
+
+Command entered: \\"zos-uss issue ss\\"
 Use \\"zowe --help\\" to view groups, commands, and options.
 Error Details:
 Unknown argument: ss

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -55,7 +55,7 @@
   },
   "dependencies": {
     "@zowe/core-for-zowe-sdk": "6.32.1",
-    "@zowe/imperative": "4.13.4",
+    "@zowe/imperative": "4.15.0",
     "@zowe/perf-timing": "1.0.7",
     "@zowe/provisioning-for-zowe-sdk": "6.32.1",
     "@zowe/zos-console-for-zowe-sdk": "6.32.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -48,7 +48,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.12.24",
-    "@zowe/imperative": "4.13.4",
+    "@zowe/imperative": "4.15.0",
     "chalk": "^4.1.0",
     "madge": "^4.0.1",
     "rimraf": "^2.6.3",

--- a/packages/provisioning/package.json
+++ b/packages/provisioning/package.json
@@ -50,7 +50,7 @@
     "@types/js-yaml": "^3.12.5",
     "@types/node": "^12.12.24",
     "@zowe/core-for-zowe-sdk": "6.32.1",
-    "@zowe/imperative": "4.13.4",
+    "@zowe/imperative": "4.15.0",
     "madge": "^4.0.1",
     "rimraf": "^2.6.3",
     "tslint": "^6.1.3",

--- a/packages/workflows/package.json
+++ b/packages/workflows/package.json
@@ -49,7 +49,7 @@
   "devDependencies": {
     "@types/node": "^12.12.24",
     "@zowe/core-for-zowe-sdk": "6.32.1",
-    "@zowe/imperative": "4.13.4",
+    "@zowe/imperative": "4.15.0",
     "madge": "^4.0.1",
     "rimraf": "^2.6.3",
     "tslint": "^6.1.3",

--- a/packages/zosconsole/package.json
+++ b/packages/zosconsole/package.json
@@ -46,7 +46,7 @@
   "devDependencies": {
     "@types/node": "^12.12.24",
     "@zowe/core-for-zowe-sdk": "6.32.1",
-    "@zowe/imperative": "4.13.4",
+    "@zowe/imperative": "4.15.0",
     "madge": "^4.0.1",
     "rimraf": "^2.6.3",
     "tslint": "^6.1.3",

--- a/packages/zosfiles/package.json
+++ b/packages/zosfiles/package.json
@@ -50,7 +50,7 @@
   "devDependencies": {
     "@types/node": "^12.12.24",
     "@zowe/core-for-zowe-sdk": "6.32.1",
-    "@zowe/imperative": "4.13.4",
+    "@zowe/imperative": "4.15.0",
     "@zowe/zos-uss-for-zowe-sdk": "6.32.1",
     "madge": "^4.0.1",
     "rimraf": "^2.6.3",

--- a/packages/zosjobs/package.json
+++ b/packages/zosjobs/package.json
@@ -50,7 +50,7 @@
   "devDependencies": {
     "@types/node": "^12.12.24",
     "@zowe/core-for-zowe-sdk": "6.32.1",
-    "@zowe/imperative": "4.13.4",
+    "@zowe/imperative": "4.15.0",
     "madge": "^4.0.1",
     "rimraf": "^2.6.3",
     "tslint": "^6.1.3",

--- a/packages/zosmf/package.json
+++ b/packages/zosmf/package.json
@@ -45,7 +45,7 @@
   "devDependencies": {
     "@types/node": "^12.12.24",
     "@zowe/core-for-zowe-sdk": "6.32.1",
-    "@zowe/imperative": "4.13.4",
+    "@zowe/imperative": "4.15.0",
     "madge": "^4.0.1",
     "rimraf": "^2.6.3",
     "tslint": "^6.1.3",

--- a/packages/zostso/package.json
+++ b/packages/zostso/package.json
@@ -49,7 +49,7 @@
   "devDependencies": {
     "@types/node": "^12.12.24",
     "@zowe/core-for-zowe-sdk": "6.32.1",
-    "@zowe/imperative": "4.13.4",
+    "@zowe/imperative": "4.15.0",
     "madge": "^4.0.1",
     "rimraf": "^2.6.3",
     "tslint": "^6.1.3",

--- a/packages/zosuss/package.json
+++ b/packages/zosuss/package.json
@@ -49,7 +49,7 @@
   "devDependencies": {
     "@types/node": "^12.12.24",
     "@types/ssh2": "^0.5.44",
-    "@zowe/imperative": "4.13.4",
+    "@zowe/imperative": "4.15.0",
     "madge": "^4.0.1",
     "rimraf": "^2.6.3",
     "tslint": "^6.1.3",


### PR DESCRIPTION
Update Imperative to 4.15.0 to absorb the new features introduced. See the CLI changelog for more info.

Signed-off-by: Andrew W. Harn <andrew.harn@broadcom.com>