### PR TITLE
[next] Bundle prebuilt daemon binaries in CLI package

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -169,6 +169,20 @@ node('zowe-jenkins-agent-dind') {
     )
 
     pipeline.createStage(
+        name: "Bundle Daemon Binaries",
+        shouldExecute: {
+            return pipeline.protectedBranches.isProtected(BRANCH_NAME)
+        },
+        timeout: [time: 10, unit: 'MINUTES'],
+        stage: {
+            def daemonVer = readProperties(file: "zowex/Cargo.toml").version
+            withCredentials([usernamePassword(credentialsId: 'zowe-robot-github', usernameVariable: 'USERNAME', passwordVariable: 'TOKEN')]) {
+                sh "bash jenkins/bundleDaemon.sh ${daemonVer} \"${USERNAME}:${TOKEN}\""
+            }
+        }
+    )
+
+    pipeline.createStage(
         name: "Bundle Keytar Binaries",
         shouldExecute: {
             return pipeline.protectedBranches.isProtected(BRANCH_NAME)

--- a/jenkins/bundleDaemon.sh
+++ b/jenkins/bundleDaemon.sh
@@ -6,7 +6,7 @@ daemonVersion=$1
 githubAuthHeader=$2
 
 until [[ $(curl -fs https://$githubAuthHeader@api.github.com/repos/zowe/zowe-cli/releases/tags/native-v$daemonVersion |
-    jq -r '.assets | length') = '3' ]]; do
+    jq -r '.assets | length') == "3" ]]; do
     echo "Waiting for Rust CLI Publish workflow to complete..."
     sleep 30
 done

--- a/jenkins/bundleDaemon.sh
+++ b/jenkins/bundleDaemon.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Usage: bash bundleDaemon.sh <daemonVersion> [githubAuthHeader]
+set -ex
+
+daemonVersion=$1
+githubAuthHeader=$2
+
+until [[ $(curl -fs https://$githubAuthHeader@api.github.com/repos/zowe/zowe-cli/releases/tags/native-v$daemonVersion |
+    jq -r '.assets | length') = '3' ]]; do
+    echo "Waiting for Rust CLI Publish workflow to complete..."
+    sleep 30
+done
+
+cd "$(git rev-parse --show-toplevel)"
+rm -rf prebuilds
+mkdir prebuilds && cd prebuilds
+
+for platform in linux macos windows; do
+    curl -fsLOJ https://github.com/zowe/zowe-cli/releases/download/native-v$daemonVersion/zowe-$platform.tgz
+done
+
+cd ..
+mv prebuilds packages/cli/


### PR DESCRIPTION
Resolves #1175 

These changes were tested in [another branch](https://github.com/zowe/zowe-cli/compare/next...test-timothy) and produced this TGZ:
https://wash.zowe.org:8443/job/brightside/job/test-timothy/8/artifact/packages/cli/zowe-cli-7.0.0-next.202110211759.tgz

![image](https://user-images.githubusercontent.com/22344007/140329171-fad9a6de-2b18-4b5b-b513-1c7e9b5b08cd.png)

No changes were required to the `files` property in package.json - "prebuilds" was already listed there since we used it previously for bundling Keytar prebuilds.
https://github.com/zowe/zowe-cli/blob/dbef8dc93e5d8fc3bf4d5e2e2fbd4c8fce94db18/packages/cli/package.json#L30-L35