### PR TITLE
Supply string, not error object to 'new Error()'

### DIFF
--- a/__tests__/__packages__/cli-test-utils/CHANGELOG.md
+++ b/__tests__/__packages__/cli-test-utils/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the Zowe CLI test utils package will be documented in thi
 
 ## Recent Changes
 
-- Corrected a attempt to re-throw an error with 'throw new Error(error)' which fails to compile with the latest version of typescript.
+- Corrected an attempt to rethrow an error with the NEW keyword which fails to compile with the latest version of typescript
 
 ## `7.0.0-next.202107091339`
 

--- a/__tests__/__packages__/cli-test-utils/CHANGELOG.md
+++ b/__tests__/__packages__/cli-test-utils/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Zowe CLI test utils package will be documented in this file.
 
+## Recent Changes
+
+- Corrected a attempt to re-throw an error with 'throw new Error(error)' which fails to compile with the latest version of typescript.
+
 ## `7.0.0-next.202107091339`
 
 - Change private methods to protected in `TestEnvironment` class for easier extensibility

--- a/__tests__/__packages__/cli-test-utils/src/environment/TestEnvironment.ts
+++ b/__tests__/__packages__/cli-test-utils/src/environment/TestEnvironment.ts
@@ -145,9 +145,10 @@ export class TestEnvironment {
             // injectCliProps(properties);
             // console.log(properties);
         } catch (error) {
-            logger.error("Error reading test properties yaml configuration file. Tests cannot continue. " +
-                "Additional details:" + error);
-            throw new Error(error);
+            const errMsg: string = "Error reading test properties yaml configuration file. Tests cannot continue. " +
+                "Additional details:" + error;
+            logger.error(errMsg);
+            throw new Error(errMsg);
         }
         logger.info("Loaded configuration properties file.");
 

--- a/__tests__/__packages__/cli-test-utils/src/environment/TestEnvironment.ts
+++ b/__tests__/__packages__/cli-test-utils/src/environment/TestEnvironment.ts
@@ -145,10 +145,9 @@ export class TestEnvironment {
             // injectCliProps(properties);
             // console.log(properties);
         } catch (error) {
-            const errMsg: string = "Error reading test properties yaml configuration file. Tests cannot continue. " +
-                "Additional details:" + error;
-            logger.error(errMsg);
-            throw new Error(errMsg);
+            logger.error("Error reading test properties yaml configuration file. Tests cannot continue. " +
+                "Additional details:" + error);
+            throw error;
         }
         logger.info("Loaded configuration properties file.");
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -62,7 +62,7 @@
     },
     "__tests__/__packages__/cli-test-utils": {
       "name": "@zowe/cli-test-utils",
-      "version": "7.0.0-next.202108121907",
+      "version": "7.0.0-next.202108202027",
       "license": "EPL-2.0",
       "dependencies": {
         "@types/js-yaml": "^4.0.0",
@@ -24723,21 +24723,21 @@
     },
     "packages/cli": {
       "name": "@zowe/cli",
-      "version": "7.0.0-next.202108121907",
+      "version": "7.0.0-next.202108202027",
       "hasInstallScript": true,
       "license": "EPL-2.0",
       "dependencies": {
-        "@zowe/core-for-zowe-sdk": "7.0.0-next.202108121907",
+        "@zowe/core-for-zowe-sdk": "7.0.0-next.202108202027",
         "@zowe/imperative": "5.0.0-next.202108181618",
         "@zowe/perf-timing": "1.0.7",
-        "@zowe/provisioning-for-zowe-sdk": "7.0.0-next.202108121907",
-        "@zowe/zos-console-for-zowe-sdk": "7.0.0-next.202108121907",
-        "@zowe/zos-files-for-zowe-sdk": "7.0.0-next.202108121907",
-        "@zowe/zos-jobs-for-zowe-sdk": "7.0.0-next.202108121907",
-        "@zowe/zos-tso-for-zowe-sdk": "7.0.0-next.202108121907",
-        "@zowe/zos-uss-for-zowe-sdk": "7.0.0-next.202108121907",
-        "@zowe/zos-workflows-for-zowe-sdk": "7.0.0-next.202108121907",
-        "@zowe/zosmf-for-zowe-sdk": "7.0.0-next.202108121907",
+        "@zowe/provisioning-for-zowe-sdk": "7.0.0-next.202108202027",
+        "@zowe/zos-console-for-zowe-sdk": "7.0.0-next.202108202027",
+        "@zowe/zos-files-for-zowe-sdk": "7.0.0-next.202108202027",
+        "@zowe/zos-jobs-for-zowe-sdk": "7.0.0-next.202108202027",
+        "@zowe/zos-tso-for-zowe-sdk": "7.0.0-next.202108202027",
+        "@zowe/zos-uss-for-zowe-sdk": "7.0.0-next.202108202027",
+        "@zowe/zos-workflows-for-zowe-sdk": "7.0.0-next.202108202027",
+        "@zowe/zosmf-for-zowe-sdk": "7.0.0-next.202108202027",
         "get-stdin": "7.0.0",
         "minimatch": "3.0.4"
       },
@@ -24747,7 +24747,7 @@
       },
       "devDependencies": {
         "@types/node": "^12.12.24",
-        "@zowe/cli-test-utils": "7.0.0-next.202108121907",
+        "@zowe/cli-test-utils": "7.0.0-next.202108202027",
         "comment-json": "^4.1.0",
         "eslint": "^7.32.0",
         "js-yaml": "^3.13.1",
@@ -24773,7 +24773,7 @@
     },
     "packages/core": {
       "name": "@zowe/core-for-zowe-sdk",
-      "version": "7.0.0-next.202108121907",
+      "version": "7.0.0-next.202108202027",
       "license": "EPL-2.0",
       "dependencies": {
         "comment-json": "4.1.0",
@@ -24781,7 +24781,7 @@
       },
       "devDependencies": {
         "@types/node": "^12.12.24",
-        "@zowe/cli-test-utils": "7.0.0-next.202108121907",
+        "@zowe/cli-test-utils": "7.0.0-next.202108202027",
         "@zowe/imperative": "5.0.0-next.202108181618",
         "chalk": "^4.1.0",
         "eslint": "^7.32.0",
@@ -24796,7 +24796,7 @@
     },
     "packages/provisioning": {
       "name": "@zowe/provisioning-for-zowe-sdk",
-      "version": "7.0.0-next.202108121907",
+      "version": "7.0.0-next.202108202027",
       "license": "EPL-2.0",
       "dependencies": {
         "js-yaml": "3.13.1"
@@ -24804,8 +24804,8 @@
       "devDependencies": {
         "@types/js-yaml": "^3.12.5",
         "@types/node": "^12.12.24",
-        "@zowe/cli-test-utils": "7.0.0-next.202108121907",
-        "@zowe/core-for-zowe-sdk": "7.0.0-next.202108121907",
+        "@zowe/cli-test-utils": "7.0.0-next.202108202027",
+        "@zowe/core-for-zowe-sdk": "7.0.0-next.202108202027",
         "@zowe/imperative": "5.0.0-next.202108181618",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
@@ -24846,15 +24846,15 @@
     },
     "packages/workflows": {
       "name": "@zowe/zos-workflows-for-zowe-sdk",
-      "version": "7.0.0-next.202108121907",
+      "version": "7.0.0-next.202108202027",
       "license": "EPL-2.0",
       "dependencies": {
-        "@zowe/zos-files-for-zowe-sdk": "7.0.0-next.202108121907"
+        "@zowe/zos-files-for-zowe-sdk": "7.0.0-next.202108202027"
       },
       "devDependencies": {
         "@types/node": "^12.12.24",
-        "@zowe/cli-test-utils": "7.0.0-next.202108121907",
-        "@zowe/core-for-zowe-sdk": "7.0.0-next.202108121907",
+        "@zowe/cli-test-utils": "7.0.0-next.202108202027",
+        "@zowe/core-for-zowe-sdk": "7.0.0-next.202108202027",
         "@zowe/imperative": "5.0.0-next.202108181618",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
@@ -24869,12 +24869,12 @@
     },
     "packages/zosconsole": {
       "name": "@zowe/zos-console-for-zowe-sdk",
-      "version": "7.0.0-next.202108121907",
+      "version": "7.0.0-next.202108202027",
       "license": "EPL-2.0",
       "devDependencies": {
         "@types/node": "^12.12.24",
-        "@zowe/cli-test-utils": "7.0.0-next.202108121907",
-        "@zowe/core-for-zowe-sdk": "7.0.0-next.202108121907",
+        "@zowe/cli-test-utils": "7.0.0-next.202108202027",
+        "@zowe/core-for-zowe-sdk": "7.0.0-next.202108202027",
         "@zowe/imperative": "5.0.0-next.202108181618",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
@@ -24889,18 +24889,17 @@
     },
     "packages/zosfiles": {
       "name": "@zowe/zos-files-for-zowe-sdk",
-      "version": "7.0.0-next.202108121907",
+      "version": "7.0.0-next.202108202027",
       "license": "EPL-2.0",
       "dependencies": {
         "minimatch": "3.0.4"
       },
       "devDependencies": {
         "@types/node": "^12.12.24",
-        "@zowe/cli-test-utils": "7.0.0-next.202108121907",
-        "@zowe/core-for-zowe-sdk": "7.0.0-next.202108121907",
+        "@zowe/cli-test-utils": "7.0.0-next.202108202027",
+        "@zowe/core-for-zowe-sdk": "7.0.0-next.202108202027",
         "@zowe/imperative": "5.0.0-next.202108181618",
-        "@zowe/zos-uss-for-zowe-sdk": "7.0.0-next.202108121907",
-        "eslint": "^7.32.0",
+        "@zowe/zos-uss-for-zowe-sdk": "7.0.0-next.202108202027",
         "madge": "^4.0.1",
         "rimraf": "^2.6.3",
         "typedoc": "^0.16.0",
@@ -24913,15 +24912,15 @@
     },
     "packages/zosjobs": {
       "name": "@zowe/zos-jobs-for-zowe-sdk",
-      "version": "7.0.0-next.202108121907",
+      "version": "7.0.0-next.202108202027",
       "license": "EPL-2.0",
       "dependencies": {
-        "@zowe/zos-files-for-zowe-sdk": "7.0.0-next.202108121907"
+        "@zowe/zos-files-for-zowe-sdk": "7.0.0-next.202108202027"
       },
       "devDependencies": {
         "@types/node": "^12.12.24",
-        "@zowe/cli-test-utils": "7.0.0-next.202108121907",
-        "@zowe/core-for-zowe-sdk": "7.0.0-next.202108121907",
+        "@zowe/cli-test-utils": "7.0.0-next.202108202027",
+        "@zowe/core-for-zowe-sdk": "7.0.0-next.202108202027",
         "@zowe/imperative": "5.0.0-next.202108181618",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
@@ -24936,12 +24935,12 @@
     },
     "packages/zosmf": {
       "name": "@zowe/zosmf-for-zowe-sdk",
-      "version": "7.0.0-next.202108121907",
+      "version": "7.0.0-next.202108202027",
       "license": "EPL-2.0",
       "devDependencies": {
         "@types/node": "^12.12.24",
-        "@zowe/cli-test-utils": "7.0.0-next.202108121907",
-        "@zowe/core-for-zowe-sdk": "7.0.0-next.202108121907",
+        "@zowe/cli-test-utils": "7.0.0-next.202108202027",
+        "@zowe/core-for-zowe-sdk": "7.0.0-next.202108202027",
         "@zowe/imperative": "5.0.0-next.202108181618",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
@@ -24956,15 +24955,15 @@
     },
     "packages/zostso": {
       "name": "@zowe/zos-tso-for-zowe-sdk",
-      "version": "7.0.0-next.202108121907",
+      "version": "7.0.0-next.202108202027",
       "license": "EPL-2.0",
       "dependencies": {
-        "@zowe/zosmf-for-zowe-sdk": "7.0.0-next.202108121907"
+        "@zowe/zosmf-for-zowe-sdk": "7.0.0-next.202108202027"
       },
       "devDependencies": {
         "@types/node": "^12.12.24",
-        "@zowe/cli-test-utils": "7.0.0-next.202108121907",
-        "@zowe/core-for-zowe-sdk": "7.0.0-next.202108121907",
+        "@zowe/cli-test-utils": "7.0.0-next.202108202027",
+        "@zowe/core-for-zowe-sdk": "7.0.0-next.202108202027",
         "@zowe/imperative": "5.0.0-next.202108181618",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
@@ -24979,7 +24978,7 @@
     },
     "packages/zosuss": {
       "name": "@zowe/zos-uss-for-zowe-sdk",
-      "version": "7.0.0-next.202108121907",
+      "version": "7.0.0-next.202108202027",
       "license": "EPL-2.0",
       "dependencies": {
         "ssh2": "0.8.7"
@@ -24987,7 +24986,7 @@
       "devDependencies": {
         "@types/node": "^12.12.24",
         "@types/ssh2": "^0.5.44",
-        "@zowe/cli-test-utils": "7.0.0-next.202108121907",
+        "@zowe/cli-test-utils": "7.0.0-next.202108202027",
         "@zowe/imperative": "5.0.0-next.202108181618",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
@@ -29010,18 +29009,18 @@
       "version": "file:packages/cli",
       "requires": {
         "@types/node": "^12.12.24",
-        "@zowe/cli-test-utils": "7.0.0-next.202108121907",
-        "@zowe/core-for-zowe-sdk": "7.0.0-next.202108121907",
+        "@zowe/cli-test-utils": "7.0.0-next.202108202027",
+        "@zowe/core-for-zowe-sdk": "7.0.0-next.202108202027",
         "@zowe/imperative": "5.0.0-next.202108181618",
         "@zowe/perf-timing": "1.0.7",
-        "@zowe/provisioning-for-zowe-sdk": "7.0.0-next.202108121907",
-        "@zowe/zos-console-for-zowe-sdk": "7.0.0-next.202108121907",
-        "@zowe/zos-files-for-zowe-sdk": "7.0.0-next.202108121907",
-        "@zowe/zos-jobs-for-zowe-sdk": "7.0.0-next.202108121907",
-        "@zowe/zos-tso-for-zowe-sdk": "7.0.0-next.202108121907",
-        "@zowe/zos-uss-for-zowe-sdk": "7.0.0-next.202108121907",
-        "@zowe/zos-workflows-for-zowe-sdk": "7.0.0-next.202108121907",
-        "@zowe/zosmf-for-zowe-sdk": "7.0.0-next.202108121907",
+        "@zowe/provisioning-for-zowe-sdk": "7.0.0-next.202108202027",
+        "@zowe/zos-console-for-zowe-sdk": "7.0.0-next.202108202027",
+        "@zowe/zos-files-for-zowe-sdk": "7.0.0-next.202108202027",
+        "@zowe/zos-jobs-for-zowe-sdk": "7.0.0-next.202108202027",
+        "@zowe/zos-tso-for-zowe-sdk": "7.0.0-next.202108202027",
+        "@zowe/zos-uss-for-zowe-sdk": "7.0.0-next.202108202027",
+        "@zowe/zos-workflows-for-zowe-sdk": "7.0.0-next.202108202027",
+        "@zowe/zosmf-for-zowe-sdk": "7.0.0-next.202108202027",
         "comment-json": "^4.1.0",
         "eslint": "^7.32.0",
         "get-stdin": "7.0.0",
@@ -29096,7 +29095,7 @@
       "version": "file:packages/core",
       "requires": {
         "@types/node": "^12.12.24",
-        "@zowe/cli-test-utils": "7.0.0-next.202108121907",
+        "@zowe/cli-test-utils": "7.0.0-next.202108202027",
         "@zowe/imperative": "5.0.0-next.202108181618",
         "chalk": "^4.1.0",
         "comment-json": "4.1.0",
@@ -29294,8 +29293,8 @@
       "requires": {
         "@types/js-yaml": "^3.12.5",
         "@types/node": "^12.12.24",
-        "@zowe/cli-test-utils": "7.0.0-next.202108121907",
-        "@zowe/core-for-zowe-sdk": "7.0.0-next.202108121907",
+        "@zowe/cli-test-utils": "7.0.0-next.202108202027",
+        "@zowe/core-for-zowe-sdk": "7.0.0-next.202108202027",
         "@zowe/imperative": "5.0.0-next.202108181618",
         "eslint": "^7.32.0",
         "js-yaml": "3.13.1",
@@ -29334,8 +29333,8 @@
       "version": "file:packages/zosconsole",
       "requires": {
         "@types/node": "^12.12.24",
-        "@zowe/cli-test-utils": "7.0.0-next.202108121907",
-        "@zowe/core-for-zowe-sdk": "7.0.0-next.202108121907",
+        "@zowe/cli-test-utils": "7.0.0-next.202108202027",
+        "@zowe/core-for-zowe-sdk": "7.0.0-next.202108202027",
         "@zowe/imperative": "5.0.0-next.202108181618",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
@@ -29348,11 +29347,10 @@
       "version": "file:packages/zosfiles",
       "requires": {
         "@types/node": "^12.12.24",
-        "@zowe/cli-test-utils": "7.0.0-next.202108121907",
-        "@zowe/core-for-zowe-sdk": "7.0.0-next.202108121907",
+        "@zowe/cli-test-utils": "7.0.0-next.202108202027",
+        "@zowe/core-for-zowe-sdk": "7.0.0-next.202108202027",
         "@zowe/imperative": "5.0.0-next.202108181618",
-        "@zowe/zos-uss-for-zowe-sdk": "7.0.0-next.202108121907",
-        "eslint": "^7.32.0",
+        "@zowe/zos-uss-for-zowe-sdk": "7.0.0-next.202108202027",
         "madge": "^4.0.1",
         "minimatch": "3.0.4",
         "rimraf": "^2.6.3",
@@ -29364,10 +29362,10 @@
       "version": "file:packages/zosjobs",
       "requires": {
         "@types/node": "^12.12.24",
-        "@zowe/cli-test-utils": "7.0.0-next.202108121907",
-        "@zowe/core-for-zowe-sdk": "7.0.0-next.202108121907",
+        "@zowe/cli-test-utils": "7.0.0-next.202108202027",
+        "@zowe/core-for-zowe-sdk": "7.0.0-next.202108202027",
         "@zowe/imperative": "5.0.0-next.202108181618",
-        "@zowe/zos-files-for-zowe-sdk": "7.0.0-next.202108121907",
+        "@zowe/zos-files-for-zowe-sdk": "7.0.0-next.202108202027",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
         "rimraf": "^2.6.3",
@@ -29379,10 +29377,10 @@
       "version": "file:packages/zostso",
       "requires": {
         "@types/node": "^12.12.24",
-        "@zowe/cli-test-utils": "7.0.0-next.202108121907",
-        "@zowe/core-for-zowe-sdk": "7.0.0-next.202108121907",
+        "@zowe/cli-test-utils": "7.0.0-next.202108202027",
+        "@zowe/core-for-zowe-sdk": "7.0.0-next.202108202027",
         "@zowe/imperative": "5.0.0-next.202108181618",
-        "@zowe/zosmf-for-zowe-sdk": "7.0.0-next.202108121907",
+        "@zowe/zosmf-for-zowe-sdk": "7.0.0-next.202108202027",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
         "rimraf": "^2.6.3",
@@ -29395,7 +29393,7 @@
       "requires": {
         "@types/node": "^12.12.24",
         "@types/ssh2": "^0.5.44",
-        "@zowe/cli-test-utils": "7.0.0-next.202108121907",
+        "@zowe/cli-test-utils": "7.0.0-next.202108202027",
         "@zowe/imperative": "5.0.0-next.202108181618",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
@@ -29409,10 +29407,10 @@
       "version": "file:packages/workflows",
       "requires": {
         "@types/node": "^12.12.24",
-        "@zowe/cli-test-utils": "7.0.0-next.202108121907",
-        "@zowe/core-for-zowe-sdk": "7.0.0-next.202108121907",
+        "@zowe/cli-test-utils": "7.0.0-next.202108202027",
+        "@zowe/core-for-zowe-sdk": "7.0.0-next.202108202027",
         "@zowe/imperative": "5.0.0-next.202108181618",
-        "@zowe/zos-files-for-zowe-sdk": "7.0.0-next.202108121907",
+        "@zowe/zos-files-for-zowe-sdk": "7.0.0-next.202108202027",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
         "rimraf": "^2.6.3",
@@ -29424,8 +29422,8 @@
       "version": "file:packages/zosmf",
       "requires": {
         "@types/node": "^12.12.24",
-        "@zowe/cli-test-utils": "7.0.0-next.202108121907",
-        "@zowe/core-for-zowe-sdk": "7.0.0-next.202108121907",
+        "@zowe/cli-test-utils": "7.0.0-next.202108202027",
+        "@zowe/core-for-zowe-sdk": "7.0.0-next.202108202027",
         "@zowe/imperative": "5.0.0-next.202108181618",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",


### PR DESCRIPTION
The following section of code caused a compile error in a fresh clone of zowe-cli (next branch).
```
} catch (error) {
    logger.error("Error reading test properties yaml configuration file. Tests cannot continue. " +
        "Additional details:" + error);
    throw new Error(error);
}
```

The error it produced was:
```
> tsc --pretty

src/environment/TestEnvironment.ts:150:29 - error TS2345: Argument of type 'unknown' is not assignable to parameter of type 'string | undefined'.
    Type 'unknown' is not assignable to type 'string'.

150             throw new Error(error);
                                ~~~~~
```

I think you can re-throw an error object:

- throw error;

or you can throw a newly created error object passing a string to the Error constructor:

- throw new Error("some string");

However, the compiler does not seem to like it when you to pass an Error object to the constructor of the Error class.

The code above has been in place for at least 5 months. I do not know why it fails to compile now. Perhaps an update to typescript made the compiler a little more strict?

I used the following code to prevent the error.

```
} catch (error) {
    const errMsg: string = "Error reading test properties yaml configuration file. Tests cannot continue. " +
        "Additional details:" + error;
    logger.error(errMsg);
    throw new Error(errMsg);
}
```