### PR TITLE
Update Daemon Bundling Script

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -180,7 +180,7 @@ node('zowe-jenkins-agent-dind') {
             withCredentials([usernamePassword(credentialsId: 'zowe-robot-github', usernameVariable: 'USERNAME', passwordVariable: 'TOKEN')]) {
                 sh "bash jenkins/bundleDaemon.sh ${daemonVer} \"${USERNAME}:${TOKEN}\""
             }
-            archiveArtifacts artifacts: "packages/cli/prebuilds"
+            archiveArtifacts artifacts: "packages/cli/prebuilds/*"
         }
     )
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -171,7 +171,8 @@ node('zowe-jenkins-agent-dind') {
     pipeline.createStage(
         name: "Bundle Daemon Binaries",
         shouldExecute: {
-            return pipeline.protectedBranches.isProtected(BRANCH_NAME)
+            return true
+            // return pipeline.protectedBranches.isProtected(BRANCH_NAME)
         },
         timeout: [time: 10, unit: 'MINUTES'],
         stage: {
@@ -179,6 +180,7 @@ node('zowe-jenkins-agent-dind') {
             withCredentials([usernamePassword(credentialsId: 'zowe-robot-github', usernameVariable: 'USERNAME', passwordVariable: 'TOKEN')]) {
                 sh "bash jenkins/bundleDaemon.sh ${daemonVer} \"${USERNAME}:${TOKEN}\""
             }
+            archiveArtifacts artifacts: "packages/cli/prebuilds"
         }
     )
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -171,8 +171,7 @@ node('zowe-jenkins-agent-dind') {
     pipeline.createStage(
         name: "Bundle Daemon Binaries",
         shouldExecute: {
-            return true
-            // return pipeline.protectedBranches.isProtected(BRANCH_NAME)
+            return pipeline.protectedBranches.isProtected(BRANCH_NAME)
         },
         timeout: [time: 10, unit: 'MINUTES'],
         stage: {

--- a/jenkins/bundleDaemon.sh
+++ b/jenkins/bundleDaemon.sh
@@ -19,5 +19,8 @@ for platform in linux macos windows; do
     curl -fsLOJ https://github.com/zowe/zowe-cli/releases/download/native-v$daemonVersion/zowe-$platform.tgz
 done
 
+curl -fsLOJ https://raw.githubusercontent.com/zowe/zowe-cli/native-v$daemonVersion/zowex/Cargo.toml
+curl -fsLOJ https://raw.githubusercontent.com/zowe/zowe-cli/native-v$daemonVersion/zowex/Cargo.lock
+
 cd ..
 mv prebuilds packages/cli/


### PR DESCRIPTION
Include the Cargo.toml and Cargo.lock files so the dependencies that were used can be determined in other pipelines.
Archive the artifacts from the Daemon Bundling step in the Jenkins pipeline