### PR TITLE
[next] Get all tests passing with daemon mode on Ubuntu

### DIFF
--- a/.github/workflows/zowe-cli.yml
+++ b/.github/workflows/zowe-cli.yml
@@ -80,7 +80,7 @@ jobs:
       if: github.event.inputs.test-type == 'binary' || github.event_name == 'push'
       run: |
         cargo build --verbose ${{ github.event.inputs.binary-type == 'release' && '--release' || '' }} --manifest-path=zowex/Cargo.toml
-        tar -cvzf zowe.tgz -C zowex/target/${{ github.event.inputs.binary-type == 'release' && 'release' || 'debug' }}  zowe${{ matrix.os == 'windows-latest' && '.exe' || '' }}
+        tar -cvzf zowe.tgz -C zowex/target/${{ github.event.inputs.binary-type == 'release' && 'release' || 'debug' }} zowe${{ matrix.os == 'windows-latest' && '.exe' || '' }}
 
     - name: Archive Binary
       if: github.event.inputs.test-type == 'binary' || github.event_name == 'push'
@@ -93,7 +93,7 @@ jobs:
     - name: Setup Binary in PATH
       if: github.event.inputs.test-type == 'binary' || github.event_name == 'push'
       id: setup-binary
-      run: tar -xvzf zowe.tgz -C ./__tests__/__resources__/application_instances ${{ matrix.os == 'ubuntu-latest' && '--overwrite' || '' }}
+      run: tar -xvzf zowe.tgz -C ./__tests__/__resources__/daemon_instances
 
     - name: Unit Tests
       id: unit

--- a/__tests__/__src__/environment/TestEnvironment.ts
+++ b/__tests__/__src__/environment/TestEnvironment.ts
@@ -40,7 +40,11 @@ export class TestEnvironment extends BaseTestEnvironment {
 
         // Ensure correct path separator for windows or linux like systems.
         const separator = process.platform === "win32" ? ";" : ":";
-        result.env.PATH = `${nodePath.resolve(__dirname, "../../__resources__/application_instances")}${separator}${process.env.PATH}`;
+        result.env.PATH = [
+            nodePath.resolve(__dirname, "../../__resources__/daemon_instances"),
+            nodePath.resolve(__dirname, "../../__resources__/application_instances"),
+            process.env.PATH
+        ].join(separator);
 
         // Return the test environment including working directory that the tests should be using
         return result;

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Zowe CLI package will be documented in this file.
 
+## Recent Changes
+
+- **Next Breaking**: Remove hardcoded `--dcd` argument sent between imperative daemon server and client.
+
 ## `7.0.0-next.202112021313`
 
 - **Next Breaking**: Use JSON-based communication protocol between imperative daemon server and client.

--- a/packages/cli/__tests__/DaemonClient.unit.test.ts
+++ b/packages/cli/__tests__/DaemonClient.unit.test.ts
@@ -49,7 +49,7 @@ describe("DaemonClient tests", () => {
         daemonClient.run();
         // force `data` call and verify input is from instantiation of DaemonClient
         // and is what is passed to mocked Imperative.parse via snapshot
-        (daemonClient as any).data("some data", {whatever: "context I want"});
+        (daemonClient as any).data("PWD\fsome data", {whatever: "context I want"});
     });
 
     it("should ignore JSON response data used for prompting when received", () => {

--- a/packages/cli/__tests__/DaemonClient.unit.test.ts
+++ b/packages/cli/__tests__/DaemonClient.unit.test.ts
@@ -49,7 +49,7 @@ describe("DaemonClient tests", () => {
         daemonClient.run();
         // force `data` call and verify input is from instantiation of DaemonClient
         // and is what is passed to mocked Imperative.parse via snapshot
-        (daemonClient as any).data("PWD\fsome data", {whatever: "context I want"});
+        (daemonClient as any).data("PWD\rsome data", {whatever: "context I want"});
     });
 
     it("should ignore JSON response data used for prompting when received", () => {

--- a/packages/cli/__tests__/__snapshots__/DaemonClient.unit.test.ts.snap
+++ b/packages/cli/__tests__/__snapshots__/DaemonClient.unit.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`DaemonClient tests should process data when received 1`] = `"some data"`;
+exports[`DaemonClient tests should process data when received 1`] = `"some data --dcd PWD"`;
 
 exports[`DaemonClient tests should process data when received 2`] = `
 Object {

--- a/packages/cli/src/DaemonClient.ts
+++ b/packages/cli/src/DaemonClient.ts
@@ -103,9 +103,12 @@ export class DaemonClient {
             // accept input parameters as we do without running in a server mode and pass our clients stream
             // handle as context
         } else {
-            Imperative.api.appLogger.trace(`daemon input command: ${data.toString()}`);
-            Imperative.commandLine = data.toString();
-            Imperative.parse(data.toString(), { stream: this.mClient });
+            const [cwd, cmdInput] = stringData.split("\f", 2);
+            Imperative.api.appLogger.trace(`daemon input command: ${cmdInput}`);
+            Imperative.commandLine = cmdInput;
+            // TODO Remove the --dcd hack - perhaps use PWD env var instead?
+            // This will be a bigger problem when we need to support multitenancy
+            Imperative.parse(`${cmdInput} --dcd ${cwd}`, { stream: this.mClient });
         }
     }
 }

--- a/packages/cli/src/DaemonClient.ts
+++ b/packages/cli/src/DaemonClient.ts
@@ -103,7 +103,7 @@ export class DaemonClient {
             // accept input parameters as we do without running in a server mode and pass our clients stream
             // handle as context
         } else {
-            const [cwd, cmdInput] = stringData.split("\f", 2);
+            const [cwd, cmdInput] = stringData.split("\r", 2);
             Imperative.api.appLogger.trace(`daemon input command: ${cmdInput}`);
             Imperative.commandLine = cmdInput;
             // TODO Remove the --dcd hack - perhaps use PWD env var instead?

--- a/zowex/src/main.rs
+++ b/zowex/src/main.rs
@@ -163,10 +163,9 @@ fn arg_vec_to_string(arg_vec: Vec<String>) -> String {
 }
 
 fn run_daemon_command(mut args: String) -> std::io::Result<()> {
-    args.push_str(" --dcd ");
     let path = env::current_dir()?;
-    args.push_str(path.to_str().unwrap());
-    args.push_str("/");
+    args.insert(0, '\x0c');
+    args.insert_str(0, path.to_str().unwrap());
     let mut _resp = args.as_bytes(); // as utf8 bytes
 
     if _resp.is_empty() {

--- a/zowex/src/main.rs
+++ b/zowex/src/main.rs
@@ -165,7 +165,7 @@ fn arg_vec_to_string(arg_vec: Vec<String>) -> String {
 
 fn run_daemon_command(mut args: String) -> std::io::Result<()> {
     let path = env::current_dir()?;
-    args.insert(0, '\x0c');
+    args.insert(0, '\r');
     args.insert_str(0, path.to_str().unwrap());
     let mut _resp = args.as_bytes(); // as utf8 bytes
 

--- a/zowex/src/main.rs
+++ b/zowex/src/main.rs
@@ -426,7 +426,7 @@ fn is_daemon_running() -> DaemonProcInfo {
     sys.refresh_all();
     for (pid, process) in sys.processes() {
         if process.name().to_lowercase().contains("node") &&
-           process.cmd().len() > 0 &&
+           process.cmd().len() > 2 &&
            process.cmd()[1].to_lowercase().contains("@zowe") &&
            process.cmd()[1].to_lowercase().contains("cli") &&
            process.cmd()[2].to_lowercase() == "--daemon"

--- a/zowex/src/main.rs
+++ b/zowex/src/main.rs
@@ -145,10 +145,11 @@ fn arg_vec_to_string(arg_vec: Vec<String>) -> String {
             arg_string.push(' ');
         }
 
-        /* An argument that contains a space must be enclosed in double quotes
-         * when it is placed into a single argument string.
+        /* An argument that contains a space, or is an empty string, must be
+         * enclosed in double quotes when it is placed into a single argument
+         * string.
          */
-        if next_arg.contains(' ') {
+        if next_arg.contains(' ') || next_arg.len() == 0 {
             arg_string.push('"');
             arg_string.push_str(next_arg);
             arg_string.push('"');


### PR DESCRIPTION
The current state of GitHub workflows is:
* Windows - _not_ using daemon binary 😢 so it passes
* Ubuntu, macOS - using daemon binary, lots of errors

This PR changes that status to:
* Ubuntu - using daemon binary, all tests pass 🚀 
* Windows, macOS - using daemon binary, still lots of errors (but all platform-specific ones)

Going forward, we can ensure that our tests pass in daemon mode 🙂

The following fixes were made:
* In daemon client, only check Node processes with at least 3 command line arguments (fixes Node 12 test failures).
* In daemon client, wrap empty string arguments in quotes (fixes a CLI integration test failure).
* In daemon client and server, pass current directory in the format `<currentDirectory>\r<zoweCommand>` where "\r" is a carriage return character. This moves the hardcoded `--dcd` argument down to a lower level, since the daemon client no longer knows about it, and the daemon server can now hide it from the Imperative command line (fixes several test failures).
* In test environment, put "daemon_instances" directory higher on PATH than "application_instances" so that daemon binary always has priority over NPM bin scripts on all platforms.