### PR TITLE
Update dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4301,9 +4301,9 @@
       }
     },
     "node_modules/@npmcli/run-script/node_modules/tar": {
-      "version": "6.1.8",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.8.tgz",
-      "integrity": "sha512-sb9b0cp855NbkMJcskdSYA7b11Q8JsX4qe4pyUAfHp+Y6jBjJeek2ZVlwEfWayshEIwlIzXx0Fain3QG9JPm2A==",
+      "version": "6.1.11",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
+      "integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
       "dependencies": {
         "chownr": "^2.0.0",
         "fs-minipass": "^2.0.0",
@@ -7581,6 +7581,19 @@
       "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/cpu-features": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/cpu-features/-/cpu-features-0.0.2.tgz",
+      "integrity": "sha512-/2yieBqvMcRj8McNzkycjW2v3OIUOibBfd2dLEJ0nWts8NobAxwiyw9phVNS6oDL8x8tz9F7uNVFEVpJncQpeA==",
+      "hasInstallScript": true,
+      "optional": true,
+      "dependencies": {
+        "nan": "^2.14.1"
+      },
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/cross-env": {
@@ -15966,7 +15979,6 @@
       "version": "3.14.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
       "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
-      "dev": true,
       "dependencies": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -17765,7 +17777,6 @@
       "version": "2.15.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
       "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ==",
-      "dev": true,
       "optional": true
     },
     "node_modules/nanoid": {
@@ -18513,9 +18524,9 @@
       }
     },
     "node_modules/npm-registry-fetch/node_modules/tar": {
-      "version": "6.1.8",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.8.tgz",
-      "integrity": "sha512-sb9b0cp855NbkMJcskdSYA7b11Q8JsX4qe4pyUAfHp+Y6jBjJeek2ZVlwEfWayshEIwlIzXx0Fain3QG9JPm2A==",
+      "version": "6.1.11",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
+      "integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
       "dependencies": {
         "chownr": "^2.0.0",
         "fs-minipass": "^2.0.0",
@@ -19246,9 +19257,9 @@
       }
     },
     "node_modules/pacote/node_modules/tar": {
-      "version": "6.1.8",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.8.tgz",
-      "integrity": "sha512-sb9b0cp855NbkMJcskdSYA7b11Q8JsX4qe4pyUAfHp+Y6jBjJeek2ZVlwEfWayshEIwlIzXx0Fain3QG9JPm2A==",
+      "version": "6.1.11",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
+      "integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
       "dependencies": {
         "chownr": "^2.0.0",
         "fs-minipass": "^2.0.0",
@@ -21780,27 +21791,20 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
     "node_modules/ssh2": {
-      "version": "0.8.7",
-      "resolved": "https://registry.npmjs.org/ssh2/-/ssh2-0.8.7.tgz",
-      "integrity": "sha512-/u1BO12kb0lDVxJXejWB9pxyF3/ncgRqI9vPCZuPzo05pdNDzqUeQRavScwSPsfMGK+5H/VRqp1IierIx0Bcxw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/ssh2/-/ssh2-1.4.0.tgz",
+      "integrity": "sha512-XvXwcXKvS452DyQvCa6Ct+chpucwc/UyxgliYz+rWXJ3jDHdtBb9xgmxJdMmnIn5bpgGAEV3KaEsH98ZGPHqwg==",
+      "hasInstallScript": true,
       "dependencies": {
-        "ssh2-streams": "~0.4.8"
+        "asn1": "^0.2.4",
+        "bcrypt-pbkdf": "^1.0.2"
       },
       "engines": {
-        "node": ">=5.2.0"
-      }
-    },
-    "node_modules/ssh2-streams": {
-      "version": "0.4.10",
-      "resolved": "https://registry.npmjs.org/ssh2-streams/-/ssh2-streams-0.4.10.tgz",
-      "integrity": "sha512-8pnlMjvnIZJvmTzUIIA5nT4jr2ZWNNVHwyXfMGdRJbug9TpI3kd99ffglgfSWqujVv/0gxwMsDn9j9RVst8yhQ==",
-      "dependencies": {
-        "asn1": "~0.2.0",
-        "bcrypt-pbkdf": "^1.0.2",
-        "streamsearch": "~0.1.2"
+        "node": ">=10.16.0"
       },
-      "engines": {
-        "node": ">=5.2.0"
+      "optionalDependencies": {
+        "cpu-features": "0.0.2",
+        "nan": "^2.15.0"
       }
     },
     "node_modules/sshpk": {
@@ -21928,14 +21932,6 @@
       "integrity": "sha512-bYQuGLeFxhkxNOF3rcMtiZxvCBAquGzZm6oWA1oZ0g2THUzivaRhv8uOhdr19LmoobSOLoIAxeUK2RdbM8IFTA==",
       "engines": {
         "node": ">=4.0"
-      }
-    },
-    "node_modules/streamsearch": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz",
-      "integrity": "sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo=",
-      "engines": {
-        "node": ">=0.8.0"
       }
     },
     "node_modules/strict-uri-encode": {
@@ -22385,9 +22381,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "4.4.17",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.17.tgz",
-      "integrity": "sha512-q7OwXq6NTdcYIa+k58nEMV3j1euhDhGCs/VRw9ymx/PbH0jtIM2+VTgDE/BW3rbLkrBUXs5fzEKgic5oUciu7g==",
+      "version": "4.4.19",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.19.tgz",
+      "integrity": "sha512-a20gEsvHnWe0ygBY8JbxoM4w3SJdhc7ZAuxkLqh+nvNQN2IOt0B5lLgM490X5Hl8FF0dl0tOf2ewFYAlIFgzVA==",
       "dev": true,
       "dependencies": {
         "chownr": "^1.1.4",
@@ -24121,21 +24117,21 @@
     },
     "packages/cli": {
       "name": "@zowe/cli",
-      "version": "6.33.0",
+      "version": "6.33.1",
       "hasInstallScript": true,
       "license": "EPL-2.0",
       "dependencies": {
-        "@zowe/core-for-zowe-sdk": "6.33.0",
+        "@zowe/core-for-zowe-sdk": "6.33.1",
         "@zowe/imperative": "4.15.0",
         "@zowe/perf-timing": "1.0.7",
-        "@zowe/provisioning-for-zowe-sdk": "6.33.0",
-        "@zowe/zos-console-for-zowe-sdk": "6.33.0",
-        "@zowe/zos-files-for-zowe-sdk": "6.33.0",
-        "@zowe/zos-jobs-for-zowe-sdk": "6.33.0",
-        "@zowe/zos-tso-for-zowe-sdk": "6.33.0",
-        "@zowe/zos-uss-for-zowe-sdk": "6.33.0",
-        "@zowe/zos-workflows-for-zowe-sdk": "6.33.0",
-        "@zowe/zosmf-for-zowe-sdk": "6.33.0",
+        "@zowe/provisioning-for-zowe-sdk": "6.33.1",
+        "@zowe/zos-console-for-zowe-sdk": "6.33.1",
+        "@zowe/zos-files-for-zowe-sdk": "6.33.1",
+        "@zowe/zos-jobs-for-zowe-sdk": "6.33.1",
+        "@zowe/zos-tso-for-zowe-sdk": "6.33.1",
+        "@zowe/zos-uss-for-zowe-sdk": "6.33.1",
+        "@zowe/zos-workflows-for-zowe-sdk": "6.33.1",
+        "@zowe/zosmf-for-zowe-sdk": "6.33.1",
         "get-stdin": "7.0.0",
         "minimatch": "3.0.4"
       },
@@ -24166,7 +24162,7 @@
     },
     "packages/core": {
       "name": "@zowe/core-for-zowe-sdk",
-      "version": "6.33.0",
+      "version": "6.33.1",
       "license": "EPL-2.0",
       "dependencies": {
         "string-width": "2.1.1"
@@ -24187,15 +24183,15 @@
     },
     "packages/provisioning": {
       "name": "@zowe/provisioning-for-zowe-sdk",
-      "version": "6.33.0",
+      "version": "6.33.1",
       "license": "EPL-2.0",
       "dependencies": {
-        "js-yaml": "3.13.1"
+        "js-yaml": "3.14.1"
       },
       "devDependencies": {
         "@types/js-yaml": "^3.12.5",
         "@types/node": "^12.12.24",
-        "@zowe/core-for-zowe-sdk": "6.33.0",
+        "@zowe/core-for-zowe-sdk": "6.33.1",
         "@zowe/imperative": "4.15.0",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
@@ -24208,28 +24204,16 @@
         "@zowe/imperative": "^4.8.1"
       }
     },
-    "packages/provisioning/node_modules/js-yaml": {
-      "version": "3.13.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
-      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
-      "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
     "packages/workflows": {
       "name": "@zowe/zos-workflows-for-zowe-sdk",
-      "version": "6.33.0",
+      "version": "6.33.1",
       "license": "EPL-2.0",
       "dependencies": {
-        "@zowe/zos-files-for-zowe-sdk": "6.33.0"
+        "@zowe/zos-files-for-zowe-sdk": "6.33.1"
       },
       "devDependencies": {
         "@types/node": "^12.12.24",
-        "@zowe/core-for-zowe-sdk": "6.33.0",
+        "@zowe/core-for-zowe-sdk": "6.33.1",
         "@zowe/imperative": "4.15.0",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
@@ -24244,11 +24228,11 @@
     },
     "packages/zosconsole": {
       "name": "@zowe/zos-console-for-zowe-sdk",
-      "version": "6.33.0",
+      "version": "6.33.1",
       "license": "EPL-2.0",
       "devDependencies": {
         "@types/node": "^12.12.24",
-        "@zowe/core-for-zowe-sdk": "6.33.0",
+        "@zowe/core-for-zowe-sdk": "6.33.1",
         "@zowe/imperative": "4.15.0",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
@@ -24263,16 +24247,16 @@
     },
     "packages/zosfiles": {
       "name": "@zowe/zos-files-for-zowe-sdk",
-      "version": "6.33.0",
+      "version": "6.33.1",
       "license": "EPL-2.0",
       "dependencies": {
         "minimatch": "3.0.4"
       },
       "devDependencies": {
         "@types/node": "^12.12.24",
-        "@zowe/core-for-zowe-sdk": "6.33.0",
+        "@zowe/core-for-zowe-sdk": "6.33.1",
         "@zowe/imperative": "4.15.0",
-        "@zowe/zos-uss-for-zowe-sdk": "6.33.0",
+        "@zowe/zos-uss-for-zowe-sdk": "6.33.1",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
         "rimraf": "^2.6.3",
@@ -24286,14 +24270,14 @@
     },
     "packages/zosjobs": {
       "name": "@zowe/zos-jobs-for-zowe-sdk",
-      "version": "6.33.0",
+      "version": "6.33.1",
       "license": "EPL-2.0",
       "dependencies": {
-        "@zowe/zos-files-for-zowe-sdk": "6.33.0"
+        "@zowe/zos-files-for-zowe-sdk": "6.33.1"
       },
       "devDependencies": {
         "@types/node": "^12.12.24",
-        "@zowe/core-for-zowe-sdk": "6.33.0",
+        "@zowe/core-for-zowe-sdk": "6.33.1",
         "@zowe/imperative": "4.15.0",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
@@ -24308,11 +24292,11 @@
     },
     "packages/zosmf": {
       "name": "@zowe/zosmf-for-zowe-sdk",
-      "version": "6.33.0",
+      "version": "6.33.1",
       "license": "EPL-2.0",
       "devDependencies": {
         "@types/node": "^12.12.24",
-        "@zowe/core-for-zowe-sdk": "6.33.0",
+        "@zowe/core-for-zowe-sdk": "6.33.1",
         "@zowe/imperative": "4.15.0",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
@@ -24327,14 +24311,14 @@
     },
     "packages/zostso": {
       "name": "@zowe/zos-tso-for-zowe-sdk",
-      "version": "6.33.0",
+      "version": "6.33.1",
       "license": "EPL-2.0",
       "dependencies": {
-        "@zowe/zosmf-for-zowe-sdk": "6.33.0"
+        "@zowe/zosmf-for-zowe-sdk": "6.33.1"
       },
       "devDependencies": {
         "@types/node": "^12.12.24",
-        "@zowe/core-for-zowe-sdk": "6.33.0",
+        "@zowe/core-for-zowe-sdk": "6.33.1",
         "@zowe/imperative": "4.15.0",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
@@ -24349,10 +24333,10 @@
     },
     "packages/zosuss": {
       "name": "@zowe/zos-uss-for-zowe-sdk",
-      "version": "6.33.0",
+      "version": "6.33.1",
       "license": "EPL-2.0",
       "dependencies": {
-        "ssh2": "0.8.7"
+        "ssh2": "1.4.0"
       },
       "devDependencies": {
         "@types/node": "^12.12.24",
@@ -27822,9 +27806,9 @@
           }
         },
         "tar": {
-          "version": "6.1.8",
-          "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.8.tgz",
-          "integrity": "sha512-sb9b0cp855NbkMJcskdSYA7b11Q8JsX4qe4pyUAfHp+Y6jBjJeek2ZVlwEfWayshEIwlIzXx0Fain3QG9JPm2A==",
+          "version": "6.1.11",
+          "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
+          "integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
           "requires": {
             "chownr": "^2.0.0",
             "fs-minipass": "^2.0.0",
@@ -28400,17 +28384,17 @@
       "version": "file:packages/cli",
       "requires": {
         "@types/node": "^12.12.24",
-        "@zowe/core-for-zowe-sdk": "6.33.0",
+        "@zowe/core-for-zowe-sdk": "6.33.1",
         "@zowe/imperative": "4.15.0",
         "@zowe/perf-timing": "1.0.7",
-        "@zowe/provisioning-for-zowe-sdk": "6.33.0",
-        "@zowe/zos-console-for-zowe-sdk": "6.33.0",
-        "@zowe/zos-files-for-zowe-sdk": "6.33.0",
-        "@zowe/zos-jobs-for-zowe-sdk": "6.33.0",
-        "@zowe/zos-tso-for-zowe-sdk": "6.33.0",
-        "@zowe/zos-uss-for-zowe-sdk": "6.33.0",
-        "@zowe/zos-workflows-for-zowe-sdk": "6.33.0",
-        "@zowe/zosmf-for-zowe-sdk": "6.33.0",
+        "@zowe/provisioning-for-zowe-sdk": "6.33.1",
+        "@zowe/zos-console-for-zowe-sdk": "6.33.1",
+        "@zowe/zos-files-for-zowe-sdk": "6.33.1",
+        "@zowe/zos-jobs-for-zowe-sdk": "6.33.1",
+        "@zowe/zos-tso-for-zowe-sdk": "6.33.1",
+        "@zowe/zos-uss-for-zowe-sdk": "6.33.1",
+        "@zowe/zos-workflows-for-zowe-sdk": "6.33.1",
+        "@zowe/zosmf-for-zowe-sdk": "6.33.1",
         "eslint": "^7.32.0",
         "get-stdin": "7.0.0",
         "js-yaml": "^3.13.1",
@@ -28581,32 +28565,21 @@
       "requires": {
         "@types/js-yaml": "^3.12.5",
         "@types/node": "^12.12.24",
-        "@zowe/core-for-zowe-sdk": "6.33.0",
+        "@zowe/core-for-zowe-sdk": "6.33.1",
         "@zowe/imperative": "4.15.0",
         "eslint": "^7.32.0",
-        "js-yaml": "3.13.1",
+        "js-yaml": "3.14.1",
         "madge": "^4.0.1",
         "rimraf": "^2.6.3",
         "typedoc": "^0.16.0",
         "typescript": "^3.8.0"
-      },
-      "dependencies": {
-        "js-yaml": {
-          "version": "3.13.1",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
-          "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
-          "requires": {
-            "argparse": "^1.0.7",
-            "esprima": "^4.0.0"
-          }
-        }
       }
     },
     "@zowe/zos-console-for-zowe-sdk": {
       "version": "file:packages/zosconsole",
       "requires": {
         "@types/node": "^12.12.24",
-        "@zowe/core-for-zowe-sdk": "6.33.0",
+        "@zowe/core-for-zowe-sdk": "6.33.1",
         "@zowe/imperative": "4.15.0",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
@@ -28619,9 +28592,9 @@
       "version": "file:packages/zosfiles",
       "requires": {
         "@types/node": "^12.12.24",
-        "@zowe/core-for-zowe-sdk": "6.33.0",
+        "@zowe/core-for-zowe-sdk": "6.33.1",
         "@zowe/imperative": "4.15.0",
-        "@zowe/zos-uss-for-zowe-sdk": "6.33.0",
+        "@zowe/zos-uss-for-zowe-sdk": "6.33.1",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
         "minimatch": "3.0.4",
@@ -28634,9 +28607,9 @@
       "version": "file:packages/zosjobs",
       "requires": {
         "@types/node": "^12.12.24",
-        "@zowe/core-for-zowe-sdk": "6.33.0",
+        "@zowe/core-for-zowe-sdk": "6.33.1",
         "@zowe/imperative": "4.15.0",
-        "@zowe/zos-files-for-zowe-sdk": "6.33.0",
+        "@zowe/zos-files-for-zowe-sdk": "6.33.1",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
         "rimraf": "^2.6.3",
@@ -28648,9 +28621,9 @@
       "version": "file:packages/zostso",
       "requires": {
         "@types/node": "^12.12.24",
-        "@zowe/core-for-zowe-sdk": "6.33.0",
+        "@zowe/core-for-zowe-sdk": "6.33.1",
         "@zowe/imperative": "4.15.0",
-        "@zowe/zosmf-for-zowe-sdk": "6.33.0",
+        "@zowe/zosmf-for-zowe-sdk": "6.33.1",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
         "rimraf": "^2.6.3",
@@ -28667,7 +28640,7 @@
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
         "rimraf": "^2.6.3",
-        "ssh2": "0.8.7",
+        "ssh2": "1.4.0",
         "typedoc": "^0.16.0",
         "typescript": "^3.8.0"
       }
@@ -28676,9 +28649,9 @@
       "version": "file:packages/workflows",
       "requires": {
         "@types/node": "^12.12.24",
-        "@zowe/core-for-zowe-sdk": "6.33.0",
+        "@zowe/core-for-zowe-sdk": "6.33.1",
         "@zowe/imperative": "4.15.0",
-        "@zowe/zos-files-for-zowe-sdk": "6.33.0",
+        "@zowe/zos-files-for-zowe-sdk": "6.33.1",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
         "rimraf": "^2.6.3",
@@ -28690,7 +28663,7 @@
       "version": "file:packages/zosmf",
       "requires": {
         "@types/node": "^12.12.24",
-        "@zowe/core-for-zowe-sdk": "6.33.0",
+        "@zowe/core-for-zowe-sdk": "6.33.1",
         "@zowe/imperative": "4.15.0",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
@@ -30612,6 +30585,15 @@
           "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
           "dev": true
         }
+      }
+    },
+    "cpu-features": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/cpu-features/-/cpu-features-0.0.2.tgz",
+      "integrity": "sha512-/2yieBqvMcRj8McNzkycjW2v3OIUOibBfd2dLEJ0nWts8NobAxwiyw9phVNS6oDL8x8tz9F7uNVFEVpJncQpeA==",
+      "optional": true,
+      "requires": {
+        "nan": "^2.14.1"
       }
     },
     "cross-env": {
@@ -37209,7 +37191,6 @@
       "version": "3.14.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
       "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
-      "dev": true,
       "requires": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -38660,7 +38641,6 @@
       "version": "2.15.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
       "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ==",
-      "dev": true,
       "optional": true
     },
     "nanoid": {
@@ -39257,9 +39237,9 @@
           }
         },
         "tar": {
-          "version": "6.1.8",
-          "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.8.tgz",
-          "integrity": "sha512-sb9b0cp855NbkMJcskdSYA7b11Q8JsX4qe4pyUAfHp+Y6jBjJeek2ZVlwEfWayshEIwlIzXx0Fain3QG9JPm2A==",
+          "version": "6.1.11",
+          "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
+          "integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
           "requires": {
             "chownr": "^2.0.0",
             "fs-minipass": "^2.0.0",
@@ -39810,9 +39790,9 @@
           }
         },
         "tar": {
-          "version": "6.1.8",
-          "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.8.tgz",
-          "integrity": "sha512-sb9b0cp855NbkMJcskdSYA7b11Q8JsX4qe4pyUAfHp+Y6jBjJeek2ZVlwEfWayshEIwlIzXx0Fain3QG9JPm2A==",
+          "version": "6.1.11",
+          "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
+          "integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
           "requires": {
             "chownr": "^2.0.0",
             "fs-minipass": "^2.0.0",
@@ -41809,21 +41789,14 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
     "ssh2": {
-      "version": "0.8.7",
-      "resolved": "https://registry.npmjs.org/ssh2/-/ssh2-0.8.7.tgz",
-      "integrity": "sha512-/u1BO12kb0lDVxJXejWB9pxyF3/ncgRqI9vPCZuPzo05pdNDzqUeQRavScwSPsfMGK+5H/VRqp1IierIx0Bcxw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/ssh2/-/ssh2-1.4.0.tgz",
+      "integrity": "sha512-XvXwcXKvS452DyQvCa6Ct+chpucwc/UyxgliYz+rWXJ3jDHdtBb9xgmxJdMmnIn5bpgGAEV3KaEsH98ZGPHqwg==",
       "requires": {
-        "ssh2-streams": "~0.4.8"
-      }
-    },
-    "ssh2-streams": {
-      "version": "0.4.10",
-      "resolved": "https://registry.npmjs.org/ssh2-streams/-/ssh2-streams-0.4.10.tgz",
-      "integrity": "sha512-8pnlMjvnIZJvmTzUIIA5nT4jr2ZWNNVHwyXfMGdRJbug9TpI3kd99ffglgfSWqujVv/0gxwMsDn9j9RVst8yhQ==",
-      "requires": {
-        "asn1": "~0.2.0",
+        "asn1": "^0.2.4",
         "bcrypt-pbkdf": "^1.0.2",
-        "streamsearch": "~0.1.2"
+        "cpu-features": "0.0.2",
+        "nan": "^2.15.0"
       }
     },
     "sshpk": {
@@ -41927,11 +41900,6 @@
           "integrity": "sha512-bYQuGLeFxhkxNOF3rcMtiZxvCBAquGzZm6oWA1oZ0g2THUzivaRhv8uOhdr19LmoobSOLoIAxeUK2RdbM8IFTA=="
         }
       }
-    },
-    "streamsearch": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz",
-      "integrity": "sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo="
     },
     "strict-uri-encode": {
       "version": "2.0.0",
@@ -42275,9 +42243,9 @@
       "dev": true
     },
     "tar": {
-      "version": "4.4.17",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.17.tgz",
-      "integrity": "sha512-q7OwXq6NTdcYIa+k58nEMV3j1euhDhGCs/VRw9ymx/PbH0jtIM2+VTgDE/BW3rbLkrBUXs5fzEKgic5oUciu7g==",
+      "version": "4.4.19",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.19.tgz",
+      "integrity": "sha512-a20gEsvHnWe0ygBY8JbxoM4w3SJdhc7ZAuxkLqh+nvNQN2IOt0B5lLgM490X5Hl8FF0dl0tOf2ewFYAlIFgzVA==",
       "dev": true,
       "requires": {
         "chownr": "^1.1.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
         "packages/*"
       ],
       "dependencies": {
-        "@zowe/imperative": "4.15.0",
+        "@zowe/imperative": "4.15.1",
         "@zowe/perf-timing": "1.0.7"
       },
       "devDependencies": {
@@ -4967,9 +4967,9 @@
       "link": true
     },
     "node_modules/@zowe/imperative": {
-      "version": "4.15.0",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@zowe/imperative/-/@zowe/imperative-4.15.0.tgz",
-      "integrity": "sha1-pEgdDXSIKU2KEtnSAA9LxsVm95o=",
+      "version": "4.15.1",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@zowe/imperative/-/@zowe/imperative-4.15.1.tgz",
+      "integrity": "sha1-BUMseB+eIQx371nKt5pMBmVCXRc=",
       "license": "EPL-2.0",
       "dependencies": {
         "@types/lodash-deep": "2.0.0",
@@ -4983,7 +4983,7 @@
         "find-up": "2.1.0",
         "fs-extra": "8.1.0",
         "glob": "7.1.6",
-        "js-yaml": "3.13.1",
+        "js-yaml": "3.14.1",
         "jsonfile": "4.0.0",
         "jsonschema": "1.1.1",
         "lodash-deep": "2.0.0",
@@ -5079,18 +5079,6 @@
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/@zowe/imperative/node_modules/js-yaml": {
-      "version": "3.13.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
-      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
-      "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/@zowe/imperative/node_modules/rimraf": {
@@ -24122,7 +24110,7 @@
       "license": "EPL-2.0",
       "dependencies": {
         "@zowe/core-for-zowe-sdk": "6.33.1",
-        "@zowe/imperative": "4.15.0",
+        "@zowe/imperative": "4.15.1",
         "@zowe/perf-timing": "1.0.7",
         "@zowe/provisioning-for-zowe-sdk": "6.33.1",
         "@zowe/zos-console-for-zowe-sdk": "6.33.1",
@@ -24169,7 +24157,7 @@
       },
       "devDependencies": {
         "@types/node": "^12.12.24",
-        "@zowe/imperative": "4.15.0",
+        "@zowe/imperative": "4.15.1",
         "chalk": "^4.1.0",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
@@ -24192,7 +24180,7 @@
         "@types/js-yaml": "^3.12.5",
         "@types/node": "^12.12.24",
         "@zowe/core-for-zowe-sdk": "6.33.1",
-        "@zowe/imperative": "4.15.0",
+        "@zowe/imperative": "4.15.1",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
         "rimraf": "^2.6.3",
@@ -24214,7 +24202,7 @@
       "devDependencies": {
         "@types/node": "^12.12.24",
         "@zowe/core-for-zowe-sdk": "6.33.1",
-        "@zowe/imperative": "4.15.0",
+        "@zowe/imperative": "4.15.1",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
         "rimraf": "^2.6.3",
@@ -24233,7 +24221,7 @@
       "devDependencies": {
         "@types/node": "^12.12.24",
         "@zowe/core-for-zowe-sdk": "6.33.1",
-        "@zowe/imperative": "4.15.0",
+        "@zowe/imperative": "4.15.1",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
         "rimraf": "^2.6.3",
@@ -24255,7 +24243,7 @@
       "devDependencies": {
         "@types/node": "^12.12.24",
         "@zowe/core-for-zowe-sdk": "6.33.1",
-        "@zowe/imperative": "4.15.0",
+        "@zowe/imperative": "4.15.1",
         "@zowe/zos-uss-for-zowe-sdk": "6.33.1",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
@@ -24278,7 +24266,7 @@
       "devDependencies": {
         "@types/node": "^12.12.24",
         "@zowe/core-for-zowe-sdk": "6.33.1",
-        "@zowe/imperative": "4.15.0",
+        "@zowe/imperative": "4.15.1",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
         "rimraf": "^2.6.3",
@@ -24297,7 +24285,7 @@
       "devDependencies": {
         "@types/node": "^12.12.24",
         "@zowe/core-for-zowe-sdk": "6.33.1",
-        "@zowe/imperative": "4.15.0",
+        "@zowe/imperative": "4.15.1",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
         "rimraf": "^2.6.3",
@@ -24319,7 +24307,7 @@
       "devDependencies": {
         "@types/node": "^12.12.24",
         "@zowe/core-for-zowe-sdk": "6.33.1",
-        "@zowe/imperative": "4.15.0",
+        "@zowe/imperative": "4.15.1",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
         "rimraf": "^2.6.3",
@@ -24341,7 +24329,7 @@
       "devDependencies": {
         "@types/node": "^12.12.24",
         "@types/ssh2": "^0.5.44",
-        "@zowe/imperative": "4.15.0",
+        "@zowe/imperative": "4.15.1",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
         "rimraf": "^2.6.3",
@@ -28385,7 +28373,7 @@
       "requires": {
         "@types/node": "^12.12.24",
         "@zowe/core-for-zowe-sdk": "6.33.1",
-        "@zowe/imperative": "4.15.0",
+        "@zowe/imperative": "4.15.1",
         "@zowe/perf-timing": "1.0.7",
         "@zowe/provisioning-for-zowe-sdk": "6.33.1",
         "@zowe/zos-console-for-zowe-sdk": "6.33.1",
@@ -28416,7 +28404,7 @@
       "version": "file:packages/core",
       "requires": {
         "@types/node": "^12.12.24",
-        "@zowe/imperative": "4.15.0",
+        "@zowe/imperative": "4.15.1",
         "chalk": "^4.1.0",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
@@ -28427,9 +28415,9 @@
       }
     },
     "@zowe/imperative": {
-      "version": "4.15.0",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@zowe/imperative/-/@zowe/imperative-4.15.0.tgz",
-      "integrity": "sha1-pEgdDXSIKU2KEtnSAA9LxsVm95o=",
+      "version": "4.15.1",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@zowe/imperative/-/@zowe/imperative-4.15.1.tgz",
+      "integrity": "sha1-BUMseB+eIQx371nKt5pMBmVCXRc=",
       "requires": {
         "@types/lodash-deep": "2.0.0",
         "@types/yargs": "13.0.4",
@@ -28442,7 +28430,7 @@
         "find-up": "2.1.0",
         "fs-extra": "8.1.0",
         "glob": "7.1.6",
-        "js-yaml": "3.13.1",
+        "js-yaml": "3.14.1",
         "jsonfile": "4.0.0",
         "jsonschema": "1.1.1",
         "lodash-deep": "2.0.0",
@@ -28519,15 +28507,6 @@
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
           "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
         },
-        "js-yaml": {
-          "version": "3.13.1",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
-          "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
-          "requires": {
-            "argparse": "^1.0.7",
-            "esprima": "^4.0.0"
-          }
-        },
         "rimraf": {
           "version": "2.6.3",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
@@ -28566,7 +28545,7 @@
         "@types/js-yaml": "^3.12.5",
         "@types/node": "^12.12.24",
         "@zowe/core-for-zowe-sdk": "6.33.1",
-        "@zowe/imperative": "4.15.0",
+        "@zowe/imperative": "4.15.1",
         "eslint": "^7.32.0",
         "js-yaml": "3.14.1",
         "madge": "^4.0.1",
@@ -28580,7 +28559,7 @@
       "requires": {
         "@types/node": "^12.12.24",
         "@zowe/core-for-zowe-sdk": "6.33.1",
-        "@zowe/imperative": "4.15.0",
+        "@zowe/imperative": "4.15.1",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
         "rimraf": "^2.6.3",
@@ -28593,7 +28572,7 @@
       "requires": {
         "@types/node": "^12.12.24",
         "@zowe/core-for-zowe-sdk": "6.33.1",
-        "@zowe/imperative": "4.15.0",
+        "@zowe/imperative": "4.15.1",
         "@zowe/zos-uss-for-zowe-sdk": "6.33.1",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
@@ -28608,7 +28587,7 @@
       "requires": {
         "@types/node": "^12.12.24",
         "@zowe/core-for-zowe-sdk": "6.33.1",
-        "@zowe/imperative": "4.15.0",
+        "@zowe/imperative": "4.15.1",
         "@zowe/zos-files-for-zowe-sdk": "6.33.1",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
@@ -28622,7 +28601,7 @@
       "requires": {
         "@types/node": "^12.12.24",
         "@zowe/core-for-zowe-sdk": "6.33.1",
-        "@zowe/imperative": "4.15.0",
+        "@zowe/imperative": "4.15.1",
         "@zowe/zosmf-for-zowe-sdk": "6.33.1",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
@@ -28636,7 +28615,7 @@
       "requires": {
         "@types/node": "^12.12.24",
         "@types/ssh2": "^0.5.44",
-        "@zowe/imperative": "4.15.0",
+        "@zowe/imperative": "4.15.1",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
         "rimraf": "^2.6.3",
@@ -28650,7 +28629,7 @@
       "requires": {
         "@types/node": "^12.12.24",
         "@zowe/core-for-zowe-sdk": "6.33.1",
-        "@zowe/imperative": "4.15.0",
+        "@zowe/imperative": "4.15.1",
         "@zowe/zos-files-for-zowe-sdk": "6.33.1",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
@@ -28664,7 +28643,7 @@
       "requires": {
         "@types/node": "^12.12.24",
         "@zowe/core-for-zowe-sdk": "6.33.1",
-        "@zowe/imperative": "4.15.0",
+        "@zowe/imperative": "4.15.1",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
         "rimraf": "^2.6.3",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "prepare": "husky install"
   },
   "dependencies": {
-    "@zowe/imperative": "4.15.0",
+    "@zowe/imperative": "4.15.1",
     "@zowe/perf-timing": "1.0.7"
   },
   "devDependencies": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -55,7 +55,7 @@
   },
   "dependencies": {
     "@zowe/core-for-zowe-sdk": "6.33.1",
-    "@zowe/imperative": "4.15.0",
+    "@zowe/imperative": "4.15.1",
     "@zowe/perf-timing": "1.0.7",
     "@zowe/provisioning-for-zowe-sdk": "6.33.1",
     "@zowe/zos-console-for-zowe-sdk": "6.33.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -48,7 +48,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.12.24",
-    "@zowe/imperative": "4.15.0",
+    "@zowe/imperative": "4.15.1",
     "chalk": "^4.1.0",
     "eslint": "^7.32.0",
     "madge": "^4.0.1",

--- a/packages/provisioning/CHANGELOG.md
+++ b/packages/provisioning/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Zowe provisioning SDK package will be documented in this file.
 
+## Recent Changes
+
+- Bugfix: Update `js-yaml` dependency to resolve a potential vulnerability
+
 ## `6.33.1`
 
 - Migrated from TSLint (now deprecated) to ESLint for static code analysis.

--- a/packages/provisioning/package.json
+++ b/packages/provisioning/package.json
@@ -50,7 +50,7 @@
     "@types/js-yaml": "^3.12.5",
     "@types/node": "^12.12.24",
     "@zowe/core-for-zowe-sdk": "6.33.1",
-    "@zowe/imperative": "4.15.0",
+    "@zowe/imperative": "4.15.1",
     "eslint": "^7.32.0",
     "madge": "^4.0.1",
     "rimraf": "^2.6.3",

--- a/packages/provisioning/package.json
+++ b/packages/provisioning/package.json
@@ -44,7 +44,7 @@
     "typedocSpecifySrc": "typedoc --options ./typedoc.json"
   },
   "dependencies": {
-    "js-yaml": "3.13.1"
+    "js-yaml": "3.14.1"
   },
   "devDependencies": {
     "@types/js-yaml": "^3.12.5",

--- a/packages/workflows/package.json
+++ b/packages/workflows/package.json
@@ -49,7 +49,7 @@
   "devDependencies": {
     "@types/node": "^12.12.24",
     "@zowe/core-for-zowe-sdk": "6.33.1",
-    "@zowe/imperative": "4.15.0",
+    "@zowe/imperative": "4.15.1",
     "eslint": "^7.32.0",
     "madge": "^4.0.1",
     "rimraf": "^2.6.3",

--- a/packages/zosconsole/package.json
+++ b/packages/zosconsole/package.json
@@ -46,7 +46,7 @@
   "devDependencies": {
     "@types/node": "^12.12.24",
     "@zowe/core-for-zowe-sdk": "6.33.1",
-    "@zowe/imperative": "4.15.0",
+    "@zowe/imperative": "4.15.1",
     "eslint": "^7.32.0",
     "madge": "^4.0.1",
     "rimraf": "^2.6.3",

--- a/packages/zosfiles/package.json
+++ b/packages/zosfiles/package.json
@@ -50,7 +50,7 @@
   "devDependencies": {
     "@types/node": "^12.12.24",
     "@zowe/core-for-zowe-sdk": "6.33.1",
-    "@zowe/imperative": "4.15.0",
+    "@zowe/imperative": "4.15.1",
     "@zowe/zos-uss-for-zowe-sdk": "6.33.1",
     "eslint": "^7.32.0",
     "madge": "^4.0.1",

--- a/packages/zosjobs/package.json
+++ b/packages/zosjobs/package.json
@@ -50,7 +50,7 @@
   "devDependencies": {
     "@types/node": "^12.12.24",
     "@zowe/core-for-zowe-sdk": "6.33.1",
-    "@zowe/imperative": "4.15.0",
+    "@zowe/imperative": "4.15.1",
     "eslint": "^7.32.0",
     "madge": "^4.0.1",
     "rimraf": "^2.6.3",

--- a/packages/zosmf/package.json
+++ b/packages/zosmf/package.json
@@ -45,7 +45,7 @@
   "devDependencies": {
     "@types/node": "^12.12.24",
     "@zowe/core-for-zowe-sdk": "6.33.1",
-    "@zowe/imperative": "4.15.0",
+    "@zowe/imperative": "4.15.1",
     "eslint": "^7.32.0",
     "madge": "^4.0.1",
     "rimraf": "^2.6.3",

--- a/packages/zostso/package.json
+++ b/packages/zostso/package.json
@@ -49,7 +49,7 @@
   "devDependencies": {
     "@types/node": "^12.12.24",
     "@zowe/core-for-zowe-sdk": "6.33.1",
-    "@zowe/imperative": "4.15.0",
+    "@zowe/imperative": "4.15.1",
     "eslint": "^7.32.0",
     "madge": "^4.0.1",
     "rimraf": "^2.6.3",

--- a/packages/zosuss/CHANGELOG.md
+++ b/packages/zosuss/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Zowe z/OS USS SDK package will be documented in this file.
 
+## Recent Changes
+
+- Bugfix: Update `ssh2` dependency to avoid false positives on a vulnerability
+
 ## `6.33.1`
 
 - Migrated from TSLint (now deprecated) to ESLint for static code analysis.

--- a/packages/zosuss/package.json
+++ b/packages/zosuss/package.json
@@ -44,7 +44,7 @@
     "typedocSpecifySrc": "typedoc --options ./typedoc.json"
   },
   "dependencies": {
-    "ssh2": "0.8.7"
+    "ssh2": "1.4.0"
   },
   "devDependencies": {
     "@types/node": "^12.12.24",

--- a/packages/zosuss/package.json
+++ b/packages/zosuss/package.json
@@ -49,7 +49,7 @@
   "devDependencies": {
     "@types/node": "^12.12.24",
     "@types/ssh2": "^0.5.44",
-    "@zowe/imperative": "4.15.0",
+    "@zowe/imperative": "4.15.1",
     "eslint": "^7.32.0",
     "madge": "^4.0.1",
     "rimraf": "^2.6.3",

--- a/packages/zosuss/src/Shell.ts
+++ b/packages/zosuss/src/Shell.ts
@@ -10,10 +10,9 @@
 */
 
 import { Logger, ImperativeError } from "@zowe/imperative";
-import { ClientChannel } from "ssh2";
+import { ClientChannel, Client } from "ssh2";
 import { SshSession } from "./SshSession";
 import { ZosUssMessages } from "./constants/ZosUss.messages";
-const Client = require("ssh2");
 
 // These are needed for authenticationHandler
 let authPos = 0;


### PR DESCRIPTION
Updates js-yaml and ssh2 dependencies for Zowe release.
~~Requires Imperative #666 to be merged first, and Imperative updated in package.json~~  ✅Done

Note: System tests run against changes to Shell.ts due to dependency breaking change, all 8 tests passed.

Requires patch release.

Signed-off-by: Andrew W. Harn <andrew.harn@broadcom.com>