### PR TITLE
etag and hidden alias

### DIFF
--- a/packages/cli/src/zosfiles/-strings-/en.ts
+++ b/packages/cli/src/zosfiles/-strings-/en.ts
@@ -347,6 +347,8 @@ export default {
                 "only when the data set is not cataloged on the system. A VOLSER is analogous to a drive name on a PC.",
             BINARY: "Download the file content in binary mode, which means that no data conversion is performed. The data transfer process " +
                 "returns each line as-is, without translation. No delimiters are added between records.",
+            ETAG: "Return the ETag token to determine if the data on z/OS host has changed.",
+            MATCH: "ETag token use for match checking before download begins.",
             ENCODING: "Download the file content with encoding mode, which means that data conversion is performed using the file encoding " +
                 "specified.",
             FAIL_FAST: "Set this option to false to continue downloading dataset members if one or more fail.",

--- a/packages/cli/src/zosfiles/create/Create.options.ts
+++ b/packages/cli/src/zosfiles/create/Create.options.ts
@@ -34,10 +34,23 @@ export const ZosFilesCreateExtraOptions: { [key: string]: ICommandOptionDefiniti
     /**
      * The indicator that we should print all allocation attributes
      * @type {ICommandOptionDefinition}
+     * @deprecated
      */
     showAttributes: {
         name: "show-attributes",
         aliases: ["pa"],
+        description: strings.SHOWATTRIBUTES,
+        hidden: true,
+        type: "boolean"
+    },
+
+    /**
+     * The indicator that we should print all allocation attributes
+     * @type {ICommandOptionDefinition}
+     */
+    attributes: {
+        name: "attributes",
+        aliases: ["a"],
         description: strings.SHOWATTRIBUTES,
         type: "boolean"
     },

--- a/packages/cli/src/zosfiles/create/pds/Pds.definition.ts
+++ b/packages/cli/src/zosfiles/create/pds/Pds.definition.ts
@@ -52,7 +52,8 @@ export const PdsDefinition: ICommandDefinition = {
         ZosFilesCreateOptions.dataclass,
         ZosFilesCreateOptions.unit,
         ZosFilesCreateOptions.dsntype,
-        ZosFilesCreateExtraOptions.showAttributes
+        ZosFilesCreateExtraOptions.showAttributes,
+        ZosFilesCreateExtraOptions.attributes,
     ].sort((a, b) => a.name.localeCompare(b.name)),
     examples: [
         {

--- a/packages/cli/src/zosfiles/download/Download.options.ts
+++ b/packages/cli/src/zosfiles/download/Download.options.ts
@@ -45,6 +45,26 @@ export const DownloadOptions: { [key: string]: ICommandOptionDefinition } = {
     },
 
     /**
+     * The etag option
+     * @type {ICommandOptionDefinition}
+     */
+    etag: {
+        name: "etag",
+        description: strings.ETAG,
+        type: "boolean"
+    },
+
+    /**
+     * The etag hash to check for match
+     * @type {ICommandOptionDefinition}
+     */
+    match: {
+        name: "match",
+        description: strings.ETAG,
+        type: "string"
+    },
+
+    /**
      * The encoding option
      * @type {ICommandOptionDefinition}
      */

--- a/packages/cli/src/zosfiles/download/ds/Dataset.definition.ts
+++ b/packages/cli/src/zosfiles/download/ds/Dataset.definition.ts
@@ -44,7 +44,9 @@ export const DatasetDefinition: ICommandDefinition = {
         DownloadOptions.extension,
         DownloadOptions.binary,
         DownloadOptions.preserveOriginalLetterCase,
-        DownloadOptions.encoding
+        DownloadOptions.encoding,
+        DownloadOptions.etag,
+        DownloadOptions.match
     ].sort((a, b) => a.name.localeCompare(b.name)),
     examples: [
         {

--- a/packages/cli/src/zosfiles/download/ds/Dataset.handler.ts
+++ b/packages/cli/src/zosfiles/download/ds/Dataset.handler.ts
@@ -33,7 +33,9 @@ export default class DatasetHandler extends ZosFilesBaseHandler {
             extension: commandParameters.arguments.extension,
             preserveOriginalLetterCase: commandParameters.arguments.preserveOriginalLetterCase,
             task,
-            responseTimeout: commandParameters.arguments.responseTimeout
+            responseTimeout: commandParameters.arguments.responseTimeout,
+            returnEtag: commandParameters.arguments.etag,
+            match: commandParameters.arguments.match
         });
     }
 }

--- a/packages/core/src/rest/ZosmfRestClient.ts
+++ b/packages/core/src/rest/ZosmfRestClient.ts
@@ -22,11 +22,33 @@ import { ZosmfHeaders } from "./ZosmfHeaders";
 export class ZosmfRestClient extends RestClient {
 
     /**
+     * Not modified if Etag toke is present and matches
+     * @static
+     * @memberof ZosmfRestClient
+     */
+    public static readonly HTTP_STATUS_NOT_MODIFIED = 304;
+
+    /**
      * Use the Brightside logger instead of the imperative logger
      * @type {Logger}
      */
     public get log(): Logger {
         return Logger.getAppLogger();
+    }
+
+    /**
+     * Success for HTTP 304 Not Modified
+     * @readonly
+     * @type {boolean}
+     * @memberof ZosmfRestClient
+     */
+    get requestSuccess(): boolean {
+        if (this.response == null) {
+            return false;
+        } else {
+            return ((this.response.statusCode >= RestConstants.HTTP_STATUS_200 &&
+                this.response.statusCode < RestConstants.HTTP_STATUS_300) || this.response.statusCode === ZosmfRestClient.HTTP_STATUS_NOT_MODIFIED);
+        }
     }
 
     /**

--- a/packages/zosfiles/src/constants/ZosFiles.messages.ts
+++ b/packages/zosfiles/src/constants/ZosFiles.messages.ts
@@ -135,6 +135,14 @@ export const ZosFilesMessages: { [key: string]: IMessageDefinition } = {
     },
 
     /**
+     * Message indicating that the data set was downloaded successfully
+     * @type {IMessageDefinition}
+     */
+    datasetDownloadSkipped: {
+        message: "Data set download skipped.\nContent unchanged from: %s"
+    },
+
+    /**
      * Message indicating that the uss file was downloaded successfully
      * @type {IMessageDefinition}
      */

--- a/packages/zosfiles/src/methods/download/doc/IDownloadOptions.ts
+++ b/packages/zosfiles/src/methods/download/doc/IDownloadOptions.ts
@@ -80,4 +80,9 @@ export interface IDownloadOptions extends IOptions {
      * The default value is true for backward compatibility.
      */
     failFast?: boolean;
+
+    /**
+     * Indicates download should only occur if z/OS data hash indicated by ETag is different from input token.
+     */
+    match?: string;
 }


### PR DESCRIPTION
Fix #1204
Partially address #598 

The proposal is to add an `--etag` option on a `zowe files download ds` command.  ETag is only returned when `--rfj` is specified.  I did this because ["If this header is enabled for very large data sets, then performance is impacted since the data set must be read twice by the system."](https://www.ibm.com/docs/en/zos/2.3.0?topic=interface-retrieve-contents-zos-data-set-member).  

Here is a sample download response:
```
C:\dev\asm\source>zowe files download ds SOURE.DATA.SET(MEMBER) --extension .tst  --etag --rfj
{
  "success": true,
  "exitCode": 0,
  "message": "",
  "stdout": "Data set downloaded successfully.\nDestination: ...\n",
  "stderr": "",
  "data": {
    "success": true,
    "commandResponse": "Data set downloaded successfully.\nDestination: ...",
    "apiResponse": {
      "etag": "E765D80FF818BAA1772482569E6FF2DD"
    }
  }
}
```

Secondly, I added a `--match` keyword to the download command for which you can supply an ETag which presents a `If-None-Match` header.  

With both `--etag` and `--match`, I satisfy my own use case where I want to loop through and only download changed files from z/OS.   I'll leave this in draft for for feedback before proceeding to refine any tests.   


Signed-off-by: Dan Kelosky <dkelosky@gmail.com>