### PR TITLE
Update Imperative version and Changelog

### DIFF
--- a/__tests__/__packages__/cli-test-utils/package.json
+++ b/__tests__/__packages__/cli-test-utils/package.json
@@ -43,7 +43,7 @@
   },
   "devDependencies": {
     "@types/node": "^14.14.37",
-    "@zowe/imperative": "5.0.0-next.202112101814",
+    "@zowe/imperative": "5.0.0-next.202112132158",
     "eslint": "^7.32.0",
     "rimraf": "^3.0.2",
     "typescript": "^4.2.3"

--- a/package-lock.json
+++ b/package-lock.json
@@ -74,7 +74,7 @@
       },
       "devDependencies": {
         "@types/node": "^14.14.37",
-        "@zowe/imperative": "5.0.0-next.202112101814",
+        "@zowe/imperative": "5.0.0-next.202112132158",
         "eslint": "^7.32.0",
         "rimraf": "^3.0.2",
         "typescript": "^4.2.3"
@@ -88,157 +88,9 @@
       "dev": true,
       "license": "MIT"
     },
-    "__tests__/__packages__/cli-test-utils/node_modules/@zowe/imperative": {
-      "version": "5.0.0-next.202112101814",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-local-release/@zowe/imperative/-/@zowe/imperative-5.0.0-next.202112101814.tgz",
-      "integrity": "sha1-thpGvXuiYGpDdjgSyHSFD8bhaRA=",
-      "dev": true,
-      "license": "EPL-2.0",
-      "dependencies": {
-        "@types/lodash-deep": "2.0.0",
-        "@types/yargs": "13.0.4",
-        "@zowe/perf-timing": "1.0.7",
-        "chalk": "2.4.2",
-        "cli-table3": "0.6.0",
-        "comment-json": "4.1.0",
-        "dataobject-parser": "1.2.1",
-        "deepmerge": "4.2.2",
-        "fast-glob": "3.2.7",
-        "fastest-levenshtein": "1.0.12",
-        "find-up": "4.1.0",
-        "fs-extra": "8.1.0",
-        "glob": "7.1.6",
-        "jest-diff": "27.0.6",
-        "js-yaml": "3.14.1",
-        "jsonfile": "4.0.0",
-        "jsonschema": "1.1.1",
-        "lodash": "4.17.21",
-        "lodash-deep": "2.0.0",
-        "log4js": "6.3.0",
-        "markdown-it": "12.0.4",
-        "moment": "2.20.1",
-        "mustache": "2.3.0",
-        "npm-package-arg": "8.1.1",
-        "open": "8.2.1",
-        "opener": "1.5.2",
-        "pacote": "11.1.4",
-        "prettyjson": "1.2.1",
-        "progress": "2.0.3",
-        "read": "1.0.7",
-        "readline-sync": "1.4.10",
-        "rimraf": "2.6.3",
-        "sanitize-html": "2.3.2",
-        "semver": "5.7.0",
-        "stack-trace": "0.0.10",
-        "strip-ansi": "6.0.1",
-        "wrap-ansi": "7.0.0",
-        "yamljs": "0.3.0",
-        "yargs": "15.3.1"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "__tests__/__packages__/cli-test-utils/node_modules/@zowe/imperative/node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
-    },
-    "__tests__/__packages__/cli-test-utils/node_modules/@zowe/imperative/node_modules/find-up": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-      "dev": true,
-      "dependencies": {
-        "locate-path": "^5.0.0",
-        "path-exists": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "__tests__/__packages__/cli-test-utils/node_modules/@zowe/imperative/node_modules/js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
-      "dev": true,
-      "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
-    "__tests__/__packages__/cli-test-utils/node_modules/@zowe/imperative/node_modules/rimraf": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
-      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
-      "dev": true,
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      }
-    },
-    "__tests__/__packages__/cli-test-utils/node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "__tests__/__packages__/cli-test-utils/node_modules/argparse": {
       "version": "2.0.1",
       "license": "Python-2.0"
-    },
-    "__tests__/__packages__/cli-test-utils/node_modules/chalk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "__tests__/__packages__/cli-test-utils/node_modules/color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "__tests__/__packages__/cli-test-utils/node_modules/color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true
-    },
-    "__tests__/__packages__/cli-test-utils/node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.8.0"
-      }
     },
     "__tests__/__packages__/cli-test-utils/node_modules/find-up": {
       "version": "5.0.0",
@@ -285,15 +137,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "__tests__/__packages__/cli-test-utils/node_modules/has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
       }
     },
     "__tests__/__packages__/cli-test-utils/node_modules/js-yaml": {
@@ -344,27 +187,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "__tests__/__packages__/cli-test-utils/node_modules/semver": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-      "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
-    "__tests__/__packages__/cli-test-utils/node_modules/supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "__tests__/__packages__/cli-test-utils/node_modules/typescript": {
@@ -26538,7 +26360,7 @@
       "license": "EPL-2.0",
       "dependencies": {
         "@zowe/core-for-zowe-sdk": "7.0.0-next.202112102143",
-        "@zowe/imperative": "5.0.0-next.202112101814",
+        "@zowe/imperative": "5.0.0-next.202112132158",
         "@zowe/perf-timing": "1.0.7",
         "@zowe/provisioning-for-zowe-sdk": "7.0.0-next.202112102143",
         "@zowe/zos-console-for-zowe-sdk": "7.0.0-next.202112102143",
@@ -26577,101 +26399,6 @@
         "keytar": "7.7.0"
       }
     },
-    "packages/cli/node_modules/@zowe/imperative": {
-      "version": "5.0.0-next.202112101814",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-local-release/@zowe/imperative/-/@zowe/imperative-5.0.0-next.202112101814.tgz",
-      "integrity": "sha1-thpGvXuiYGpDdjgSyHSFD8bhaRA=",
-      "license": "EPL-2.0",
-      "dependencies": {
-        "@types/lodash-deep": "2.0.0",
-        "@types/yargs": "13.0.4",
-        "@zowe/perf-timing": "1.0.7",
-        "chalk": "2.4.2",
-        "cli-table3": "0.6.0",
-        "comment-json": "4.1.0",
-        "dataobject-parser": "1.2.1",
-        "deepmerge": "4.2.2",
-        "fast-glob": "3.2.7",
-        "fastest-levenshtein": "1.0.12",
-        "find-up": "4.1.0",
-        "fs-extra": "8.1.0",
-        "glob": "7.1.6",
-        "jest-diff": "27.0.6",
-        "js-yaml": "3.14.1",
-        "jsonfile": "4.0.0",
-        "jsonschema": "1.1.1",
-        "lodash": "4.17.21",
-        "lodash-deep": "2.0.0",
-        "log4js": "6.3.0",
-        "markdown-it": "12.0.4",
-        "moment": "2.20.1",
-        "mustache": "2.3.0",
-        "npm-package-arg": "8.1.1",
-        "open": "8.2.1",
-        "opener": "1.5.2",
-        "pacote": "11.1.4",
-        "prettyjson": "1.2.1",
-        "progress": "2.0.3",
-        "read": "1.0.7",
-        "readline-sync": "1.4.10",
-        "rimraf": "2.6.3",
-        "sanitize-html": "2.3.2",
-        "semver": "5.7.0",
-        "stack-trace": "0.0.10",
-        "strip-ansi": "6.0.1",
-        "wrap-ansi": "7.0.0",
-        "yamljs": "0.3.0",
-        "yargs": "15.3.1"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "packages/cli/node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "packages/cli/node_modules/chalk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "packages/cli/node_modules/color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "packages/cli/node_modules/color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
-    },
-    "packages/cli/node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
     "packages/cli/node_modules/get-stdin": {
       "version": "7.0.0",
       "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/get-stdin/-/get-stdin-7.0.0.tgz",
@@ -26685,6 +26412,7 @@
       "version": "7.1.6",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
       "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "dev": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -26700,42 +26428,16 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "packages/cli/node_modules/has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "packages/cli/node_modules/rimraf": {
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
       "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+      "dev": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
       "bin": {
         "rimraf": "bin.js"
-      }
-    },
-    "packages/cli/node_modules/semver": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-      "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
-    "packages/cli/node_modules/supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "packages/core": {
@@ -26749,7 +26451,7 @@
       "devDependencies": {
         "@types/node": "^12.12.24",
         "@zowe/cli-test-utils": "7.0.0-next.202112102143",
-        "@zowe/imperative": "5.0.0-next.202112101814",
+        "@zowe/imperative": "5.0.0-next.202112132158",
         "chalk": "^4.1.0",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
@@ -26759,107 +26461,6 @@
       },
       "peerDependencies": {
         "@zowe/imperative": ">=5.0.0-next.202106041929 <5.0.0"
-      }
-    },
-    "packages/core/node_modules/@zowe/imperative": {
-      "version": "5.0.0-next.202112101814",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-local-release/@zowe/imperative/-/@zowe/imperative-5.0.0-next.202112101814.tgz",
-      "integrity": "sha1-thpGvXuiYGpDdjgSyHSFD8bhaRA=",
-      "dev": true,
-      "license": "EPL-2.0",
-      "dependencies": {
-        "@types/lodash-deep": "2.0.0",
-        "@types/yargs": "13.0.4",
-        "@zowe/perf-timing": "1.0.7",
-        "chalk": "2.4.2",
-        "cli-table3": "0.6.0",
-        "comment-json": "4.1.0",
-        "dataobject-parser": "1.2.1",
-        "deepmerge": "4.2.2",
-        "fast-glob": "3.2.7",
-        "fastest-levenshtein": "1.0.12",
-        "find-up": "4.1.0",
-        "fs-extra": "8.1.0",
-        "glob": "7.1.6",
-        "jest-diff": "27.0.6",
-        "js-yaml": "3.14.1",
-        "jsonfile": "4.0.0",
-        "jsonschema": "1.1.1",
-        "lodash": "4.17.21",
-        "lodash-deep": "2.0.0",
-        "log4js": "6.3.0",
-        "markdown-it": "12.0.4",
-        "moment": "2.20.1",
-        "mustache": "2.3.0",
-        "npm-package-arg": "8.1.1",
-        "open": "8.2.1",
-        "opener": "1.5.2",
-        "pacote": "11.1.4",
-        "prettyjson": "1.2.1",
-        "progress": "2.0.3",
-        "read": "1.0.7",
-        "readline-sync": "1.4.10",
-        "rimraf": "2.6.3",
-        "sanitize-html": "2.3.2",
-        "semver": "5.7.0",
-        "stack-trace": "0.0.10",
-        "strip-ansi": "6.0.1",
-        "wrap-ansi": "7.0.0",
-        "yamljs": "0.3.0",
-        "yargs": "15.3.1"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "packages/core/node_modules/@zowe/imperative/node_modules/chalk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "packages/core/node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "packages/core/node_modules/color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "packages/core/node_modules/color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true
-    },
-    "packages/core/node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.8.0"
       }
     },
     "packages/core/node_modules/glob": {
@@ -26882,15 +26483,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "packages/core/node_modules/has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "packages/core/node_modules/rimraf": {
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
@@ -26901,27 +26493,6 @@
       },
       "bin": {
         "rimraf": "bin.js"
-      }
-    },
-    "packages/core/node_modules/semver": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-      "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
-    "packages/core/node_modules/supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "packages/provisioning": {
@@ -26936,7 +26507,7 @@
         "@types/node": "^12.12.24",
         "@zowe/cli-test-utils": "7.0.0-next.202112102143",
         "@zowe/core-for-zowe-sdk": "7.0.0-next.202112102143",
-        "@zowe/imperative": "5.0.0-next.202112101814",
+        "@zowe/imperative": "5.0.0-next.202112132158",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
         "rimraf": "^2.6.3",
@@ -26954,107 +26525,6 @@
       "integrity": "sha1-Mwxdl6NQDpyQMhDW5J8ClkrwSg4=",
       "dev": true,
       "license": "MIT"
-    },
-    "packages/provisioning/node_modules/@zowe/imperative": {
-      "version": "5.0.0-next.202112101814",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-local-release/@zowe/imperative/-/@zowe/imperative-5.0.0-next.202112101814.tgz",
-      "integrity": "sha1-thpGvXuiYGpDdjgSyHSFD8bhaRA=",
-      "dev": true,
-      "license": "EPL-2.0",
-      "dependencies": {
-        "@types/lodash-deep": "2.0.0",
-        "@types/yargs": "13.0.4",
-        "@zowe/perf-timing": "1.0.7",
-        "chalk": "2.4.2",
-        "cli-table3": "0.6.0",
-        "comment-json": "4.1.0",
-        "dataobject-parser": "1.2.1",
-        "deepmerge": "4.2.2",
-        "fast-glob": "3.2.7",
-        "fastest-levenshtein": "1.0.12",
-        "find-up": "4.1.0",
-        "fs-extra": "8.1.0",
-        "glob": "7.1.6",
-        "jest-diff": "27.0.6",
-        "js-yaml": "3.14.1",
-        "jsonfile": "4.0.0",
-        "jsonschema": "1.1.1",
-        "lodash": "4.17.21",
-        "lodash-deep": "2.0.0",
-        "log4js": "6.3.0",
-        "markdown-it": "12.0.4",
-        "moment": "2.20.1",
-        "mustache": "2.3.0",
-        "npm-package-arg": "8.1.1",
-        "open": "8.2.1",
-        "opener": "1.5.2",
-        "pacote": "11.1.4",
-        "prettyjson": "1.2.1",
-        "progress": "2.0.3",
-        "read": "1.0.7",
-        "readline-sync": "1.4.10",
-        "rimraf": "2.6.3",
-        "sanitize-html": "2.3.2",
-        "semver": "5.7.0",
-        "stack-trace": "0.0.10",
-        "strip-ansi": "6.0.1",
-        "wrap-ansi": "7.0.0",
-        "yamljs": "0.3.0",
-        "yargs": "15.3.1"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "packages/provisioning/node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "packages/provisioning/node_modules/chalk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "packages/provisioning/node_modules/color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "packages/provisioning/node_modules/color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true
-    },
-    "packages/provisioning/node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.8.0"
-      }
     },
     "packages/provisioning/node_modules/glob": {
       "version": "7.1.6",
@@ -27076,15 +26546,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "packages/provisioning/node_modules/has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "packages/provisioning/node_modules/rimraf": {
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
@@ -27095,27 +26556,6 @@
       },
       "bin": {
         "rimraf": "bin.js"
-      }
-    },
-    "packages/provisioning/node_modules/semver": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-      "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
-    "packages/provisioning/node_modules/supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "packages/workflows": {
@@ -27129,7 +26569,7 @@
         "@types/node": "^12.12.24",
         "@zowe/cli-test-utils": "7.0.0-next.202112102143",
         "@zowe/core-for-zowe-sdk": "7.0.0-next.202112102143",
-        "@zowe/imperative": "5.0.0-next.202112101814",
+        "@zowe/imperative": "5.0.0-next.202112132158",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
         "rimraf": "^2.6.3",
@@ -27139,107 +26579,6 @@
       "peerDependencies": {
         "@zowe/core-for-zowe-sdk": ">=7.0.0-next <7.0.0",
         "@zowe/imperative": ">=5.0.0-next.202106041929 <5.0.0"
-      }
-    },
-    "packages/workflows/node_modules/@zowe/imperative": {
-      "version": "5.0.0-next.202112101814",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-local-release/@zowe/imperative/-/@zowe/imperative-5.0.0-next.202112101814.tgz",
-      "integrity": "sha1-thpGvXuiYGpDdjgSyHSFD8bhaRA=",
-      "dev": true,
-      "license": "EPL-2.0",
-      "dependencies": {
-        "@types/lodash-deep": "2.0.0",
-        "@types/yargs": "13.0.4",
-        "@zowe/perf-timing": "1.0.7",
-        "chalk": "2.4.2",
-        "cli-table3": "0.6.0",
-        "comment-json": "4.1.0",
-        "dataobject-parser": "1.2.1",
-        "deepmerge": "4.2.2",
-        "fast-glob": "3.2.7",
-        "fastest-levenshtein": "1.0.12",
-        "find-up": "4.1.0",
-        "fs-extra": "8.1.0",
-        "glob": "7.1.6",
-        "jest-diff": "27.0.6",
-        "js-yaml": "3.14.1",
-        "jsonfile": "4.0.0",
-        "jsonschema": "1.1.1",
-        "lodash": "4.17.21",
-        "lodash-deep": "2.0.0",
-        "log4js": "6.3.0",
-        "markdown-it": "12.0.4",
-        "moment": "2.20.1",
-        "mustache": "2.3.0",
-        "npm-package-arg": "8.1.1",
-        "open": "8.2.1",
-        "opener": "1.5.2",
-        "pacote": "11.1.4",
-        "prettyjson": "1.2.1",
-        "progress": "2.0.3",
-        "read": "1.0.7",
-        "readline-sync": "1.4.10",
-        "rimraf": "2.6.3",
-        "sanitize-html": "2.3.2",
-        "semver": "5.7.0",
-        "stack-trace": "0.0.10",
-        "strip-ansi": "6.0.1",
-        "wrap-ansi": "7.0.0",
-        "yamljs": "0.3.0",
-        "yargs": "15.3.1"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "packages/workflows/node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "packages/workflows/node_modules/chalk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "packages/workflows/node_modules/color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "packages/workflows/node_modules/color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true
-    },
-    "packages/workflows/node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.8.0"
       }
     },
     "packages/workflows/node_modules/glob": {
@@ -27262,15 +26601,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "packages/workflows/node_modules/has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "packages/workflows/node_modules/rimraf": {
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
@@ -27283,27 +26613,6 @@
         "rimraf": "bin.js"
       }
     },
-    "packages/workflows/node_modules/semver": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-      "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
-    "packages/workflows/node_modules/supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "packages/zosconsole": {
       "name": "@zowe/zos-console-for-zowe-sdk",
       "version": "7.0.0-next.202112102143",
@@ -27312,7 +26621,7 @@
         "@types/node": "^12.12.24",
         "@zowe/cli-test-utils": "7.0.0-next.202112102143",
         "@zowe/core-for-zowe-sdk": "7.0.0-next.202112102143",
-        "@zowe/imperative": "5.0.0-next.202112101814",
+        "@zowe/imperative": "5.0.0-next.202112132158",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
         "rimraf": "^2.6.3",
@@ -27322,107 +26631,6 @@
       "peerDependencies": {
         "@zowe/core-for-zowe-sdk": ">=7.0.0-next <7.0.0",
         "@zowe/imperative": ">=5.0.0-next.202106041929 <5.0.0"
-      }
-    },
-    "packages/zosconsole/node_modules/@zowe/imperative": {
-      "version": "5.0.0-next.202112101814",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-local-release/@zowe/imperative/-/@zowe/imperative-5.0.0-next.202112101814.tgz",
-      "integrity": "sha1-thpGvXuiYGpDdjgSyHSFD8bhaRA=",
-      "dev": true,
-      "license": "EPL-2.0",
-      "dependencies": {
-        "@types/lodash-deep": "2.0.0",
-        "@types/yargs": "13.0.4",
-        "@zowe/perf-timing": "1.0.7",
-        "chalk": "2.4.2",
-        "cli-table3": "0.6.0",
-        "comment-json": "4.1.0",
-        "dataobject-parser": "1.2.1",
-        "deepmerge": "4.2.2",
-        "fast-glob": "3.2.7",
-        "fastest-levenshtein": "1.0.12",
-        "find-up": "4.1.0",
-        "fs-extra": "8.1.0",
-        "glob": "7.1.6",
-        "jest-diff": "27.0.6",
-        "js-yaml": "3.14.1",
-        "jsonfile": "4.0.0",
-        "jsonschema": "1.1.1",
-        "lodash": "4.17.21",
-        "lodash-deep": "2.0.0",
-        "log4js": "6.3.0",
-        "markdown-it": "12.0.4",
-        "moment": "2.20.1",
-        "mustache": "2.3.0",
-        "npm-package-arg": "8.1.1",
-        "open": "8.2.1",
-        "opener": "1.5.2",
-        "pacote": "11.1.4",
-        "prettyjson": "1.2.1",
-        "progress": "2.0.3",
-        "read": "1.0.7",
-        "readline-sync": "1.4.10",
-        "rimraf": "2.6.3",
-        "sanitize-html": "2.3.2",
-        "semver": "5.7.0",
-        "stack-trace": "0.0.10",
-        "strip-ansi": "6.0.1",
-        "wrap-ansi": "7.0.0",
-        "yamljs": "0.3.0",
-        "yargs": "15.3.1"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "packages/zosconsole/node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "packages/zosconsole/node_modules/chalk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "packages/zosconsole/node_modules/color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "packages/zosconsole/node_modules/color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true
-    },
-    "packages/zosconsole/node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.8.0"
       }
     },
     "packages/zosconsole/node_modules/glob": {
@@ -27445,15 +26653,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "packages/zosconsole/node_modules/has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "packages/zosconsole/node_modules/rimraf": {
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
@@ -27464,27 +26663,6 @@
       },
       "bin": {
         "rimraf": "bin.js"
-      }
-    },
-    "packages/zosconsole/node_modules/semver": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-      "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
-    "packages/zosconsole/node_modules/supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "packages/zosfiles": {
@@ -27498,7 +26676,7 @@
         "@types/node": "^12.12.24",
         "@zowe/cli-test-utils": "7.0.0-next.202112102143",
         "@zowe/core-for-zowe-sdk": "7.0.0-next.202112102143",
-        "@zowe/imperative": "5.0.0-next.202112101814",
+        "@zowe/imperative": "5.0.0-next.202112132158",
         "@zowe/zos-uss-for-zowe-sdk": "7.0.0-next.202112102143",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
@@ -27509,107 +26687,6 @@
       "peerDependencies": {
         "@zowe/core-for-zowe-sdk": ">=7.0.0-next <7.0.0",
         "@zowe/imperative": ">=5.0.0-next.202106041929 <5.0.0"
-      }
-    },
-    "packages/zosfiles/node_modules/@zowe/imperative": {
-      "version": "5.0.0-next.202112101814",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-local-release/@zowe/imperative/-/@zowe/imperative-5.0.0-next.202112101814.tgz",
-      "integrity": "sha1-thpGvXuiYGpDdjgSyHSFD8bhaRA=",
-      "dev": true,
-      "license": "EPL-2.0",
-      "dependencies": {
-        "@types/lodash-deep": "2.0.0",
-        "@types/yargs": "13.0.4",
-        "@zowe/perf-timing": "1.0.7",
-        "chalk": "2.4.2",
-        "cli-table3": "0.6.0",
-        "comment-json": "4.1.0",
-        "dataobject-parser": "1.2.1",
-        "deepmerge": "4.2.2",
-        "fast-glob": "3.2.7",
-        "fastest-levenshtein": "1.0.12",
-        "find-up": "4.1.0",
-        "fs-extra": "8.1.0",
-        "glob": "7.1.6",
-        "jest-diff": "27.0.6",
-        "js-yaml": "3.14.1",
-        "jsonfile": "4.0.0",
-        "jsonschema": "1.1.1",
-        "lodash": "4.17.21",
-        "lodash-deep": "2.0.0",
-        "log4js": "6.3.0",
-        "markdown-it": "12.0.4",
-        "moment": "2.20.1",
-        "mustache": "2.3.0",
-        "npm-package-arg": "8.1.1",
-        "open": "8.2.1",
-        "opener": "1.5.2",
-        "pacote": "11.1.4",
-        "prettyjson": "1.2.1",
-        "progress": "2.0.3",
-        "read": "1.0.7",
-        "readline-sync": "1.4.10",
-        "rimraf": "2.6.3",
-        "sanitize-html": "2.3.2",
-        "semver": "5.7.0",
-        "stack-trace": "0.0.10",
-        "strip-ansi": "6.0.1",
-        "wrap-ansi": "7.0.0",
-        "yamljs": "0.3.0",
-        "yargs": "15.3.1"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "packages/zosfiles/node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "packages/zosfiles/node_modules/chalk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "packages/zosfiles/node_modules/color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "packages/zosfiles/node_modules/color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true
-    },
-    "packages/zosfiles/node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.8.0"
       }
     },
     "packages/zosfiles/node_modules/glob": {
@@ -27632,15 +26709,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "packages/zosfiles/node_modules/has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "packages/zosfiles/node_modules/rimraf": {
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
@@ -27651,27 +26719,6 @@
       },
       "bin": {
         "rimraf": "bin.js"
-      }
-    },
-    "packages/zosfiles/node_modules/semver": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-      "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
-    "packages/zosfiles/node_modules/supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "packages/zosjobs": {
@@ -27685,7 +26732,7 @@
         "@types/node": "^12.12.24",
         "@zowe/cli-test-utils": "7.0.0-next.202112102143",
         "@zowe/core-for-zowe-sdk": "7.0.0-next.202112102143",
-        "@zowe/imperative": "5.0.0-next.202112101814",
+        "@zowe/imperative": "5.0.0-next.202112132158",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
         "rimraf": "^2.6.3",
@@ -27695,107 +26742,6 @@
       "peerDependencies": {
         "@zowe/core-for-zowe-sdk": ">=7.0.0-next <7.0.0",
         "@zowe/imperative": ">=5.0.0-next.202106041929 <5.0.0"
-      }
-    },
-    "packages/zosjobs/node_modules/@zowe/imperative": {
-      "version": "5.0.0-next.202112101814",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-local-release/@zowe/imperative/-/@zowe/imperative-5.0.0-next.202112101814.tgz",
-      "integrity": "sha1-thpGvXuiYGpDdjgSyHSFD8bhaRA=",
-      "dev": true,
-      "license": "EPL-2.0",
-      "dependencies": {
-        "@types/lodash-deep": "2.0.0",
-        "@types/yargs": "13.0.4",
-        "@zowe/perf-timing": "1.0.7",
-        "chalk": "2.4.2",
-        "cli-table3": "0.6.0",
-        "comment-json": "4.1.0",
-        "dataobject-parser": "1.2.1",
-        "deepmerge": "4.2.2",
-        "fast-glob": "3.2.7",
-        "fastest-levenshtein": "1.0.12",
-        "find-up": "4.1.0",
-        "fs-extra": "8.1.0",
-        "glob": "7.1.6",
-        "jest-diff": "27.0.6",
-        "js-yaml": "3.14.1",
-        "jsonfile": "4.0.0",
-        "jsonschema": "1.1.1",
-        "lodash": "4.17.21",
-        "lodash-deep": "2.0.0",
-        "log4js": "6.3.0",
-        "markdown-it": "12.0.4",
-        "moment": "2.20.1",
-        "mustache": "2.3.0",
-        "npm-package-arg": "8.1.1",
-        "open": "8.2.1",
-        "opener": "1.5.2",
-        "pacote": "11.1.4",
-        "prettyjson": "1.2.1",
-        "progress": "2.0.3",
-        "read": "1.0.7",
-        "readline-sync": "1.4.10",
-        "rimraf": "2.6.3",
-        "sanitize-html": "2.3.2",
-        "semver": "5.7.0",
-        "stack-trace": "0.0.10",
-        "strip-ansi": "6.0.1",
-        "wrap-ansi": "7.0.0",
-        "yamljs": "0.3.0",
-        "yargs": "15.3.1"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "packages/zosjobs/node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "packages/zosjobs/node_modules/chalk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "packages/zosjobs/node_modules/color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "packages/zosjobs/node_modules/color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true
-    },
-    "packages/zosjobs/node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.8.0"
       }
     },
     "packages/zosjobs/node_modules/glob": {
@@ -27818,15 +26764,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "packages/zosjobs/node_modules/has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "packages/zosjobs/node_modules/rimraf": {
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
@@ -27839,27 +26776,6 @@
         "rimraf": "bin.js"
       }
     },
-    "packages/zosjobs/node_modules/semver": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-      "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
-    "packages/zosjobs/node_modules/supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "packages/zoslogs": {
       "name": "@zowe/zos-logs-for-zowe-sdk",
       "version": "7.0.0-next.202112102143",
@@ -27868,7 +26784,7 @@
         "@types/node": "^12.12.24",
         "@zowe/cli-test-utils": "7.0.0-next.202112102143",
         "@zowe/core-for-zowe-sdk": "7.0.0-next.202112102143",
-        "@zowe/imperative": "5.0.0-next.202112101814",
+        "@zowe/imperative": "5.0.0-next.202112132158",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
         "rimraf": "^2.6.3",
@@ -27878,107 +26794,6 @@
       "peerDependencies": {
         "@zowe/core-for-zowe-sdk": ">=7.0.0-next <7.0.0",
         "@zowe/imperative": ">=5.0.0-next.202106041929 <5.0.0"
-      }
-    },
-    "packages/zoslogs/node_modules/@zowe/imperative": {
-      "version": "5.0.0-next.202112101814",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-local-release/@zowe/imperative/-/@zowe/imperative-5.0.0-next.202112101814.tgz",
-      "integrity": "sha1-thpGvXuiYGpDdjgSyHSFD8bhaRA=",
-      "dev": true,
-      "license": "EPL-2.0",
-      "dependencies": {
-        "@types/lodash-deep": "2.0.0",
-        "@types/yargs": "13.0.4",
-        "@zowe/perf-timing": "1.0.7",
-        "chalk": "2.4.2",
-        "cli-table3": "0.6.0",
-        "comment-json": "4.1.0",
-        "dataobject-parser": "1.2.1",
-        "deepmerge": "4.2.2",
-        "fast-glob": "3.2.7",
-        "fastest-levenshtein": "1.0.12",
-        "find-up": "4.1.0",
-        "fs-extra": "8.1.0",
-        "glob": "7.1.6",
-        "jest-diff": "27.0.6",
-        "js-yaml": "3.14.1",
-        "jsonfile": "4.0.0",
-        "jsonschema": "1.1.1",
-        "lodash": "4.17.21",
-        "lodash-deep": "2.0.0",
-        "log4js": "6.3.0",
-        "markdown-it": "12.0.4",
-        "moment": "2.20.1",
-        "mustache": "2.3.0",
-        "npm-package-arg": "8.1.1",
-        "open": "8.2.1",
-        "opener": "1.5.2",
-        "pacote": "11.1.4",
-        "prettyjson": "1.2.1",
-        "progress": "2.0.3",
-        "read": "1.0.7",
-        "readline-sync": "1.4.10",
-        "rimraf": "2.6.3",
-        "sanitize-html": "2.3.2",
-        "semver": "5.7.0",
-        "stack-trace": "0.0.10",
-        "strip-ansi": "6.0.1",
-        "wrap-ansi": "7.0.0",
-        "yamljs": "0.3.0",
-        "yargs": "15.3.1"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "packages/zoslogs/node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "packages/zoslogs/node_modules/chalk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "packages/zoslogs/node_modules/color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "packages/zoslogs/node_modules/color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true
-    },
-    "packages/zoslogs/node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.8.0"
       }
     },
     "packages/zoslogs/node_modules/glob": {
@@ -28001,15 +26816,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "packages/zoslogs/node_modules/has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "packages/zoslogs/node_modules/rimraf": {
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
@@ -28022,27 +26828,6 @@
         "rimraf": "bin.js"
       }
     },
-    "packages/zoslogs/node_modules/semver": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-      "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
-    "packages/zoslogs/node_modules/supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "packages/zosmf": {
       "name": "@zowe/zosmf-for-zowe-sdk",
       "version": "7.0.0-next.202112102143",
@@ -28051,7 +26836,7 @@
         "@types/node": "^12.12.24",
         "@zowe/cli-test-utils": "7.0.0-next.202112102143",
         "@zowe/core-for-zowe-sdk": "7.0.0-next.202112102143",
-        "@zowe/imperative": "5.0.0-next.202112101814",
+        "@zowe/imperative": "5.0.0-next.202112132158",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
         "rimraf": "^2.6.3",
@@ -28061,107 +26846,6 @@
       "peerDependencies": {
         "@zowe/core-for-zowe-sdk": ">=7.0.0-next <7.0.0",
         "@zowe/imperative": ">=5.0.0-next.202106041929 <5.0.0"
-      }
-    },
-    "packages/zosmf/node_modules/@zowe/imperative": {
-      "version": "5.0.0-next.202112101814",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-local-release/@zowe/imperative/-/@zowe/imperative-5.0.0-next.202112101814.tgz",
-      "integrity": "sha1-thpGvXuiYGpDdjgSyHSFD8bhaRA=",
-      "dev": true,
-      "license": "EPL-2.0",
-      "dependencies": {
-        "@types/lodash-deep": "2.0.0",
-        "@types/yargs": "13.0.4",
-        "@zowe/perf-timing": "1.0.7",
-        "chalk": "2.4.2",
-        "cli-table3": "0.6.0",
-        "comment-json": "4.1.0",
-        "dataobject-parser": "1.2.1",
-        "deepmerge": "4.2.2",
-        "fast-glob": "3.2.7",
-        "fastest-levenshtein": "1.0.12",
-        "find-up": "4.1.0",
-        "fs-extra": "8.1.0",
-        "glob": "7.1.6",
-        "jest-diff": "27.0.6",
-        "js-yaml": "3.14.1",
-        "jsonfile": "4.0.0",
-        "jsonschema": "1.1.1",
-        "lodash": "4.17.21",
-        "lodash-deep": "2.0.0",
-        "log4js": "6.3.0",
-        "markdown-it": "12.0.4",
-        "moment": "2.20.1",
-        "mustache": "2.3.0",
-        "npm-package-arg": "8.1.1",
-        "open": "8.2.1",
-        "opener": "1.5.2",
-        "pacote": "11.1.4",
-        "prettyjson": "1.2.1",
-        "progress": "2.0.3",
-        "read": "1.0.7",
-        "readline-sync": "1.4.10",
-        "rimraf": "2.6.3",
-        "sanitize-html": "2.3.2",
-        "semver": "5.7.0",
-        "stack-trace": "0.0.10",
-        "strip-ansi": "6.0.1",
-        "wrap-ansi": "7.0.0",
-        "yamljs": "0.3.0",
-        "yargs": "15.3.1"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "packages/zosmf/node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "packages/zosmf/node_modules/chalk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "packages/zosmf/node_modules/color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "packages/zosmf/node_modules/color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true
-    },
-    "packages/zosmf/node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.8.0"
       }
     },
     "packages/zosmf/node_modules/glob": {
@@ -28184,15 +26868,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "packages/zosmf/node_modules/has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "packages/zosmf/node_modules/rimraf": {
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
@@ -28203,27 +26878,6 @@
       },
       "bin": {
         "rimraf": "bin.js"
-      }
-    },
-    "packages/zosmf/node_modules/semver": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-      "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
-    "packages/zosmf/node_modules/supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "packages/zostso": {
@@ -28237,7 +26891,7 @@
         "@types/node": "^12.12.24",
         "@zowe/cli-test-utils": "7.0.0-next.202112102143",
         "@zowe/core-for-zowe-sdk": "7.0.0-next.202112102143",
-        "@zowe/imperative": "5.0.0-next.202112101814",
+        "@zowe/imperative": "5.0.0-next.202112132158",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
         "rimraf": "^2.6.3",
@@ -28247,107 +26901,6 @@
       "peerDependencies": {
         "@zowe/core-for-zowe-sdk": ">=7.0.0-next <7.0.0",
         "@zowe/imperative": ">=5.0.0-next.202106041929 <5.0.0"
-      }
-    },
-    "packages/zostso/node_modules/@zowe/imperative": {
-      "version": "5.0.0-next.202112101814",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-local-release/@zowe/imperative/-/@zowe/imperative-5.0.0-next.202112101814.tgz",
-      "integrity": "sha1-thpGvXuiYGpDdjgSyHSFD8bhaRA=",
-      "dev": true,
-      "license": "EPL-2.0",
-      "dependencies": {
-        "@types/lodash-deep": "2.0.0",
-        "@types/yargs": "13.0.4",
-        "@zowe/perf-timing": "1.0.7",
-        "chalk": "2.4.2",
-        "cli-table3": "0.6.0",
-        "comment-json": "4.1.0",
-        "dataobject-parser": "1.2.1",
-        "deepmerge": "4.2.2",
-        "fast-glob": "3.2.7",
-        "fastest-levenshtein": "1.0.12",
-        "find-up": "4.1.0",
-        "fs-extra": "8.1.0",
-        "glob": "7.1.6",
-        "jest-diff": "27.0.6",
-        "js-yaml": "3.14.1",
-        "jsonfile": "4.0.0",
-        "jsonschema": "1.1.1",
-        "lodash": "4.17.21",
-        "lodash-deep": "2.0.0",
-        "log4js": "6.3.0",
-        "markdown-it": "12.0.4",
-        "moment": "2.20.1",
-        "mustache": "2.3.0",
-        "npm-package-arg": "8.1.1",
-        "open": "8.2.1",
-        "opener": "1.5.2",
-        "pacote": "11.1.4",
-        "prettyjson": "1.2.1",
-        "progress": "2.0.3",
-        "read": "1.0.7",
-        "readline-sync": "1.4.10",
-        "rimraf": "2.6.3",
-        "sanitize-html": "2.3.2",
-        "semver": "5.7.0",
-        "stack-trace": "0.0.10",
-        "strip-ansi": "6.0.1",
-        "wrap-ansi": "7.0.0",
-        "yamljs": "0.3.0",
-        "yargs": "15.3.1"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "packages/zostso/node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "packages/zostso/node_modules/chalk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "packages/zostso/node_modules/color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "packages/zostso/node_modules/color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true
-    },
-    "packages/zostso/node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.8.0"
       }
     },
     "packages/zostso/node_modules/glob": {
@@ -28370,15 +26923,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "packages/zostso/node_modules/has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "packages/zostso/node_modules/rimraf": {
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
@@ -28389,27 +26933,6 @@
       },
       "bin": {
         "rimraf": "bin.js"
-      }
-    },
-    "packages/zostso/node_modules/semver": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-      "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
-    "packages/zostso/node_modules/supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "packages/zosuss": {
@@ -28423,7 +26946,7 @@
         "@types/node": "^12.12.24",
         "@types/ssh2": "^0.5.44",
         "@zowe/cli-test-utils": "7.0.0-next.202112102143",
-        "@zowe/imperative": "5.0.0-next.202112101814",
+        "@zowe/imperative": "5.0.0-next.202112132158",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
         "rimraf": "^2.6.3",
@@ -28432,107 +26955,6 @@
       },
       "peerDependencies": {
         "@zowe/imperative": ">=5.0.0-next.202106041929 <5.0.0"
-      }
-    },
-    "packages/zosuss/node_modules/@zowe/imperative": {
-      "version": "5.0.0-next.202112101814",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-local-release/@zowe/imperative/-/@zowe/imperative-5.0.0-next.202112101814.tgz",
-      "integrity": "sha1-thpGvXuiYGpDdjgSyHSFD8bhaRA=",
-      "dev": true,
-      "license": "EPL-2.0",
-      "dependencies": {
-        "@types/lodash-deep": "2.0.0",
-        "@types/yargs": "13.0.4",
-        "@zowe/perf-timing": "1.0.7",
-        "chalk": "2.4.2",
-        "cli-table3": "0.6.0",
-        "comment-json": "4.1.0",
-        "dataobject-parser": "1.2.1",
-        "deepmerge": "4.2.2",
-        "fast-glob": "3.2.7",
-        "fastest-levenshtein": "1.0.12",
-        "find-up": "4.1.0",
-        "fs-extra": "8.1.0",
-        "glob": "7.1.6",
-        "jest-diff": "27.0.6",
-        "js-yaml": "3.14.1",
-        "jsonfile": "4.0.0",
-        "jsonschema": "1.1.1",
-        "lodash": "4.17.21",
-        "lodash-deep": "2.0.0",
-        "log4js": "6.3.0",
-        "markdown-it": "12.0.4",
-        "moment": "2.20.1",
-        "mustache": "2.3.0",
-        "npm-package-arg": "8.1.1",
-        "open": "8.2.1",
-        "opener": "1.5.2",
-        "pacote": "11.1.4",
-        "prettyjson": "1.2.1",
-        "progress": "2.0.3",
-        "read": "1.0.7",
-        "readline-sync": "1.4.10",
-        "rimraf": "2.6.3",
-        "sanitize-html": "2.3.2",
-        "semver": "5.7.0",
-        "stack-trace": "0.0.10",
-        "strip-ansi": "6.0.1",
-        "wrap-ansi": "7.0.0",
-        "yamljs": "0.3.0",
-        "yargs": "15.3.1"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "packages/zosuss/node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "packages/zosuss/node_modules/chalk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "packages/zosuss/node_modules/color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "packages/zosuss/node_modules/color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true
-    },
-    "packages/zosuss/node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.8.0"
       }
     },
     "packages/zosuss/node_modules/glob": {
@@ -28555,15 +26977,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "packages/zosuss/node_modules/has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "packages/zosuss/node_modules/rimraf": {
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
@@ -28574,27 +26987,6 @@
       },
       "bin": {
         "rimraf": "bin.js"
-      }
-    },
-    "packages/zosuss/node_modules/semver": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-      "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
-    "packages/zosuss/node_modules/supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
       }
     }
   },
@@ -32543,7 +30935,7 @@
         "@types/node": "^12.12.24",
         "@zowe/cli-test-utils": "7.0.0-next.202112102143",
         "@zowe/core-for-zowe-sdk": "7.0.0-next.202112102143",
-        "@zowe/imperative": "5.0.0-next.202112101814",
+        "@zowe/imperative": "5.0.0-next.202112132158",
         "@zowe/perf-timing": "1.0.7",
         "@zowe/provisioning-for-zowe-sdk": "7.0.0-next.202112102143",
         "@zowe/zos-console-for-zowe-sdk": "7.0.0-next.202112102143",
@@ -32568,88 +30960,6 @@
         "typescript": "^3.8.0"
       },
       "dependencies": {
-        "@zowe/imperative": {
-          "version": "5.0.0-next.202112101814",
-          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-local-release/@zowe/imperative/-/@zowe/imperative-5.0.0-next.202112101814.tgz",
-          "integrity": "sha1-thpGvXuiYGpDdjgSyHSFD8bhaRA=",
-          "requires": {
-            "@types/lodash-deep": "2.0.0",
-            "@types/yargs": "13.0.4",
-            "@zowe/perf-timing": "1.0.7",
-            "chalk": "2.4.2",
-            "cli-table3": "0.6.0",
-            "comment-json": "4.1.0",
-            "dataobject-parser": "1.2.1",
-            "deepmerge": "4.2.2",
-            "fast-glob": "3.2.7",
-            "fastest-levenshtein": "1.0.12",
-            "find-up": "4.1.0",
-            "fs-extra": "8.1.0",
-            "glob": "7.1.6",
-            "jest-diff": "27.0.6",
-            "js-yaml": "3.14.1",
-            "jsonfile": "4.0.0",
-            "jsonschema": "1.1.1",
-            "lodash": "4.17.21",
-            "lodash-deep": "2.0.0",
-            "log4js": "6.3.0",
-            "markdown-it": "12.0.4",
-            "moment": "2.20.1",
-            "mustache": "2.3.0",
-            "npm-package-arg": "8.1.1",
-            "open": "8.2.1",
-            "opener": "1.5.2",
-            "pacote": "11.1.4",
-            "prettyjson": "1.2.1",
-            "progress": "2.0.3",
-            "read": "1.0.7",
-            "readline-sync": "1.4.10",
-            "rimraf": "2.6.3",
-            "sanitize-html": "2.3.2",
-            "semver": "5.7.0",
-            "stack-trace": "0.0.10",
-            "strip-ansi": "6.0.1",
-            "wrap-ansi": "7.0.0",
-            "yamljs": "0.3.0",
-            "yargs": "15.3.1"
-          }
-        },
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "requires": {
-            "color-convert": "^1.9.0"
-          }
-        },
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        },
-        "color-convert": {
-          "version": "1.9.3",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-          "requires": {
-            "color-name": "1.1.3"
-          }
-        },
-        "color-name": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
-        },
-        "escape-string-regexp": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
-        },
         "get-stdin": {
           "version": "7.0.0",
           "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/get-stdin/-/get-stdin-7.0.0.tgz",
@@ -32659,6 +30969,7 @@
           "version": "7.1.6",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
           "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+          "dev": true,
           "requires": {
             "fs.realpath": "^1.0.0",
             "inflight": "^1.0.4",
@@ -32668,30 +30979,13 @@
             "path-is-absolute": "^1.0.0"
           }
         },
-        "has-flag": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
-        },
         "rimraf": {
           "version": "2.6.3",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
           "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+          "dev": true,
           "requires": {
             "glob": "^7.1.3"
-          }
-        },
-        "semver": {
-          "version": "5.7.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
-        },
-        "supports-color": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-          "requires": {
-            "has-flag": "^3.0.0"
           }
         }
       }
@@ -32702,7 +30996,7 @@
         "@types/js-yaml": "^4.0.0",
         "@types/node": "^14.14.37",
         "@types/uuid": "^8.3.0",
-        "@zowe/imperative": "5.0.0-next.202112101814",
+        "@zowe/imperative": "5.0.0-next.202112132158",
         "eslint": "^7.32.0",
         "find-up": "^5.0.0",
         "js-yaml": "^4.0.0",
@@ -32716,136 +31010,8 @@
           "version": "14.17.27",
           "dev": true
         },
-        "@zowe/imperative": {
-          "version": "5.0.0-next.202112101814",
-          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-local-release/@zowe/imperative/-/@zowe/imperative-5.0.0-next.202112101814.tgz",
-          "integrity": "sha1-thpGvXuiYGpDdjgSyHSFD8bhaRA=",
-          "dev": true,
-          "requires": {
-            "@types/lodash-deep": "2.0.0",
-            "@types/yargs": "13.0.4",
-            "@zowe/perf-timing": "1.0.7",
-            "chalk": "2.4.2",
-            "cli-table3": "0.6.0",
-            "comment-json": "4.1.0",
-            "dataobject-parser": "1.2.1",
-            "deepmerge": "4.2.2",
-            "fast-glob": "3.2.7",
-            "fastest-levenshtein": "1.0.12",
-            "find-up": "4.1.0",
-            "fs-extra": "8.1.0",
-            "glob": "7.1.6",
-            "jest-diff": "27.0.6",
-            "js-yaml": "3.14.1",
-            "jsonfile": "4.0.0",
-            "jsonschema": "1.1.1",
-            "lodash": "4.17.21",
-            "lodash-deep": "2.0.0",
-            "log4js": "6.3.0",
-            "markdown-it": "12.0.4",
-            "moment": "2.20.1",
-            "mustache": "2.3.0",
-            "npm-package-arg": "8.1.1",
-            "open": "8.2.1",
-            "opener": "1.5.2",
-            "pacote": "11.1.4",
-            "prettyjson": "1.2.1",
-            "progress": "2.0.3",
-            "read": "1.0.7",
-            "readline-sync": "1.4.10",
-            "rimraf": "2.6.3",
-            "sanitize-html": "2.3.2",
-            "semver": "5.7.0",
-            "stack-trace": "0.0.10",
-            "strip-ansi": "6.0.1",
-            "wrap-ansi": "7.0.0",
-            "yamljs": "0.3.0",
-            "yargs": "15.3.1"
-          },
-          "dependencies": {
-            "argparse": {
-              "version": "1.0.10",
-              "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-              "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-              "dev": true,
-              "requires": {
-                "sprintf-js": "~1.0.2"
-              }
-            },
-            "find-up": {
-              "version": "4.1.0",
-              "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-              "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-              "dev": true,
-              "requires": {
-                "locate-path": "^5.0.0",
-                "path-exists": "^4.0.0"
-              }
-            },
-            "js-yaml": {
-              "version": "3.14.1",
-              "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-              "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
-              "dev": true,
-              "requires": {
-                "argparse": "^1.0.7",
-                "esprima": "^4.0.0"
-              }
-            },
-            "rimraf": {
-              "version": "2.6.3",
-              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
-              "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
-              "dev": true,
-              "requires": {
-                "glob": "^7.1.3"
-              }
-            }
-          }
-        },
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^1.9.0"
-          }
-        },
         "argparse": {
           "version": "2.0.1"
-        },
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        },
-        "color-convert": {
-          "version": "1.9.3",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-          "dev": true,
-          "requires": {
-            "color-name": "1.1.3"
-          }
-        },
-        "color-name": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-          "dev": true
-        },
-        "escape-string-regexp": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-          "dev": true
         },
         "find-up": {
           "version": "5.0.0",
@@ -32876,12 +31042,6 @@
             "path-is-absolute": "^1.0.0"
           }
         },
-        "has-flag": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-          "dev": true
-        },
         "js-yaml": {
           "version": "4.1.0",
           "requires": {
@@ -32907,21 +31067,6 @@
             "glob": "^7.1.3"
           }
         },
-        "semver": {
-          "version": "5.7.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
-        },
         "typescript": {
           "version": "4.4.4",
           "dev": true
@@ -32936,7 +31081,7 @@
       "requires": {
         "@types/node": "^12.12.24",
         "@zowe/cli-test-utils": "7.0.0-next.202112102143",
-        "@zowe/imperative": "5.0.0-next.202112101814",
+        "@zowe/imperative": "5.0.0-next.202112132158",
         "chalk": "^4.1.0",
         "comment-json": "4.1.0",
         "eslint": "^7.32.0",
@@ -32947,96 +31092,6 @@
         "typescript": "^3.8.0"
       },
       "dependencies": {
-        "@zowe/imperative": {
-          "version": "5.0.0-next.202112101814",
-          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-local-release/@zowe/imperative/-/@zowe/imperative-5.0.0-next.202112101814.tgz",
-          "integrity": "sha1-thpGvXuiYGpDdjgSyHSFD8bhaRA=",
-          "dev": true,
-          "requires": {
-            "@types/lodash-deep": "2.0.0",
-            "@types/yargs": "13.0.4",
-            "@zowe/perf-timing": "1.0.7",
-            "chalk": "2.4.2",
-            "cli-table3": "0.6.0",
-            "comment-json": "4.1.0",
-            "dataobject-parser": "1.2.1",
-            "deepmerge": "4.2.2",
-            "fast-glob": "3.2.7",
-            "fastest-levenshtein": "1.0.12",
-            "find-up": "4.1.0",
-            "fs-extra": "8.1.0",
-            "glob": "7.1.6",
-            "jest-diff": "27.0.6",
-            "js-yaml": "3.14.1",
-            "jsonfile": "4.0.0",
-            "jsonschema": "1.1.1",
-            "lodash": "4.17.21",
-            "lodash-deep": "2.0.0",
-            "log4js": "6.3.0",
-            "markdown-it": "12.0.4",
-            "moment": "2.20.1",
-            "mustache": "2.3.0",
-            "npm-package-arg": "8.1.1",
-            "open": "8.2.1",
-            "opener": "1.5.2",
-            "pacote": "11.1.4",
-            "prettyjson": "1.2.1",
-            "progress": "2.0.3",
-            "read": "1.0.7",
-            "readline-sync": "1.4.10",
-            "rimraf": "2.6.3",
-            "sanitize-html": "2.3.2",
-            "semver": "5.7.0",
-            "stack-trace": "0.0.10",
-            "strip-ansi": "6.0.1",
-            "wrap-ansi": "7.0.0",
-            "yamljs": "0.3.0",
-            "yargs": "15.3.1"
-          },
-          "dependencies": {
-            "chalk": {
-              "version": "2.4.2",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-              "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-              "dev": true,
-              "requires": {
-                "ansi-styles": "^3.2.1",
-                "escape-string-regexp": "^1.0.5",
-                "supports-color": "^5.3.0"
-              }
-            }
-          }
-        },
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^1.9.0"
-          }
-        },
-        "color-convert": {
-          "version": "1.9.3",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-          "dev": true,
-          "requires": {
-            "color-name": "1.1.3"
-          }
-        },
-        "color-name": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-          "dev": true
-        },
-        "escape-string-regexp": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-          "dev": true
-        },
         "glob": {
           "version": "7.1.6",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
@@ -33051,12 +31106,6 @@
             "path-is-absolute": "^1.0.0"
           }
         },
-        "has-flag": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-          "dev": true
-        },
         "rimraf": {
           "version": "2.6.3",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
@@ -33064,21 +31113,6 @@
           "dev": true,
           "requires": {
             "glob": "^7.1.3"
-          }
-        },
-        "semver": {
-          "version": "5.7.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^3.0.0"
           }
         }
       }
@@ -33222,7 +31256,7 @@
         "@types/node": "^12.12.24",
         "@zowe/cli-test-utils": "7.0.0-next.202112102143",
         "@zowe/core-for-zowe-sdk": "7.0.0-next.202112102143",
-        "@zowe/imperative": "5.0.0-next.202112101814",
+        "@zowe/imperative": "5.0.0-next.202112132158",
         "eslint": "^7.32.0",
         "js-yaml": "3.14.1",
         "madge": "^4.0.1",
@@ -33237,94 +31271,6 @@
           "integrity": "sha1-Mwxdl6NQDpyQMhDW5J8ClkrwSg4=",
           "dev": true
         },
-        "@zowe/imperative": {
-          "version": "5.0.0-next.202112101814",
-          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-local-release/@zowe/imperative/-/@zowe/imperative-5.0.0-next.202112101814.tgz",
-          "integrity": "sha1-thpGvXuiYGpDdjgSyHSFD8bhaRA=",
-          "dev": true,
-          "requires": {
-            "@types/lodash-deep": "2.0.0",
-            "@types/yargs": "13.0.4",
-            "@zowe/perf-timing": "1.0.7",
-            "chalk": "2.4.2",
-            "cli-table3": "0.6.0",
-            "comment-json": "4.1.0",
-            "dataobject-parser": "1.2.1",
-            "deepmerge": "4.2.2",
-            "fast-glob": "3.2.7",
-            "fastest-levenshtein": "1.0.12",
-            "find-up": "4.1.0",
-            "fs-extra": "8.1.0",
-            "glob": "7.1.6",
-            "jest-diff": "27.0.6",
-            "js-yaml": "3.14.1",
-            "jsonfile": "4.0.0",
-            "jsonschema": "1.1.1",
-            "lodash": "4.17.21",
-            "lodash-deep": "2.0.0",
-            "log4js": "6.3.0",
-            "markdown-it": "12.0.4",
-            "moment": "2.20.1",
-            "mustache": "2.3.0",
-            "npm-package-arg": "8.1.1",
-            "open": "8.2.1",
-            "opener": "1.5.2",
-            "pacote": "11.1.4",
-            "prettyjson": "1.2.1",
-            "progress": "2.0.3",
-            "read": "1.0.7",
-            "readline-sync": "1.4.10",
-            "rimraf": "2.6.3",
-            "sanitize-html": "2.3.2",
-            "semver": "5.7.0",
-            "stack-trace": "0.0.10",
-            "strip-ansi": "6.0.1",
-            "wrap-ansi": "7.0.0",
-            "yamljs": "0.3.0",
-            "yargs": "15.3.1"
-          }
-        },
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^1.9.0"
-          }
-        },
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        },
-        "color-convert": {
-          "version": "1.9.3",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-          "dev": true,
-          "requires": {
-            "color-name": "1.1.3"
-          }
-        },
-        "color-name": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-          "dev": true
-        },
-        "escape-string-regexp": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-          "dev": true
-        },
         "glob": {
           "version": "7.1.6",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
@@ -33339,12 +31285,6 @@
             "path-is-absolute": "^1.0.0"
           }
         },
-        "has-flag": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-          "dev": true
-        },
         "rimraf": {
           "version": "2.6.3",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
@@ -33352,21 +31292,6 @@
           "dev": true,
           "requires": {
             "glob": "^7.1.3"
-          }
-        },
-        "semver": {
-          "version": "5.7.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^3.0.0"
           }
         }
       }
@@ -33377,7 +31302,7 @@
         "@types/node": "^12.12.24",
         "@zowe/cli-test-utils": "7.0.0-next.202112102143",
         "@zowe/core-for-zowe-sdk": "7.0.0-next.202112102143",
-        "@zowe/imperative": "5.0.0-next.202112101814",
+        "@zowe/imperative": "5.0.0-next.202112132158",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
         "rimraf": "^2.6.3",
@@ -33385,94 +31310,6 @@
         "typescript": "^3.8.0"
       },
       "dependencies": {
-        "@zowe/imperative": {
-          "version": "5.0.0-next.202112101814",
-          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-local-release/@zowe/imperative/-/@zowe/imperative-5.0.0-next.202112101814.tgz",
-          "integrity": "sha1-thpGvXuiYGpDdjgSyHSFD8bhaRA=",
-          "dev": true,
-          "requires": {
-            "@types/lodash-deep": "2.0.0",
-            "@types/yargs": "13.0.4",
-            "@zowe/perf-timing": "1.0.7",
-            "chalk": "2.4.2",
-            "cli-table3": "0.6.0",
-            "comment-json": "4.1.0",
-            "dataobject-parser": "1.2.1",
-            "deepmerge": "4.2.2",
-            "fast-glob": "3.2.7",
-            "fastest-levenshtein": "1.0.12",
-            "find-up": "4.1.0",
-            "fs-extra": "8.1.0",
-            "glob": "7.1.6",
-            "jest-diff": "27.0.6",
-            "js-yaml": "3.14.1",
-            "jsonfile": "4.0.0",
-            "jsonschema": "1.1.1",
-            "lodash": "4.17.21",
-            "lodash-deep": "2.0.0",
-            "log4js": "6.3.0",
-            "markdown-it": "12.0.4",
-            "moment": "2.20.1",
-            "mustache": "2.3.0",
-            "npm-package-arg": "8.1.1",
-            "open": "8.2.1",
-            "opener": "1.5.2",
-            "pacote": "11.1.4",
-            "prettyjson": "1.2.1",
-            "progress": "2.0.3",
-            "read": "1.0.7",
-            "readline-sync": "1.4.10",
-            "rimraf": "2.6.3",
-            "sanitize-html": "2.3.2",
-            "semver": "5.7.0",
-            "stack-trace": "0.0.10",
-            "strip-ansi": "6.0.1",
-            "wrap-ansi": "7.0.0",
-            "yamljs": "0.3.0",
-            "yargs": "15.3.1"
-          }
-        },
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^1.9.0"
-          }
-        },
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        },
-        "color-convert": {
-          "version": "1.9.3",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-          "dev": true,
-          "requires": {
-            "color-name": "1.1.3"
-          }
-        },
-        "color-name": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-          "dev": true
-        },
-        "escape-string-regexp": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-          "dev": true
-        },
         "glob": {
           "version": "7.1.6",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
@@ -33487,12 +31324,6 @@
             "path-is-absolute": "^1.0.0"
           }
         },
-        "has-flag": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-          "dev": true
-        },
         "rimraf": {
           "version": "2.6.3",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
@@ -33500,21 +31331,6 @@
           "dev": true,
           "requires": {
             "glob": "^7.1.3"
-          }
-        },
-        "semver": {
-          "version": "5.7.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^3.0.0"
           }
         }
       }
@@ -33525,7 +31341,7 @@
         "@types/node": "^12.12.24",
         "@zowe/cli-test-utils": "7.0.0-next.202112102143",
         "@zowe/core-for-zowe-sdk": "7.0.0-next.202112102143",
-        "@zowe/imperative": "5.0.0-next.202112101814",
+        "@zowe/imperative": "5.0.0-next.202112132158",
         "@zowe/zos-uss-for-zowe-sdk": "7.0.0-next.202112102143",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
@@ -33535,94 +31351,6 @@
         "typescript": "^3.8.0"
       },
       "dependencies": {
-        "@zowe/imperative": {
-          "version": "5.0.0-next.202112101814",
-          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-local-release/@zowe/imperative/-/@zowe/imperative-5.0.0-next.202112101814.tgz",
-          "integrity": "sha1-thpGvXuiYGpDdjgSyHSFD8bhaRA=",
-          "dev": true,
-          "requires": {
-            "@types/lodash-deep": "2.0.0",
-            "@types/yargs": "13.0.4",
-            "@zowe/perf-timing": "1.0.7",
-            "chalk": "2.4.2",
-            "cli-table3": "0.6.0",
-            "comment-json": "4.1.0",
-            "dataobject-parser": "1.2.1",
-            "deepmerge": "4.2.2",
-            "fast-glob": "3.2.7",
-            "fastest-levenshtein": "1.0.12",
-            "find-up": "4.1.0",
-            "fs-extra": "8.1.0",
-            "glob": "7.1.6",
-            "jest-diff": "27.0.6",
-            "js-yaml": "3.14.1",
-            "jsonfile": "4.0.0",
-            "jsonschema": "1.1.1",
-            "lodash": "4.17.21",
-            "lodash-deep": "2.0.0",
-            "log4js": "6.3.0",
-            "markdown-it": "12.0.4",
-            "moment": "2.20.1",
-            "mustache": "2.3.0",
-            "npm-package-arg": "8.1.1",
-            "open": "8.2.1",
-            "opener": "1.5.2",
-            "pacote": "11.1.4",
-            "prettyjson": "1.2.1",
-            "progress": "2.0.3",
-            "read": "1.0.7",
-            "readline-sync": "1.4.10",
-            "rimraf": "2.6.3",
-            "sanitize-html": "2.3.2",
-            "semver": "5.7.0",
-            "stack-trace": "0.0.10",
-            "strip-ansi": "6.0.1",
-            "wrap-ansi": "7.0.0",
-            "yamljs": "0.3.0",
-            "yargs": "15.3.1"
-          }
-        },
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^1.9.0"
-          }
-        },
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        },
-        "color-convert": {
-          "version": "1.9.3",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-          "dev": true,
-          "requires": {
-            "color-name": "1.1.3"
-          }
-        },
-        "color-name": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-          "dev": true
-        },
-        "escape-string-regexp": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-          "dev": true
-        },
         "glob": {
           "version": "7.1.6",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
@@ -33637,12 +31365,6 @@
             "path-is-absolute": "^1.0.0"
           }
         },
-        "has-flag": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-          "dev": true
-        },
         "rimraf": {
           "version": "2.6.3",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
@@ -33650,21 +31372,6 @@
           "dev": true,
           "requires": {
             "glob": "^7.1.3"
-          }
-        },
-        "semver": {
-          "version": "5.7.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^3.0.0"
           }
         }
       }
@@ -33675,7 +31382,7 @@
         "@types/node": "^12.12.24",
         "@zowe/cli-test-utils": "7.0.0-next.202112102143",
         "@zowe/core-for-zowe-sdk": "7.0.0-next.202112102143",
-        "@zowe/imperative": "5.0.0-next.202112101814",
+        "@zowe/imperative": "5.0.0-next.202112132158",
         "@zowe/zos-files-for-zowe-sdk": "7.0.0-next.202112102143",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
@@ -33684,94 +31391,6 @@
         "typescript": "^3.8.0"
       },
       "dependencies": {
-        "@zowe/imperative": {
-          "version": "5.0.0-next.202112101814",
-          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-local-release/@zowe/imperative/-/@zowe/imperative-5.0.0-next.202112101814.tgz",
-          "integrity": "sha1-thpGvXuiYGpDdjgSyHSFD8bhaRA=",
-          "dev": true,
-          "requires": {
-            "@types/lodash-deep": "2.0.0",
-            "@types/yargs": "13.0.4",
-            "@zowe/perf-timing": "1.0.7",
-            "chalk": "2.4.2",
-            "cli-table3": "0.6.0",
-            "comment-json": "4.1.0",
-            "dataobject-parser": "1.2.1",
-            "deepmerge": "4.2.2",
-            "fast-glob": "3.2.7",
-            "fastest-levenshtein": "1.0.12",
-            "find-up": "4.1.0",
-            "fs-extra": "8.1.0",
-            "glob": "7.1.6",
-            "jest-diff": "27.0.6",
-            "js-yaml": "3.14.1",
-            "jsonfile": "4.0.0",
-            "jsonschema": "1.1.1",
-            "lodash": "4.17.21",
-            "lodash-deep": "2.0.0",
-            "log4js": "6.3.0",
-            "markdown-it": "12.0.4",
-            "moment": "2.20.1",
-            "mustache": "2.3.0",
-            "npm-package-arg": "8.1.1",
-            "open": "8.2.1",
-            "opener": "1.5.2",
-            "pacote": "11.1.4",
-            "prettyjson": "1.2.1",
-            "progress": "2.0.3",
-            "read": "1.0.7",
-            "readline-sync": "1.4.10",
-            "rimraf": "2.6.3",
-            "sanitize-html": "2.3.2",
-            "semver": "5.7.0",
-            "stack-trace": "0.0.10",
-            "strip-ansi": "6.0.1",
-            "wrap-ansi": "7.0.0",
-            "yamljs": "0.3.0",
-            "yargs": "15.3.1"
-          }
-        },
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^1.9.0"
-          }
-        },
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        },
-        "color-convert": {
-          "version": "1.9.3",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-          "dev": true,
-          "requires": {
-            "color-name": "1.1.3"
-          }
-        },
-        "color-name": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-          "dev": true
-        },
-        "escape-string-regexp": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-          "dev": true
-        },
         "glob": {
           "version": "7.1.6",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
@@ -33786,12 +31405,6 @@
             "path-is-absolute": "^1.0.0"
           }
         },
-        "has-flag": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-          "dev": true
-        },
         "rimraf": {
           "version": "2.6.3",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
@@ -33799,21 +31412,6 @@
           "dev": true,
           "requires": {
             "glob": "^7.1.3"
-          }
-        },
-        "semver": {
-          "version": "5.7.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^3.0.0"
           }
         }
       }
@@ -33824,7 +31422,7 @@
         "@types/node": "^12.12.24",
         "@zowe/cli-test-utils": "7.0.0-next.202112102143",
         "@zowe/core-for-zowe-sdk": "7.0.0-next.202112102143",
-        "@zowe/imperative": "5.0.0-next.202112101814",
+        "@zowe/imperative": "5.0.0-next.202112132158",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
         "rimraf": "^2.6.3",
@@ -33832,94 +31430,6 @@
         "typescript": "^3.8.0"
       },
       "dependencies": {
-        "@zowe/imperative": {
-          "version": "5.0.0-next.202112101814",
-          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-local-release/@zowe/imperative/-/@zowe/imperative-5.0.0-next.202112101814.tgz",
-          "integrity": "sha1-thpGvXuiYGpDdjgSyHSFD8bhaRA=",
-          "dev": true,
-          "requires": {
-            "@types/lodash-deep": "2.0.0",
-            "@types/yargs": "13.0.4",
-            "@zowe/perf-timing": "1.0.7",
-            "chalk": "2.4.2",
-            "cli-table3": "0.6.0",
-            "comment-json": "4.1.0",
-            "dataobject-parser": "1.2.1",
-            "deepmerge": "4.2.2",
-            "fast-glob": "3.2.7",
-            "fastest-levenshtein": "1.0.12",
-            "find-up": "4.1.0",
-            "fs-extra": "8.1.0",
-            "glob": "7.1.6",
-            "jest-diff": "27.0.6",
-            "js-yaml": "3.14.1",
-            "jsonfile": "4.0.0",
-            "jsonschema": "1.1.1",
-            "lodash": "4.17.21",
-            "lodash-deep": "2.0.0",
-            "log4js": "6.3.0",
-            "markdown-it": "12.0.4",
-            "moment": "2.20.1",
-            "mustache": "2.3.0",
-            "npm-package-arg": "8.1.1",
-            "open": "8.2.1",
-            "opener": "1.5.2",
-            "pacote": "11.1.4",
-            "prettyjson": "1.2.1",
-            "progress": "2.0.3",
-            "read": "1.0.7",
-            "readline-sync": "1.4.10",
-            "rimraf": "2.6.3",
-            "sanitize-html": "2.3.2",
-            "semver": "5.7.0",
-            "stack-trace": "0.0.10",
-            "strip-ansi": "6.0.1",
-            "wrap-ansi": "7.0.0",
-            "yamljs": "0.3.0",
-            "yargs": "15.3.1"
-          }
-        },
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^1.9.0"
-          }
-        },
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        },
-        "color-convert": {
-          "version": "1.9.3",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-          "dev": true,
-          "requires": {
-            "color-name": "1.1.3"
-          }
-        },
-        "color-name": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-          "dev": true
-        },
-        "escape-string-regexp": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-          "dev": true
-        },
         "glob": {
           "version": "7.1.6",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
@@ -33934,12 +31444,6 @@
             "path-is-absolute": "^1.0.0"
           }
         },
-        "has-flag": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-          "dev": true
-        },
         "rimraf": {
           "version": "2.6.3",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
@@ -33947,21 +31451,6 @@
           "dev": true,
           "requires": {
             "glob": "^7.1.3"
-          }
-        },
-        "semver": {
-          "version": "5.7.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^3.0.0"
           }
         }
       }
@@ -33972,7 +31461,7 @@
         "@types/node": "^12.12.24",
         "@zowe/cli-test-utils": "7.0.0-next.202112102143",
         "@zowe/core-for-zowe-sdk": "7.0.0-next.202112102143",
-        "@zowe/imperative": "5.0.0-next.202112101814",
+        "@zowe/imperative": "5.0.0-next.202112132158",
         "@zowe/zosmf-for-zowe-sdk": "7.0.0-next.202112102143",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
@@ -33981,94 +31470,6 @@
         "typescript": "^3.8.0"
       },
       "dependencies": {
-        "@zowe/imperative": {
-          "version": "5.0.0-next.202112101814",
-          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-local-release/@zowe/imperative/-/@zowe/imperative-5.0.0-next.202112101814.tgz",
-          "integrity": "sha1-thpGvXuiYGpDdjgSyHSFD8bhaRA=",
-          "dev": true,
-          "requires": {
-            "@types/lodash-deep": "2.0.0",
-            "@types/yargs": "13.0.4",
-            "@zowe/perf-timing": "1.0.7",
-            "chalk": "2.4.2",
-            "cli-table3": "0.6.0",
-            "comment-json": "4.1.0",
-            "dataobject-parser": "1.2.1",
-            "deepmerge": "4.2.2",
-            "fast-glob": "3.2.7",
-            "fastest-levenshtein": "1.0.12",
-            "find-up": "4.1.0",
-            "fs-extra": "8.1.0",
-            "glob": "7.1.6",
-            "jest-diff": "27.0.6",
-            "js-yaml": "3.14.1",
-            "jsonfile": "4.0.0",
-            "jsonschema": "1.1.1",
-            "lodash": "4.17.21",
-            "lodash-deep": "2.0.0",
-            "log4js": "6.3.0",
-            "markdown-it": "12.0.4",
-            "moment": "2.20.1",
-            "mustache": "2.3.0",
-            "npm-package-arg": "8.1.1",
-            "open": "8.2.1",
-            "opener": "1.5.2",
-            "pacote": "11.1.4",
-            "prettyjson": "1.2.1",
-            "progress": "2.0.3",
-            "read": "1.0.7",
-            "readline-sync": "1.4.10",
-            "rimraf": "2.6.3",
-            "sanitize-html": "2.3.2",
-            "semver": "5.7.0",
-            "stack-trace": "0.0.10",
-            "strip-ansi": "6.0.1",
-            "wrap-ansi": "7.0.0",
-            "yamljs": "0.3.0",
-            "yargs": "15.3.1"
-          }
-        },
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^1.9.0"
-          }
-        },
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        },
-        "color-convert": {
-          "version": "1.9.3",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-          "dev": true,
-          "requires": {
-            "color-name": "1.1.3"
-          }
-        },
-        "color-name": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-          "dev": true
-        },
-        "escape-string-regexp": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-          "dev": true
-        },
         "glob": {
           "version": "7.1.6",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
@@ -34083,12 +31484,6 @@
             "path-is-absolute": "^1.0.0"
           }
         },
-        "has-flag": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-          "dev": true
-        },
         "rimraf": {
           "version": "2.6.3",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
@@ -34096,21 +31491,6 @@
           "dev": true,
           "requires": {
             "glob": "^7.1.3"
-          }
-        },
-        "semver": {
-          "version": "5.7.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^3.0.0"
           }
         }
       }
@@ -34121,7 +31501,7 @@
         "@types/node": "^12.12.24",
         "@types/ssh2": "^0.5.44",
         "@zowe/cli-test-utils": "7.0.0-next.202112102143",
-        "@zowe/imperative": "5.0.0-next.202112101814",
+        "@zowe/imperative": "5.0.0-next.202112132158",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
         "rimraf": "^2.6.3",
@@ -34130,94 +31510,6 @@
         "typescript": "^3.8.0"
       },
       "dependencies": {
-        "@zowe/imperative": {
-          "version": "5.0.0-next.202112101814",
-          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-local-release/@zowe/imperative/-/@zowe/imperative-5.0.0-next.202112101814.tgz",
-          "integrity": "sha1-thpGvXuiYGpDdjgSyHSFD8bhaRA=",
-          "dev": true,
-          "requires": {
-            "@types/lodash-deep": "2.0.0",
-            "@types/yargs": "13.0.4",
-            "@zowe/perf-timing": "1.0.7",
-            "chalk": "2.4.2",
-            "cli-table3": "0.6.0",
-            "comment-json": "4.1.0",
-            "dataobject-parser": "1.2.1",
-            "deepmerge": "4.2.2",
-            "fast-glob": "3.2.7",
-            "fastest-levenshtein": "1.0.12",
-            "find-up": "4.1.0",
-            "fs-extra": "8.1.0",
-            "glob": "7.1.6",
-            "jest-diff": "27.0.6",
-            "js-yaml": "3.14.1",
-            "jsonfile": "4.0.0",
-            "jsonschema": "1.1.1",
-            "lodash": "4.17.21",
-            "lodash-deep": "2.0.0",
-            "log4js": "6.3.0",
-            "markdown-it": "12.0.4",
-            "moment": "2.20.1",
-            "mustache": "2.3.0",
-            "npm-package-arg": "8.1.1",
-            "open": "8.2.1",
-            "opener": "1.5.2",
-            "pacote": "11.1.4",
-            "prettyjson": "1.2.1",
-            "progress": "2.0.3",
-            "read": "1.0.7",
-            "readline-sync": "1.4.10",
-            "rimraf": "2.6.3",
-            "sanitize-html": "2.3.2",
-            "semver": "5.7.0",
-            "stack-trace": "0.0.10",
-            "strip-ansi": "6.0.1",
-            "wrap-ansi": "7.0.0",
-            "yamljs": "0.3.0",
-            "yargs": "15.3.1"
-          }
-        },
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^1.9.0"
-          }
-        },
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        },
-        "color-convert": {
-          "version": "1.9.3",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-          "dev": true,
-          "requires": {
-            "color-name": "1.1.3"
-          }
-        },
-        "color-name": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-          "dev": true
-        },
-        "escape-string-regexp": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-          "dev": true
-        },
         "glob": {
           "version": "7.1.6",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
@@ -34232,12 +31524,6 @@
             "path-is-absolute": "^1.0.0"
           }
         },
-        "has-flag": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-          "dev": true
-        },
         "rimraf": {
           "version": "2.6.3",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
@@ -34245,21 +31531,6 @@
           "dev": true,
           "requires": {
             "glob": "^7.1.3"
-          }
-        },
-        "semver": {
-          "version": "5.7.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^3.0.0"
           }
         }
       }
@@ -34270,7 +31541,7 @@
         "@types/node": "^12.12.24",
         "@zowe/cli-test-utils": "7.0.0-next.202112102143",
         "@zowe/core-for-zowe-sdk": "7.0.0-next.202112102143",
-        "@zowe/imperative": "5.0.0-next.202112101814",
+        "@zowe/imperative": "5.0.0-next.202112132158",
         "@zowe/zos-files-for-zowe-sdk": "7.0.0-next.202112102143",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
@@ -34279,94 +31550,6 @@
         "typescript": "^3.8.0"
       },
       "dependencies": {
-        "@zowe/imperative": {
-          "version": "5.0.0-next.202112101814",
-          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-local-release/@zowe/imperative/-/@zowe/imperative-5.0.0-next.202112101814.tgz",
-          "integrity": "sha1-thpGvXuiYGpDdjgSyHSFD8bhaRA=",
-          "dev": true,
-          "requires": {
-            "@types/lodash-deep": "2.0.0",
-            "@types/yargs": "13.0.4",
-            "@zowe/perf-timing": "1.0.7",
-            "chalk": "2.4.2",
-            "cli-table3": "0.6.0",
-            "comment-json": "4.1.0",
-            "dataobject-parser": "1.2.1",
-            "deepmerge": "4.2.2",
-            "fast-glob": "3.2.7",
-            "fastest-levenshtein": "1.0.12",
-            "find-up": "4.1.0",
-            "fs-extra": "8.1.0",
-            "glob": "7.1.6",
-            "jest-diff": "27.0.6",
-            "js-yaml": "3.14.1",
-            "jsonfile": "4.0.0",
-            "jsonschema": "1.1.1",
-            "lodash": "4.17.21",
-            "lodash-deep": "2.0.0",
-            "log4js": "6.3.0",
-            "markdown-it": "12.0.4",
-            "moment": "2.20.1",
-            "mustache": "2.3.0",
-            "npm-package-arg": "8.1.1",
-            "open": "8.2.1",
-            "opener": "1.5.2",
-            "pacote": "11.1.4",
-            "prettyjson": "1.2.1",
-            "progress": "2.0.3",
-            "read": "1.0.7",
-            "readline-sync": "1.4.10",
-            "rimraf": "2.6.3",
-            "sanitize-html": "2.3.2",
-            "semver": "5.7.0",
-            "stack-trace": "0.0.10",
-            "strip-ansi": "6.0.1",
-            "wrap-ansi": "7.0.0",
-            "yamljs": "0.3.0",
-            "yargs": "15.3.1"
-          }
-        },
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^1.9.0"
-          }
-        },
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        },
-        "color-convert": {
-          "version": "1.9.3",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-          "dev": true,
-          "requires": {
-            "color-name": "1.1.3"
-          }
-        },
-        "color-name": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-          "dev": true
-        },
-        "escape-string-regexp": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-          "dev": true
-        },
         "glob": {
           "version": "7.1.6",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
@@ -34381,12 +31564,6 @@
             "path-is-absolute": "^1.0.0"
           }
         },
-        "has-flag": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-          "dev": true
-        },
         "rimraf": {
           "version": "2.6.3",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
@@ -34394,21 +31571,6 @@
           "dev": true,
           "requires": {
             "glob": "^7.1.3"
-          }
-        },
-        "semver": {
-          "version": "5.7.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^3.0.0"
           }
         }
       }
@@ -34419,7 +31581,7 @@
         "@types/node": "^12.12.24",
         "@zowe/cli-test-utils": "7.0.0-next.202112102143",
         "@zowe/core-for-zowe-sdk": "7.0.0-next.202112102143",
-        "@zowe/imperative": "5.0.0-next.202112101814",
+        "@zowe/imperative": "5.0.0-next.202112132158",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
         "rimraf": "^2.6.3",
@@ -34427,94 +31589,6 @@
         "typescript": "^3.8.0"
       },
       "dependencies": {
-        "@zowe/imperative": {
-          "version": "5.0.0-next.202112101814",
-          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-local-release/@zowe/imperative/-/@zowe/imperative-5.0.0-next.202112101814.tgz",
-          "integrity": "sha1-thpGvXuiYGpDdjgSyHSFD8bhaRA=",
-          "dev": true,
-          "requires": {
-            "@types/lodash-deep": "2.0.0",
-            "@types/yargs": "13.0.4",
-            "@zowe/perf-timing": "1.0.7",
-            "chalk": "2.4.2",
-            "cli-table3": "0.6.0",
-            "comment-json": "4.1.0",
-            "dataobject-parser": "1.2.1",
-            "deepmerge": "4.2.2",
-            "fast-glob": "3.2.7",
-            "fastest-levenshtein": "1.0.12",
-            "find-up": "4.1.0",
-            "fs-extra": "8.1.0",
-            "glob": "7.1.6",
-            "jest-diff": "27.0.6",
-            "js-yaml": "3.14.1",
-            "jsonfile": "4.0.0",
-            "jsonschema": "1.1.1",
-            "lodash": "4.17.21",
-            "lodash-deep": "2.0.0",
-            "log4js": "6.3.0",
-            "markdown-it": "12.0.4",
-            "moment": "2.20.1",
-            "mustache": "2.3.0",
-            "npm-package-arg": "8.1.1",
-            "open": "8.2.1",
-            "opener": "1.5.2",
-            "pacote": "11.1.4",
-            "prettyjson": "1.2.1",
-            "progress": "2.0.3",
-            "read": "1.0.7",
-            "readline-sync": "1.4.10",
-            "rimraf": "2.6.3",
-            "sanitize-html": "2.3.2",
-            "semver": "5.7.0",
-            "stack-trace": "0.0.10",
-            "strip-ansi": "6.0.1",
-            "wrap-ansi": "7.0.0",
-            "yamljs": "0.3.0",
-            "yargs": "15.3.1"
-          }
-        },
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^1.9.0"
-          }
-        },
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        },
-        "color-convert": {
-          "version": "1.9.3",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-          "dev": true,
-          "requires": {
-            "color-name": "1.1.3"
-          }
-        },
-        "color-name": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-          "dev": true
-        },
-        "escape-string-regexp": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-          "dev": true
-        },
         "glob": {
           "version": "7.1.6",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
@@ -34529,12 +31603,6 @@
             "path-is-absolute": "^1.0.0"
           }
         },
-        "has-flag": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-          "dev": true
-        },
         "rimraf": {
           "version": "2.6.3",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
@@ -34542,21 +31610,6 @@
           "dev": true,
           "requires": {
             "glob": "^7.1.3"
-          }
-        },
-        "semver": {
-          "version": "5.7.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^3.0.0"
           }
         }
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "__tests__/__packages__/*"
       ],
       "dependencies": {
-        "@zowe/imperative": "5.0.0-next.202112101814",
+        "@zowe/imperative": "5.0.0-next.202112132158",
         "@zowe/perf-timing": "1.0.7"
       },
       "devDependencies": {
@@ -62,7 +62,7 @@
     },
     "__tests__/__packages__/cli-test-utils": {
       "name": "@zowe/cli-test-utils",
-      "version": "7.0.0-next.202112081943",
+      "version": "7.0.0-next.202112102143",
       "license": "EPL-2.0",
       "dependencies": {
         "@types/js-yaml": "^4.0.0",
@@ -88,9 +88,157 @@
       "dev": true,
       "license": "MIT"
     },
+    "__tests__/__packages__/cli-test-utils/node_modules/@zowe/imperative": {
+      "version": "5.0.0-next.202112101814",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-local-release/@zowe/imperative/-/@zowe/imperative-5.0.0-next.202112101814.tgz",
+      "integrity": "sha1-thpGvXuiYGpDdjgSyHSFD8bhaRA=",
+      "dev": true,
+      "license": "EPL-2.0",
+      "dependencies": {
+        "@types/lodash-deep": "2.0.0",
+        "@types/yargs": "13.0.4",
+        "@zowe/perf-timing": "1.0.7",
+        "chalk": "2.4.2",
+        "cli-table3": "0.6.0",
+        "comment-json": "4.1.0",
+        "dataobject-parser": "1.2.1",
+        "deepmerge": "4.2.2",
+        "fast-glob": "3.2.7",
+        "fastest-levenshtein": "1.0.12",
+        "find-up": "4.1.0",
+        "fs-extra": "8.1.0",
+        "glob": "7.1.6",
+        "jest-diff": "27.0.6",
+        "js-yaml": "3.14.1",
+        "jsonfile": "4.0.0",
+        "jsonschema": "1.1.1",
+        "lodash": "4.17.21",
+        "lodash-deep": "2.0.0",
+        "log4js": "6.3.0",
+        "markdown-it": "12.0.4",
+        "moment": "2.20.1",
+        "mustache": "2.3.0",
+        "npm-package-arg": "8.1.1",
+        "open": "8.2.1",
+        "opener": "1.5.2",
+        "pacote": "11.1.4",
+        "prettyjson": "1.2.1",
+        "progress": "2.0.3",
+        "read": "1.0.7",
+        "readline-sync": "1.4.10",
+        "rimraf": "2.6.3",
+        "sanitize-html": "2.3.2",
+        "semver": "5.7.0",
+        "stack-trace": "0.0.10",
+        "strip-ansi": "6.0.1",
+        "wrap-ansi": "7.0.0",
+        "yamljs": "0.3.0",
+        "yargs": "15.3.1"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "__tests__/__packages__/cli-test-utils/node_modules/@zowe/imperative/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "__tests__/__packages__/cli-test-utils/node_modules/@zowe/imperative/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dev": true,
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "__tests__/__packages__/cli-test-utils/node_modules/@zowe/imperative/node_modules/js-yaml": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "__tests__/__packages__/cli-test-utils/node_modules/@zowe/imperative/node_modules/rimraf": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
+    "__tests__/__packages__/cli-test-utils/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "__tests__/__packages__/cli-test-utils/node_modules/argparse": {
       "version": "2.0.1",
       "license": "Python-2.0"
+    },
+    "__tests__/__packages__/cli-test-utils/node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "__tests__/__packages__/cli-test-utils/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "__tests__/__packages__/cli-test-utils/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
+    },
+    "__tests__/__packages__/cli-test-utils/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
     },
     "__tests__/__packages__/cli-test-utils/node_modules/find-up": {
       "version": "5.0.0",
@@ -117,6 +265,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "__tests__/__packages__/cli-test-utils/node_modules/glob": {
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "__tests__/__packages__/cli-test-utils/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
       }
     },
     "__tests__/__packages__/cli-test-utils/node_modules/js-yaml": {
@@ -167,6 +344,27 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "__tests__/__packages__/cli-test-utils/node_modules/semver": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+      "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "__tests__/__packages__/cli-test-utils/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "__tests__/__packages__/cli-test-utils/node_modules/typescript": {
@@ -5319,9 +5517,9 @@
       "link": true
     },
     "node_modules/@zowe/imperative": {
-      "version": "5.0.0-next.202112101814",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-local-release/@zowe/imperative/-/@zowe/imperative-5.0.0-next.202112101814.tgz",
-      "integrity": "sha1-thpGvXuiYGpDdjgSyHSFD8bhaRA=",
+      "version": "5.0.0-next.202112132158",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-local-release/@zowe/imperative/-/@zowe/imperative-5.0.0-next.202112132158.tgz",
+      "integrity": "sha1-5XOJHTUWKTMrwv/J2h3wA+cSkXk=",
       "license": "EPL-2.0",
       "dependencies": {
         "@types/lodash-deep": "2.0.0",
@@ -26335,22 +26533,22 @@
     },
     "packages/cli": {
       "name": "@zowe/cli",
-      "version": "7.0.0-next.202112081943",
+      "version": "7.0.0-next.202112102143",
       "hasInstallScript": true,
       "license": "EPL-2.0",
       "dependencies": {
-        "@zowe/core-for-zowe-sdk": "7.0.0-next.202112081943",
+        "@zowe/core-for-zowe-sdk": "7.0.0-next.202112102143",
         "@zowe/imperative": "5.0.0-next.202112101814",
         "@zowe/perf-timing": "1.0.7",
-        "@zowe/provisioning-for-zowe-sdk": "7.0.0-next.202112081943",
-        "@zowe/zos-console-for-zowe-sdk": "7.0.0-next.202112081943",
-        "@zowe/zos-files-for-zowe-sdk": "7.0.0-next.202112081943",
-        "@zowe/zos-jobs-for-zowe-sdk": "7.0.0-next.202112081943",
-        "@zowe/zos-logs-for-zowe-sdk": "7.0.0-next.202112081943",
-        "@zowe/zos-tso-for-zowe-sdk": "7.0.0-next.202112081943",
-        "@zowe/zos-uss-for-zowe-sdk": "7.0.0-next.202112081943",
-        "@zowe/zos-workflows-for-zowe-sdk": "7.0.0-next.202112081943",
-        "@zowe/zosmf-for-zowe-sdk": "7.0.0-next.202112081943",
+        "@zowe/provisioning-for-zowe-sdk": "7.0.0-next.202112102143",
+        "@zowe/zos-console-for-zowe-sdk": "7.0.0-next.202112102143",
+        "@zowe/zos-files-for-zowe-sdk": "7.0.0-next.202112102143",
+        "@zowe/zos-jobs-for-zowe-sdk": "7.0.0-next.202112102143",
+        "@zowe/zos-logs-for-zowe-sdk": "7.0.0-next.202112102143",
+        "@zowe/zos-tso-for-zowe-sdk": "7.0.0-next.202112102143",
+        "@zowe/zos-uss-for-zowe-sdk": "7.0.0-next.202112102143",
+        "@zowe/zos-workflows-for-zowe-sdk": "7.0.0-next.202112102143",
+        "@zowe/zosmf-for-zowe-sdk": "7.0.0-next.202112102143",
         "get-stdin": "7.0.0",
         "lodash": "4.17.21",
         "minimatch": "3.0.4"
@@ -26362,7 +26560,7 @@
       "devDependencies": {
         "@types/lodash": "^4.14.175",
         "@types/node": "^12.12.24",
-        "@zowe/cli-test-utils": "7.0.0-next.202112081943",
+        "@zowe/cli-test-utils": "7.0.0-next.202112102143",
         "comment-json": "^4.1.0",
         "eslint": "^7.32.0",
         "js-yaml": "^3.13.1",
@@ -26379,6 +26577,101 @@
         "keytar": "7.7.0"
       }
     },
+    "packages/cli/node_modules/@zowe/imperative": {
+      "version": "5.0.0-next.202112101814",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-local-release/@zowe/imperative/-/@zowe/imperative-5.0.0-next.202112101814.tgz",
+      "integrity": "sha1-thpGvXuiYGpDdjgSyHSFD8bhaRA=",
+      "license": "EPL-2.0",
+      "dependencies": {
+        "@types/lodash-deep": "2.0.0",
+        "@types/yargs": "13.0.4",
+        "@zowe/perf-timing": "1.0.7",
+        "chalk": "2.4.2",
+        "cli-table3": "0.6.0",
+        "comment-json": "4.1.0",
+        "dataobject-parser": "1.2.1",
+        "deepmerge": "4.2.2",
+        "fast-glob": "3.2.7",
+        "fastest-levenshtein": "1.0.12",
+        "find-up": "4.1.0",
+        "fs-extra": "8.1.0",
+        "glob": "7.1.6",
+        "jest-diff": "27.0.6",
+        "js-yaml": "3.14.1",
+        "jsonfile": "4.0.0",
+        "jsonschema": "1.1.1",
+        "lodash": "4.17.21",
+        "lodash-deep": "2.0.0",
+        "log4js": "6.3.0",
+        "markdown-it": "12.0.4",
+        "moment": "2.20.1",
+        "mustache": "2.3.0",
+        "npm-package-arg": "8.1.1",
+        "open": "8.2.1",
+        "opener": "1.5.2",
+        "pacote": "11.1.4",
+        "prettyjson": "1.2.1",
+        "progress": "2.0.3",
+        "read": "1.0.7",
+        "readline-sync": "1.4.10",
+        "rimraf": "2.6.3",
+        "sanitize-html": "2.3.2",
+        "semver": "5.7.0",
+        "stack-trace": "0.0.10",
+        "strip-ansi": "6.0.1",
+        "wrap-ansi": "7.0.0",
+        "yamljs": "0.3.0",
+        "yargs": "15.3.1"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "packages/cli/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "packages/cli/node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "packages/cli/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "packages/cli/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+    },
+    "packages/cli/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "packages/cli/node_modules/get-stdin": {
       "version": "7.0.0",
       "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/get-stdin/-/get-stdin-7.0.0.tgz",
@@ -26388,9 +26681,66 @@
         "node": ">=8"
       }
     },
+    "packages/cli/node_modules/glob": {
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/cli/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "packages/cli/node_modules/rimraf": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
+    "packages/cli/node_modules/semver": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+      "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "packages/cli/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "packages/core": {
       "name": "@zowe/core-for-zowe-sdk",
-      "version": "7.0.0-next.202112081943",
+      "version": "7.0.0-next.202112102143",
       "license": "EPL-2.0",
       "dependencies": {
         "comment-json": "4.1.0",
@@ -26398,7 +26748,7 @@
       },
       "devDependencies": {
         "@types/node": "^12.12.24",
-        "@zowe/cli-test-utils": "7.0.0-next.202112081943",
+        "@zowe/cli-test-utils": "7.0.0-next.202112102143",
         "@zowe/imperative": "5.0.0-next.202112101814",
         "chalk": "^4.1.0",
         "eslint": "^7.32.0",
@@ -26411,9 +26761,172 @@
         "@zowe/imperative": ">=5.0.0-next.202106041929 <5.0.0"
       }
     },
+    "packages/core/node_modules/@zowe/imperative": {
+      "version": "5.0.0-next.202112101814",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-local-release/@zowe/imperative/-/@zowe/imperative-5.0.0-next.202112101814.tgz",
+      "integrity": "sha1-thpGvXuiYGpDdjgSyHSFD8bhaRA=",
+      "dev": true,
+      "license": "EPL-2.0",
+      "dependencies": {
+        "@types/lodash-deep": "2.0.0",
+        "@types/yargs": "13.0.4",
+        "@zowe/perf-timing": "1.0.7",
+        "chalk": "2.4.2",
+        "cli-table3": "0.6.0",
+        "comment-json": "4.1.0",
+        "dataobject-parser": "1.2.1",
+        "deepmerge": "4.2.2",
+        "fast-glob": "3.2.7",
+        "fastest-levenshtein": "1.0.12",
+        "find-up": "4.1.0",
+        "fs-extra": "8.1.0",
+        "glob": "7.1.6",
+        "jest-diff": "27.0.6",
+        "js-yaml": "3.14.1",
+        "jsonfile": "4.0.0",
+        "jsonschema": "1.1.1",
+        "lodash": "4.17.21",
+        "lodash-deep": "2.0.0",
+        "log4js": "6.3.0",
+        "markdown-it": "12.0.4",
+        "moment": "2.20.1",
+        "mustache": "2.3.0",
+        "npm-package-arg": "8.1.1",
+        "open": "8.2.1",
+        "opener": "1.5.2",
+        "pacote": "11.1.4",
+        "prettyjson": "1.2.1",
+        "progress": "2.0.3",
+        "read": "1.0.7",
+        "readline-sync": "1.4.10",
+        "rimraf": "2.6.3",
+        "sanitize-html": "2.3.2",
+        "semver": "5.7.0",
+        "stack-trace": "0.0.10",
+        "strip-ansi": "6.0.1",
+        "wrap-ansi": "7.0.0",
+        "yamljs": "0.3.0",
+        "yargs": "15.3.1"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "packages/core/node_modules/@zowe/imperative/node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "packages/core/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "packages/core/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "packages/core/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
+    },
+    "packages/core/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "packages/core/node_modules/glob": {
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/core/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "packages/core/node_modules/rimraf": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
+    "packages/core/node_modules/semver": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+      "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "packages/core/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "packages/provisioning": {
       "name": "@zowe/provisioning-for-zowe-sdk",
-      "version": "7.0.0-next.202112081943",
+      "version": "7.0.0-next.202112102143",
       "license": "EPL-2.0",
       "dependencies": {
         "js-yaml": "3.14.1"
@@ -26421,8 +26934,8 @@
       "devDependencies": {
         "@types/js-yaml": "^3.12.5",
         "@types/node": "^12.12.24",
-        "@zowe/cli-test-utils": "7.0.0-next.202112081943",
-        "@zowe/core-for-zowe-sdk": "7.0.0-next.202112081943",
+        "@zowe/cli-test-utils": "7.0.0-next.202112102143",
+        "@zowe/core-for-zowe-sdk": "7.0.0-next.202112102143",
         "@zowe/imperative": "5.0.0-next.202112101814",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
@@ -26442,17 +26955,180 @@
       "dev": true,
       "license": "MIT"
     },
-    "packages/workflows": {
-      "name": "@zowe/zos-workflows-for-zowe-sdk",
-      "version": "7.0.0-next.202112081943",
+    "packages/provisioning/node_modules/@zowe/imperative": {
+      "version": "5.0.0-next.202112101814",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-local-release/@zowe/imperative/-/@zowe/imperative-5.0.0-next.202112101814.tgz",
+      "integrity": "sha1-thpGvXuiYGpDdjgSyHSFD8bhaRA=",
+      "dev": true,
       "license": "EPL-2.0",
       "dependencies": {
-        "@zowe/zos-files-for-zowe-sdk": "7.0.0-next.202112081943"
+        "@types/lodash-deep": "2.0.0",
+        "@types/yargs": "13.0.4",
+        "@zowe/perf-timing": "1.0.7",
+        "chalk": "2.4.2",
+        "cli-table3": "0.6.0",
+        "comment-json": "4.1.0",
+        "dataobject-parser": "1.2.1",
+        "deepmerge": "4.2.2",
+        "fast-glob": "3.2.7",
+        "fastest-levenshtein": "1.0.12",
+        "find-up": "4.1.0",
+        "fs-extra": "8.1.0",
+        "glob": "7.1.6",
+        "jest-diff": "27.0.6",
+        "js-yaml": "3.14.1",
+        "jsonfile": "4.0.0",
+        "jsonschema": "1.1.1",
+        "lodash": "4.17.21",
+        "lodash-deep": "2.0.0",
+        "log4js": "6.3.0",
+        "markdown-it": "12.0.4",
+        "moment": "2.20.1",
+        "mustache": "2.3.0",
+        "npm-package-arg": "8.1.1",
+        "open": "8.2.1",
+        "opener": "1.5.2",
+        "pacote": "11.1.4",
+        "prettyjson": "1.2.1",
+        "progress": "2.0.3",
+        "read": "1.0.7",
+        "readline-sync": "1.4.10",
+        "rimraf": "2.6.3",
+        "sanitize-html": "2.3.2",
+        "semver": "5.7.0",
+        "stack-trace": "0.0.10",
+        "strip-ansi": "6.0.1",
+        "wrap-ansi": "7.0.0",
+        "yamljs": "0.3.0",
+        "yargs": "15.3.1"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "packages/provisioning/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "packages/provisioning/node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "packages/provisioning/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "packages/provisioning/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
+    },
+    "packages/provisioning/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "packages/provisioning/node_modules/glob": {
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/provisioning/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "packages/provisioning/node_modules/rimraf": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
+    "packages/provisioning/node_modules/semver": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+      "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "packages/provisioning/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "packages/workflows": {
+      "name": "@zowe/zos-workflows-for-zowe-sdk",
+      "version": "7.0.0-next.202112102143",
+      "license": "EPL-2.0",
+      "dependencies": {
+        "@zowe/zos-files-for-zowe-sdk": "7.0.0-next.202112102143"
       },
       "devDependencies": {
         "@types/node": "^12.12.24",
-        "@zowe/cli-test-utils": "7.0.0-next.202112081943",
-        "@zowe/core-for-zowe-sdk": "7.0.0-next.202112081943",
+        "@zowe/cli-test-utils": "7.0.0-next.202112102143",
+        "@zowe/core-for-zowe-sdk": "7.0.0-next.202112102143",
         "@zowe/imperative": "5.0.0-next.202112101814",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
@@ -26463,16 +27139,179 @@
       "peerDependencies": {
         "@zowe/core-for-zowe-sdk": ">=7.0.0-next <7.0.0",
         "@zowe/imperative": ">=5.0.0-next.202106041929 <5.0.0"
+      }
+    },
+    "packages/workflows/node_modules/@zowe/imperative": {
+      "version": "5.0.0-next.202112101814",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-local-release/@zowe/imperative/-/@zowe/imperative-5.0.0-next.202112101814.tgz",
+      "integrity": "sha1-thpGvXuiYGpDdjgSyHSFD8bhaRA=",
+      "dev": true,
+      "license": "EPL-2.0",
+      "dependencies": {
+        "@types/lodash-deep": "2.0.0",
+        "@types/yargs": "13.0.4",
+        "@zowe/perf-timing": "1.0.7",
+        "chalk": "2.4.2",
+        "cli-table3": "0.6.0",
+        "comment-json": "4.1.0",
+        "dataobject-parser": "1.2.1",
+        "deepmerge": "4.2.2",
+        "fast-glob": "3.2.7",
+        "fastest-levenshtein": "1.0.12",
+        "find-up": "4.1.0",
+        "fs-extra": "8.1.0",
+        "glob": "7.1.6",
+        "jest-diff": "27.0.6",
+        "js-yaml": "3.14.1",
+        "jsonfile": "4.0.0",
+        "jsonschema": "1.1.1",
+        "lodash": "4.17.21",
+        "lodash-deep": "2.0.0",
+        "log4js": "6.3.0",
+        "markdown-it": "12.0.4",
+        "moment": "2.20.1",
+        "mustache": "2.3.0",
+        "npm-package-arg": "8.1.1",
+        "open": "8.2.1",
+        "opener": "1.5.2",
+        "pacote": "11.1.4",
+        "prettyjson": "1.2.1",
+        "progress": "2.0.3",
+        "read": "1.0.7",
+        "readline-sync": "1.4.10",
+        "rimraf": "2.6.3",
+        "sanitize-html": "2.3.2",
+        "semver": "5.7.0",
+        "stack-trace": "0.0.10",
+        "strip-ansi": "6.0.1",
+        "wrap-ansi": "7.0.0",
+        "yamljs": "0.3.0",
+        "yargs": "15.3.1"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "packages/workflows/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "packages/workflows/node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "packages/workflows/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "packages/workflows/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
+    },
+    "packages/workflows/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "packages/workflows/node_modules/glob": {
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/workflows/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "packages/workflows/node_modules/rimraf": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
+    "packages/workflows/node_modules/semver": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+      "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "packages/workflows/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "packages/zosconsole": {
       "name": "@zowe/zos-console-for-zowe-sdk",
-      "version": "7.0.0-next.202112081943",
+      "version": "7.0.0-next.202112102143",
       "license": "EPL-2.0",
       "devDependencies": {
         "@types/node": "^12.12.24",
-        "@zowe/cli-test-utils": "7.0.0-next.202112081943",
-        "@zowe/core-for-zowe-sdk": "7.0.0-next.202112081943",
+        "@zowe/cli-test-utils": "7.0.0-next.202112102143",
+        "@zowe/core-for-zowe-sdk": "7.0.0-next.202112102143",
         "@zowe/imperative": "5.0.0-next.202112101814",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
@@ -26485,19 +27324,182 @@
         "@zowe/imperative": ">=5.0.0-next.202106041929 <5.0.0"
       }
     },
+    "packages/zosconsole/node_modules/@zowe/imperative": {
+      "version": "5.0.0-next.202112101814",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-local-release/@zowe/imperative/-/@zowe/imperative-5.0.0-next.202112101814.tgz",
+      "integrity": "sha1-thpGvXuiYGpDdjgSyHSFD8bhaRA=",
+      "dev": true,
+      "license": "EPL-2.0",
+      "dependencies": {
+        "@types/lodash-deep": "2.0.0",
+        "@types/yargs": "13.0.4",
+        "@zowe/perf-timing": "1.0.7",
+        "chalk": "2.4.2",
+        "cli-table3": "0.6.0",
+        "comment-json": "4.1.0",
+        "dataobject-parser": "1.2.1",
+        "deepmerge": "4.2.2",
+        "fast-glob": "3.2.7",
+        "fastest-levenshtein": "1.0.12",
+        "find-up": "4.1.0",
+        "fs-extra": "8.1.0",
+        "glob": "7.1.6",
+        "jest-diff": "27.0.6",
+        "js-yaml": "3.14.1",
+        "jsonfile": "4.0.0",
+        "jsonschema": "1.1.1",
+        "lodash": "4.17.21",
+        "lodash-deep": "2.0.0",
+        "log4js": "6.3.0",
+        "markdown-it": "12.0.4",
+        "moment": "2.20.1",
+        "mustache": "2.3.0",
+        "npm-package-arg": "8.1.1",
+        "open": "8.2.1",
+        "opener": "1.5.2",
+        "pacote": "11.1.4",
+        "prettyjson": "1.2.1",
+        "progress": "2.0.3",
+        "read": "1.0.7",
+        "readline-sync": "1.4.10",
+        "rimraf": "2.6.3",
+        "sanitize-html": "2.3.2",
+        "semver": "5.7.0",
+        "stack-trace": "0.0.10",
+        "strip-ansi": "6.0.1",
+        "wrap-ansi": "7.0.0",
+        "yamljs": "0.3.0",
+        "yargs": "15.3.1"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "packages/zosconsole/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "packages/zosconsole/node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "packages/zosconsole/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "packages/zosconsole/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
+    },
+    "packages/zosconsole/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "packages/zosconsole/node_modules/glob": {
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/zosconsole/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "packages/zosconsole/node_modules/rimraf": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
+    "packages/zosconsole/node_modules/semver": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+      "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "packages/zosconsole/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "packages/zosfiles": {
       "name": "@zowe/zos-files-for-zowe-sdk",
-      "version": "7.0.0-next.202112081943",
+      "version": "7.0.0-next.202112102143",
       "license": "EPL-2.0",
       "dependencies": {
         "minimatch": "3.0.4"
       },
       "devDependencies": {
         "@types/node": "^12.12.24",
-        "@zowe/cli-test-utils": "7.0.0-next.202112081943",
-        "@zowe/core-for-zowe-sdk": "7.0.0-next.202112081943",
+        "@zowe/cli-test-utils": "7.0.0-next.202112102143",
+        "@zowe/core-for-zowe-sdk": "7.0.0-next.202112102143",
         "@zowe/imperative": "5.0.0-next.202112101814",
-        "@zowe/zos-uss-for-zowe-sdk": "7.0.0-next.202112081943",
+        "@zowe/zos-uss-for-zowe-sdk": "7.0.0-next.202112102143",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
         "rimraf": "^2.6.3",
@@ -26507,19 +27509,182 @@
       "peerDependencies": {
         "@zowe/core-for-zowe-sdk": ">=7.0.0-next <7.0.0",
         "@zowe/imperative": ">=5.0.0-next.202106041929 <5.0.0"
+      }
+    },
+    "packages/zosfiles/node_modules/@zowe/imperative": {
+      "version": "5.0.0-next.202112101814",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-local-release/@zowe/imperative/-/@zowe/imperative-5.0.0-next.202112101814.tgz",
+      "integrity": "sha1-thpGvXuiYGpDdjgSyHSFD8bhaRA=",
+      "dev": true,
+      "license": "EPL-2.0",
+      "dependencies": {
+        "@types/lodash-deep": "2.0.0",
+        "@types/yargs": "13.0.4",
+        "@zowe/perf-timing": "1.0.7",
+        "chalk": "2.4.2",
+        "cli-table3": "0.6.0",
+        "comment-json": "4.1.0",
+        "dataobject-parser": "1.2.1",
+        "deepmerge": "4.2.2",
+        "fast-glob": "3.2.7",
+        "fastest-levenshtein": "1.0.12",
+        "find-up": "4.1.0",
+        "fs-extra": "8.1.0",
+        "glob": "7.1.6",
+        "jest-diff": "27.0.6",
+        "js-yaml": "3.14.1",
+        "jsonfile": "4.0.0",
+        "jsonschema": "1.1.1",
+        "lodash": "4.17.21",
+        "lodash-deep": "2.0.0",
+        "log4js": "6.3.0",
+        "markdown-it": "12.0.4",
+        "moment": "2.20.1",
+        "mustache": "2.3.0",
+        "npm-package-arg": "8.1.1",
+        "open": "8.2.1",
+        "opener": "1.5.2",
+        "pacote": "11.1.4",
+        "prettyjson": "1.2.1",
+        "progress": "2.0.3",
+        "read": "1.0.7",
+        "readline-sync": "1.4.10",
+        "rimraf": "2.6.3",
+        "sanitize-html": "2.3.2",
+        "semver": "5.7.0",
+        "stack-trace": "0.0.10",
+        "strip-ansi": "6.0.1",
+        "wrap-ansi": "7.0.0",
+        "yamljs": "0.3.0",
+        "yargs": "15.3.1"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "packages/zosfiles/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "packages/zosfiles/node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "packages/zosfiles/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "packages/zosfiles/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
+    },
+    "packages/zosfiles/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "packages/zosfiles/node_modules/glob": {
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/zosfiles/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "packages/zosfiles/node_modules/rimraf": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
+    "packages/zosfiles/node_modules/semver": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+      "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "packages/zosfiles/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "packages/zosjobs": {
       "name": "@zowe/zos-jobs-for-zowe-sdk",
-      "version": "7.0.0-next.202112081943",
+      "version": "7.0.0-next.202112102143",
       "license": "EPL-2.0",
       "dependencies": {
-        "@zowe/zos-files-for-zowe-sdk": "7.0.0-next.202112081943"
+        "@zowe/zos-files-for-zowe-sdk": "7.0.0-next.202112102143"
       },
       "devDependencies": {
         "@types/node": "^12.12.24",
-        "@zowe/cli-test-utils": "7.0.0-next.202112081943",
-        "@zowe/core-for-zowe-sdk": "7.0.0-next.202112081943",
+        "@zowe/cli-test-utils": "7.0.0-next.202112102143",
+        "@zowe/core-for-zowe-sdk": "7.0.0-next.202112102143",
         "@zowe/imperative": "5.0.0-next.202112101814",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
@@ -26530,16 +27695,179 @@
       "peerDependencies": {
         "@zowe/core-for-zowe-sdk": ">=7.0.0-next <7.0.0",
         "@zowe/imperative": ">=5.0.0-next.202106041929 <5.0.0"
+      }
+    },
+    "packages/zosjobs/node_modules/@zowe/imperative": {
+      "version": "5.0.0-next.202112101814",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-local-release/@zowe/imperative/-/@zowe/imperative-5.0.0-next.202112101814.tgz",
+      "integrity": "sha1-thpGvXuiYGpDdjgSyHSFD8bhaRA=",
+      "dev": true,
+      "license": "EPL-2.0",
+      "dependencies": {
+        "@types/lodash-deep": "2.0.0",
+        "@types/yargs": "13.0.4",
+        "@zowe/perf-timing": "1.0.7",
+        "chalk": "2.4.2",
+        "cli-table3": "0.6.0",
+        "comment-json": "4.1.0",
+        "dataobject-parser": "1.2.1",
+        "deepmerge": "4.2.2",
+        "fast-glob": "3.2.7",
+        "fastest-levenshtein": "1.0.12",
+        "find-up": "4.1.0",
+        "fs-extra": "8.1.0",
+        "glob": "7.1.6",
+        "jest-diff": "27.0.6",
+        "js-yaml": "3.14.1",
+        "jsonfile": "4.0.0",
+        "jsonschema": "1.1.1",
+        "lodash": "4.17.21",
+        "lodash-deep": "2.0.0",
+        "log4js": "6.3.0",
+        "markdown-it": "12.0.4",
+        "moment": "2.20.1",
+        "mustache": "2.3.0",
+        "npm-package-arg": "8.1.1",
+        "open": "8.2.1",
+        "opener": "1.5.2",
+        "pacote": "11.1.4",
+        "prettyjson": "1.2.1",
+        "progress": "2.0.3",
+        "read": "1.0.7",
+        "readline-sync": "1.4.10",
+        "rimraf": "2.6.3",
+        "sanitize-html": "2.3.2",
+        "semver": "5.7.0",
+        "stack-trace": "0.0.10",
+        "strip-ansi": "6.0.1",
+        "wrap-ansi": "7.0.0",
+        "yamljs": "0.3.0",
+        "yargs": "15.3.1"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "packages/zosjobs/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "packages/zosjobs/node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "packages/zosjobs/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "packages/zosjobs/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
+    },
+    "packages/zosjobs/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "packages/zosjobs/node_modules/glob": {
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/zosjobs/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "packages/zosjobs/node_modules/rimraf": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
+    "packages/zosjobs/node_modules/semver": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+      "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "packages/zosjobs/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "packages/zoslogs": {
       "name": "@zowe/zos-logs-for-zowe-sdk",
-      "version": "7.0.0-next.202112081943",
+      "version": "7.0.0-next.202112102143",
       "license": "EPL-2.0",
       "devDependencies": {
         "@types/node": "^12.12.24",
-        "@zowe/cli-test-utils": "7.0.0-next.202112081943",
-        "@zowe/core-for-zowe-sdk": "7.0.0-next.202112081943",
+        "@zowe/cli-test-utils": "7.0.0-next.202112102143",
+        "@zowe/core-for-zowe-sdk": "7.0.0-next.202112102143",
         "@zowe/imperative": "5.0.0-next.202112101814",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
@@ -26550,16 +27878,179 @@
       "peerDependencies": {
         "@zowe/core-for-zowe-sdk": ">=7.0.0-next <7.0.0",
         "@zowe/imperative": ">=5.0.0-next.202106041929 <5.0.0"
+      }
+    },
+    "packages/zoslogs/node_modules/@zowe/imperative": {
+      "version": "5.0.0-next.202112101814",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-local-release/@zowe/imperative/-/@zowe/imperative-5.0.0-next.202112101814.tgz",
+      "integrity": "sha1-thpGvXuiYGpDdjgSyHSFD8bhaRA=",
+      "dev": true,
+      "license": "EPL-2.0",
+      "dependencies": {
+        "@types/lodash-deep": "2.0.0",
+        "@types/yargs": "13.0.4",
+        "@zowe/perf-timing": "1.0.7",
+        "chalk": "2.4.2",
+        "cli-table3": "0.6.0",
+        "comment-json": "4.1.0",
+        "dataobject-parser": "1.2.1",
+        "deepmerge": "4.2.2",
+        "fast-glob": "3.2.7",
+        "fastest-levenshtein": "1.0.12",
+        "find-up": "4.1.0",
+        "fs-extra": "8.1.0",
+        "glob": "7.1.6",
+        "jest-diff": "27.0.6",
+        "js-yaml": "3.14.1",
+        "jsonfile": "4.0.0",
+        "jsonschema": "1.1.1",
+        "lodash": "4.17.21",
+        "lodash-deep": "2.0.0",
+        "log4js": "6.3.0",
+        "markdown-it": "12.0.4",
+        "moment": "2.20.1",
+        "mustache": "2.3.0",
+        "npm-package-arg": "8.1.1",
+        "open": "8.2.1",
+        "opener": "1.5.2",
+        "pacote": "11.1.4",
+        "prettyjson": "1.2.1",
+        "progress": "2.0.3",
+        "read": "1.0.7",
+        "readline-sync": "1.4.10",
+        "rimraf": "2.6.3",
+        "sanitize-html": "2.3.2",
+        "semver": "5.7.0",
+        "stack-trace": "0.0.10",
+        "strip-ansi": "6.0.1",
+        "wrap-ansi": "7.0.0",
+        "yamljs": "0.3.0",
+        "yargs": "15.3.1"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "packages/zoslogs/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "packages/zoslogs/node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "packages/zoslogs/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "packages/zoslogs/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
+    },
+    "packages/zoslogs/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "packages/zoslogs/node_modules/glob": {
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/zoslogs/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "packages/zoslogs/node_modules/rimraf": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
+    "packages/zoslogs/node_modules/semver": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+      "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "packages/zoslogs/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "packages/zosmf": {
       "name": "@zowe/zosmf-for-zowe-sdk",
-      "version": "7.0.0-next.202112081943",
+      "version": "7.0.0-next.202112102143",
       "license": "EPL-2.0",
       "devDependencies": {
         "@types/node": "^12.12.24",
-        "@zowe/cli-test-utils": "7.0.0-next.202112081943",
-        "@zowe/core-for-zowe-sdk": "7.0.0-next.202112081943",
+        "@zowe/cli-test-utils": "7.0.0-next.202112102143",
+        "@zowe/core-for-zowe-sdk": "7.0.0-next.202112102143",
         "@zowe/imperative": "5.0.0-next.202112101814",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
@@ -26570,19 +28061,182 @@
       "peerDependencies": {
         "@zowe/core-for-zowe-sdk": ">=7.0.0-next <7.0.0",
         "@zowe/imperative": ">=5.0.0-next.202106041929 <5.0.0"
+      }
+    },
+    "packages/zosmf/node_modules/@zowe/imperative": {
+      "version": "5.0.0-next.202112101814",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-local-release/@zowe/imperative/-/@zowe/imperative-5.0.0-next.202112101814.tgz",
+      "integrity": "sha1-thpGvXuiYGpDdjgSyHSFD8bhaRA=",
+      "dev": true,
+      "license": "EPL-2.0",
+      "dependencies": {
+        "@types/lodash-deep": "2.0.0",
+        "@types/yargs": "13.0.4",
+        "@zowe/perf-timing": "1.0.7",
+        "chalk": "2.4.2",
+        "cli-table3": "0.6.0",
+        "comment-json": "4.1.0",
+        "dataobject-parser": "1.2.1",
+        "deepmerge": "4.2.2",
+        "fast-glob": "3.2.7",
+        "fastest-levenshtein": "1.0.12",
+        "find-up": "4.1.0",
+        "fs-extra": "8.1.0",
+        "glob": "7.1.6",
+        "jest-diff": "27.0.6",
+        "js-yaml": "3.14.1",
+        "jsonfile": "4.0.0",
+        "jsonschema": "1.1.1",
+        "lodash": "4.17.21",
+        "lodash-deep": "2.0.0",
+        "log4js": "6.3.0",
+        "markdown-it": "12.0.4",
+        "moment": "2.20.1",
+        "mustache": "2.3.0",
+        "npm-package-arg": "8.1.1",
+        "open": "8.2.1",
+        "opener": "1.5.2",
+        "pacote": "11.1.4",
+        "prettyjson": "1.2.1",
+        "progress": "2.0.3",
+        "read": "1.0.7",
+        "readline-sync": "1.4.10",
+        "rimraf": "2.6.3",
+        "sanitize-html": "2.3.2",
+        "semver": "5.7.0",
+        "stack-trace": "0.0.10",
+        "strip-ansi": "6.0.1",
+        "wrap-ansi": "7.0.0",
+        "yamljs": "0.3.0",
+        "yargs": "15.3.1"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "packages/zosmf/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "packages/zosmf/node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "packages/zosmf/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "packages/zosmf/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
+    },
+    "packages/zosmf/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "packages/zosmf/node_modules/glob": {
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/zosmf/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "packages/zosmf/node_modules/rimraf": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
+    "packages/zosmf/node_modules/semver": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+      "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "packages/zosmf/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "packages/zostso": {
       "name": "@zowe/zos-tso-for-zowe-sdk",
-      "version": "7.0.0-next.202112081943",
+      "version": "7.0.0-next.202112102143",
       "license": "EPL-2.0",
       "dependencies": {
-        "@zowe/zosmf-for-zowe-sdk": "7.0.0-next.202112081943"
+        "@zowe/zosmf-for-zowe-sdk": "7.0.0-next.202112102143"
       },
       "devDependencies": {
         "@types/node": "^12.12.24",
-        "@zowe/cli-test-utils": "7.0.0-next.202112081943",
-        "@zowe/core-for-zowe-sdk": "7.0.0-next.202112081943",
+        "@zowe/cli-test-utils": "7.0.0-next.202112102143",
+        "@zowe/core-for-zowe-sdk": "7.0.0-next.202112102143",
         "@zowe/imperative": "5.0.0-next.202112101814",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
@@ -26595,9 +28249,172 @@
         "@zowe/imperative": ">=5.0.0-next.202106041929 <5.0.0"
       }
     },
+    "packages/zostso/node_modules/@zowe/imperative": {
+      "version": "5.0.0-next.202112101814",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-local-release/@zowe/imperative/-/@zowe/imperative-5.0.0-next.202112101814.tgz",
+      "integrity": "sha1-thpGvXuiYGpDdjgSyHSFD8bhaRA=",
+      "dev": true,
+      "license": "EPL-2.0",
+      "dependencies": {
+        "@types/lodash-deep": "2.0.0",
+        "@types/yargs": "13.0.4",
+        "@zowe/perf-timing": "1.0.7",
+        "chalk": "2.4.2",
+        "cli-table3": "0.6.0",
+        "comment-json": "4.1.0",
+        "dataobject-parser": "1.2.1",
+        "deepmerge": "4.2.2",
+        "fast-glob": "3.2.7",
+        "fastest-levenshtein": "1.0.12",
+        "find-up": "4.1.0",
+        "fs-extra": "8.1.0",
+        "glob": "7.1.6",
+        "jest-diff": "27.0.6",
+        "js-yaml": "3.14.1",
+        "jsonfile": "4.0.0",
+        "jsonschema": "1.1.1",
+        "lodash": "4.17.21",
+        "lodash-deep": "2.0.0",
+        "log4js": "6.3.0",
+        "markdown-it": "12.0.4",
+        "moment": "2.20.1",
+        "mustache": "2.3.0",
+        "npm-package-arg": "8.1.1",
+        "open": "8.2.1",
+        "opener": "1.5.2",
+        "pacote": "11.1.4",
+        "prettyjson": "1.2.1",
+        "progress": "2.0.3",
+        "read": "1.0.7",
+        "readline-sync": "1.4.10",
+        "rimraf": "2.6.3",
+        "sanitize-html": "2.3.2",
+        "semver": "5.7.0",
+        "stack-trace": "0.0.10",
+        "strip-ansi": "6.0.1",
+        "wrap-ansi": "7.0.0",
+        "yamljs": "0.3.0",
+        "yargs": "15.3.1"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "packages/zostso/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "packages/zostso/node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "packages/zostso/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "packages/zostso/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
+    },
+    "packages/zostso/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "packages/zostso/node_modules/glob": {
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/zostso/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "packages/zostso/node_modules/rimraf": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
+    "packages/zostso/node_modules/semver": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+      "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "packages/zostso/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "packages/zosuss": {
       "name": "@zowe/zos-uss-for-zowe-sdk",
-      "version": "7.0.0-next.202112081943",
+      "version": "7.0.0-next.202112102143",
       "license": "EPL-2.0",
       "dependencies": {
         "ssh2": "1.4.0"
@@ -26605,7 +28422,7 @@
       "devDependencies": {
         "@types/node": "^12.12.24",
         "@types/ssh2": "^0.5.44",
-        "@zowe/cli-test-utils": "7.0.0-next.202112081943",
+        "@zowe/cli-test-utils": "7.0.0-next.202112102143",
         "@zowe/imperative": "5.0.0-next.202112101814",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
@@ -26615,6 +28432,169 @@
       },
       "peerDependencies": {
         "@zowe/imperative": ">=5.0.0-next.202106041929 <5.0.0"
+      }
+    },
+    "packages/zosuss/node_modules/@zowe/imperative": {
+      "version": "5.0.0-next.202112101814",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-local-release/@zowe/imperative/-/@zowe/imperative-5.0.0-next.202112101814.tgz",
+      "integrity": "sha1-thpGvXuiYGpDdjgSyHSFD8bhaRA=",
+      "dev": true,
+      "license": "EPL-2.0",
+      "dependencies": {
+        "@types/lodash-deep": "2.0.0",
+        "@types/yargs": "13.0.4",
+        "@zowe/perf-timing": "1.0.7",
+        "chalk": "2.4.2",
+        "cli-table3": "0.6.0",
+        "comment-json": "4.1.0",
+        "dataobject-parser": "1.2.1",
+        "deepmerge": "4.2.2",
+        "fast-glob": "3.2.7",
+        "fastest-levenshtein": "1.0.12",
+        "find-up": "4.1.0",
+        "fs-extra": "8.1.0",
+        "glob": "7.1.6",
+        "jest-diff": "27.0.6",
+        "js-yaml": "3.14.1",
+        "jsonfile": "4.0.0",
+        "jsonschema": "1.1.1",
+        "lodash": "4.17.21",
+        "lodash-deep": "2.0.0",
+        "log4js": "6.3.0",
+        "markdown-it": "12.0.4",
+        "moment": "2.20.1",
+        "mustache": "2.3.0",
+        "npm-package-arg": "8.1.1",
+        "open": "8.2.1",
+        "opener": "1.5.2",
+        "pacote": "11.1.4",
+        "prettyjson": "1.2.1",
+        "progress": "2.0.3",
+        "read": "1.0.7",
+        "readline-sync": "1.4.10",
+        "rimraf": "2.6.3",
+        "sanitize-html": "2.3.2",
+        "semver": "5.7.0",
+        "stack-trace": "0.0.10",
+        "strip-ansi": "6.0.1",
+        "wrap-ansi": "7.0.0",
+        "yamljs": "0.3.0",
+        "yargs": "15.3.1"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "packages/zosuss/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "packages/zosuss/node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "packages/zosuss/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "packages/zosuss/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
+    },
+    "packages/zosuss/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "packages/zosuss/node_modules/glob": {
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/zosuss/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "packages/zosuss/node_modules/rimraf": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
+    "packages/zosuss/node_modules/semver": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+      "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "packages/zosuss/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
       }
     }
   },
@@ -30561,19 +32541,19 @@
       "requires": {
         "@types/lodash": "^4.14.175",
         "@types/node": "^12.12.24",
-        "@zowe/cli-test-utils": "7.0.0-next.202112081943",
-        "@zowe/core-for-zowe-sdk": "7.0.0-next.202112081943",
+        "@zowe/cli-test-utils": "7.0.0-next.202112102143",
+        "@zowe/core-for-zowe-sdk": "7.0.0-next.202112102143",
         "@zowe/imperative": "5.0.0-next.202112101814",
         "@zowe/perf-timing": "1.0.7",
-        "@zowe/provisioning-for-zowe-sdk": "7.0.0-next.202112081943",
-        "@zowe/zos-console-for-zowe-sdk": "7.0.0-next.202112081943",
-        "@zowe/zos-files-for-zowe-sdk": "7.0.0-next.202112081943",
-        "@zowe/zos-jobs-for-zowe-sdk": "7.0.0-next.202112081943",
-        "@zowe/zos-logs-for-zowe-sdk": "7.0.0-next.202112081943",
-        "@zowe/zos-tso-for-zowe-sdk": "7.0.0-next.202112081943",
-        "@zowe/zos-uss-for-zowe-sdk": "7.0.0-next.202112081943",
-        "@zowe/zos-workflows-for-zowe-sdk": "7.0.0-next.202112081943",
-        "@zowe/zosmf-for-zowe-sdk": "7.0.0-next.202112081943",
+        "@zowe/provisioning-for-zowe-sdk": "7.0.0-next.202112102143",
+        "@zowe/zos-console-for-zowe-sdk": "7.0.0-next.202112102143",
+        "@zowe/zos-files-for-zowe-sdk": "7.0.0-next.202112102143",
+        "@zowe/zos-jobs-for-zowe-sdk": "7.0.0-next.202112102143",
+        "@zowe/zos-logs-for-zowe-sdk": "7.0.0-next.202112102143",
+        "@zowe/zos-tso-for-zowe-sdk": "7.0.0-next.202112102143",
+        "@zowe/zos-uss-for-zowe-sdk": "7.0.0-next.202112102143",
+        "@zowe/zos-workflows-for-zowe-sdk": "7.0.0-next.202112102143",
+        "@zowe/zosmf-for-zowe-sdk": "7.0.0-next.202112102143",
         "comment-json": "^4.1.0",
         "eslint": "^7.32.0",
         "get-stdin": "7.0.0",
@@ -30588,10 +32568,131 @@
         "typescript": "^3.8.0"
       },
       "dependencies": {
+        "@zowe/imperative": {
+          "version": "5.0.0-next.202112101814",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-local-release/@zowe/imperative/-/@zowe/imperative-5.0.0-next.202112101814.tgz",
+          "integrity": "sha1-thpGvXuiYGpDdjgSyHSFD8bhaRA=",
+          "requires": {
+            "@types/lodash-deep": "2.0.0",
+            "@types/yargs": "13.0.4",
+            "@zowe/perf-timing": "1.0.7",
+            "chalk": "2.4.2",
+            "cli-table3": "0.6.0",
+            "comment-json": "4.1.0",
+            "dataobject-parser": "1.2.1",
+            "deepmerge": "4.2.2",
+            "fast-glob": "3.2.7",
+            "fastest-levenshtein": "1.0.12",
+            "find-up": "4.1.0",
+            "fs-extra": "8.1.0",
+            "glob": "7.1.6",
+            "jest-diff": "27.0.6",
+            "js-yaml": "3.14.1",
+            "jsonfile": "4.0.0",
+            "jsonschema": "1.1.1",
+            "lodash": "4.17.21",
+            "lodash-deep": "2.0.0",
+            "log4js": "6.3.0",
+            "markdown-it": "12.0.4",
+            "moment": "2.20.1",
+            "mustache": "2.3.0",
+            "npm-package-arg": "8.1.1",
+            "open": "8.2.1",
+            "opener": "1.5.2",
+            "pacote": "11.1.4",
+            "prettyjson": "1.2.1",
+            "progress": "2.0.3",
+            "read": "1.0.7",
+            "readline-sync": "1.4.10",
+            "rimraf": "2.6.3",
+            "sanitize-html": "2.3.2",
+            "semver": "5.7.0",
+            "stack-trace": "0.0.10",
+            "strip-ansi": "6.0.1",
+            "wrap-ansi": "7.0.0",
+            "yamljs": "0.3.0",
+            "yargs": "15.3.1"
+          }
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "color-convert": {
+          "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+          "requires": {
+            "color-name": "1.1.3"
+          }
+        },
+        "color-name": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+        },
         "get-stdin": {
           "version": "7.0.0",
           "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/get-stdin/-/get-stdin-7.0.0.tgz",
           "integrity": "sha1-jV3pjxUXGhJcXlFmQ8em0OqKlvY="
+        },
+        "glob": {
+          "version": "7.1.6",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+        },
+        "rimraf": {
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+          "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "semver": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
         }
       }
     },
@@ -30615,8 +32716,136 @@
           "version": "14.17.27",
           "dev": true
         },
+        "@zowe/imperative": {
+          "version": "5.0.0-next.202112101814",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-local-release/@zowe/imperative/-/@zowe/imperative-5.0.0-next.202112101814.tgz",
+          "integrity": "sha1-thpGvXuiYGpDdjgSyHSFD8bhaRA=",
+          "dev": true,
+          "requires": {
+            "@types/lodash-deep": "2.0.0",
+            "@types/yargs": "13.0.4",
+            "@zowe/perf-timing": "1.0.7",
+            "chalk": "2.4.2",
+            "cli-table3": "0.6.0",
+            "comment-json": "4.1.0",
+            "dataobject-parser": "1.2.1",
+            "deepmerge": "4.2.2",
+            "fast-glob": "3.2.7",
+            "fastest-levenshtein": "1.0.12",
+            "find-up": "4.1.0",
+            "fs-extra": "8.1.0",
+            "glob": "7.1.6",
+            "jest-diff": "27.0.6",
+            "js-yaml": "3.14.1",
+            "jsonfile": "4.0.0",
+            "jsonschema": "1.1.1",
+            "lodash": "4.17.21",
+            "lodash-deep": "2.0.0",
+            "log4js": "6.3.0",
+            "markdown-it": "12.0.4",
+            "moment": "2.20.1",
+            "mustache": "2.3.0",
+            "npm-package-arg": "8.1.1",
+            "open": "8.2.1",
+            "opener": "1.5.2",
+            "pacote": "11.1.4",
+            "prettyjson": "1.2.1",
+            "progress": "2.0.3",
+            "read": "1.0.7",
+            "readline-sync": "1.4.10",
+            "rimraf": "2.6.3",
+            "sanitize-html": "2.3.2",
+            "semver": "5.7.0",
+            "stack-trace": "0.0.10",
+            "strip-ansi": "6.0.1",
+            "wrap-ansi": "7.0.0",
+            "yamljs": "0.3.0",
+            "yargs": "15.3.1"
+          },
+          "dependencies": {
+            "argparse": {
+              "version": "1.0.10",
+              "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+              "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+              "dev": true,
+              "requires": {
+                "sprintf-js": "~1.0.2"
+              }
+            },
+            "find-up": {
+              "version": "4.1.0",
+              "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+              "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+              "dev": true,
+              "requires": {
+                "locate-path": "^5.0.0",
+                "path-exists": "^4.0.0"
+              }
+            },
+            "js-yaml": {
+              "version": "3.14.1",
+              "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+              "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+              "dev": true,
+              "requires": {
+                "argparse": "^1.0.7",
+                "esprima": "^4.0.0"
+              }
+            },
+            "rimraf": {
+              "version": "2.6.3",
+              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+              "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+              "dev": true,
+              "requires": {
+                "glob": "^7.1.3"
+              }
+            }
+          }
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
         "argparse": {
           "version": "2.0.1"
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "color-convert": {
+          "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+          "dev": true,
+          "requires": {
+            "color-name": "1.1.3"
+          }
+        },
+        "color-name": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+          "dev": true
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+          "dev": true
         },
         "find-up": {
           "version": "5.0.0",
@@ -30632,6 +32861,26 @@
               }
             }
           }
+        },
+        "glob": {
+          "version": "7.1.6",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
         },
         "js-yaml": {
           "version": "4.1.0",
@@ -30658,6 +32907,21 @@
             "glob": "^7.1.3"
           }
         },
+        "semver": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        },
         "typescript": {
           "version": "4.4.4",
           "dev": true
@@ -30671,7 +32935,7 @@
       "version": "file:packages/core",
       "requires": {
         "@types/node": "^12.12.24",
-        "@zowe/cli-test-utils": "7.0.0-next.202112081943",
+        "@zowe/cli-test-utils": "7.0.0-next.202112102143",
         "@zowe/imperative": "5.0.0-next.202112101814",
         "chalk": "^4.1.0",
         "comment-json": "4.1.0",
@@ -30681,12 +32945,148 @@
         "string-width": "4.2.3",
         "typedoc": "^0.16.0",
         "typescript": "^3.8.0"
+      },
+      "dependencies": {
+        "@zowe/imperative": {
+          "version": "5.0.0-next.202112101814",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-local-release/@zowe/imperative/-/@zowe/imperative-5.0.0-next.202112101814.tgz",
+          "integrity": "sha1-thpGvXuiYGpDdjgSyHSFD8bhaRA=",
+          "dev": true,
+          "requires": {
+            "@types/lodash-deep": "2.0.0",
+            "@types/yargs": "13.0.4",
+            "@zowe/perf-timing": "1.0.7",
+            "chalk": "2.4.2",
+            "cli-table3": "0.6.0",
+            "comment-json": "4.1.0",
+            "dataobject-parser": "1.2.1",
+            "deepmerge": "4.2.2",
+            "fast-glob": "3.2.7",
+            "fastest-levenshtein": "1.0.12",
+            "find-up": "4.1.0",
+            "fs-extra": "8.1.0",
+            "glob": "7.1.6",
+            "jest-diff": "27.0.6",
+            "js-yaml": "3.14.1",
+            "jsonfile": "4.0.0",
+            "jsonschema": "1.1.1",
+            "lodash": "4.17.21",
+            "lodash-deep": "2.0.0",
+            "log4js": "6.3.0",
+            "markdown-it": "12.0.4",
+            "moment": "2.20.1",
+            "mustache": "2.3.0",
+            "npm-package-arg": "8.1.1",
+            "open": "8.2.1",
+            "opener": "1.5.2",
+            "pacote": "11.1.4",
+            "prettyjson": "1.2.1",
+            "progress": "2.0.3",
+            "read": "1.0.7",
+            "readline-sync": "1.4.10",
+            "rimraf": "2.6.3",
+            "sanitize-html": "2.3.2",
+            "semver": "5.7.0",
+            "stack-trace": "0.0.10",
+            "strip-ansi": "6.0.1",
+            "wrap-ansi": "7.0.0",
+            "yamljs": "0.3.0",
+            "yargs": "15.3.1"
+          },
+          "dependencies": {
+            "chalk": {
+              "version": "2.4.2",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+              "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+              "dev": true,
+              "requires": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+              }
+            }
+          }
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "color-convert": {
+          "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+          "dev": true,
+          "requires": {
+            "color-name": "1.1.3"
+          }
+        },
+        "color-name": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+          "dev": true
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+          "dev": true
+        },
+        "glob": {
+          "version": "7.1.6",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "rimraf": {
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+          "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "semver": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
       }
     },
     "@zowe/imperative": {
-      "version": "5.0.0-next.202112101814",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-local-release/@zowe/imperative/-/@zowe/imperative-5.0.0-next.202112101814.tgz",
-      "integrity": "sha1-thpGvXuiYGpDdjgSyHSFD8bhaRA=",
+      "version": "5.0.0-next.202112132158",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-local-release/@zowe/imperative/-/@zowe/imperative-5.0.0-next.202112132158.tgz",
+      "integrity": "sha1-5XOJHTUWKTMrwv/J2h3wA+cSkXk=",
       "requires": {
         "@types/lodash-deep": "2.0.0",
         "@types/yargs": "13.0.4",
@@ -30820,8 +33220,8 @@
       "requires": {
         "@types/js-yaml": "^3.12.5",
         "@types/node": "^12.12.24",
-        "@zowe/cli-test-utils": "7.0.0-next.202112081943",
-        "@zowe/core-for-zowe-sdk": "7.0.0-next.202112081943",
+        "@zowe/cli-test-utils": "7.0.0-next.202112102143",
+        "@zowe/core-for-zowe-sdk": "7.0.0-next.202112102143",
         "@zowe/imperative": "5.0.0-next.202112101814",
         "eslint": "^7.32.0",
         "js-yaml": "3.14.1",
@@ -30836,6 +33236,138 @@
           "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@types/js-yaml/-/js-yaml-3.12.7.tgz",
           "integrity": "sha1-Mwxdl6NQDpyQMhDW5J8ClkrwSg4=",
           "dev": true
+        },
+        "@zowe/imperative": {
+          "version": "5.0.0-next.202112101814",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-local-release/@zowe/imperative/-/@zowe/imperative-5.0.0-next.202112101814.tgz",
+          "integrity": "sha1-thpGvXuiYGpDdjgSyHSFD8bhaRA=",
+          "dev": true,
+          "requires": {
+            "@types/lodash-deep": "2.0.0",
+            "@types/yargs": "13.0.4",
+            "@zowe/perf-timing": "1.0.7",
+            "chalk": "2.4.2",
+            "cli-table3": "0.6.0",
+            "comment-json": "4.1.0",
+            "dataobject-parser": "1.2.1",
+            "deepmerge": "4.2.2",
+            "fast-glob": "3.2.7",
+            "fastest-levenshtein": "1.0.12",
+            "find-up": "4.1.0",
+            "fs-extra": "8.1.0",
+            "glob": "7.1.6",
+            "jest-diff": "27.0.6",
+            "js-yaml": "3.14.1",
+            "jsonfile": "4.0.0",
+            "jsonschema": "1.1.1",
+            "lodash": "4.17.21",
+            "lodash-deep": "2.0.0",
+            "log4js": "6.3.0",
+            "markdown-it": "12.0.4",
+            "moment": "2.20.1",
+            "mustache": "2.3.0",
+            "npm-package-arg": "8.1.1",
+            "open": "8.2.1",
+            "opener": "1.5.2",
+            "pacote": "11.1.4",
+            "prettyjson": "1.2.1",
+            "progress": "2.0.3",
+            "read": "1.0.7",
+            "readline-sync": "1.4.10",
+            "rimraf": "2.6.3",
+            "sanitize-html": "2.3.2",
+            "semver": "5.7.0",
+            "stack-trace": "0.0.10",
+            "strip-ansi": "6.0.1",
+            "wrap-ansi": "7.0.0",
+            "yamljs": "0.3.0",
+            "yargs": "15.3.1"
+          }
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "color-convert": {
+          "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+          "dev": true,
+          "requires": {
+            "color-name": "1.1.3"
+          }
+        },
+        "color-name": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+          "dev": true
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+          "dev": true
+        },
+        "glob": {
+          "version": "7.1.6",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "rimraf": {
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+          "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "semver": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
         }
       }
     },
@@ -30843,74 +33375,744 @@
       "version": "file:packages/zosconsole",
       "requires": {
         "@types/node": "^12.12.24",
-        "@zowe/cli-test-utils": "7.0.0-next.202112081943",
-        "@zowe/core-for-zowe-sdk": "7.0.0-next.202112081943",
+        "@zowe/cli-test-utils": "7.0.0-next.202112102143",
+        "@zowe/core-for-zowe-sdk": "7.0.0-next.202112102143",
         "@zowe/imperative": "5.0.0-next.202112101814",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
         "rimraf": "^2.6.3",
         "typedoc": "^0.16.0",
         "typescript": "^3.8.0"
+      },
+      "dependencies": {
+        "@zowe/imperative": {
+          "version": "5.0.0-next.202112101814",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-local-release/@zowe/imperative/-/@zowe/imperative-5.0.0-next.202112101814.tgz",
+          "integrity": "sha1-thpGvXuiYGpDdjgSyHSFD8bhaRA=",
+          "dev": true,
+          "requires": {
+            "@types/lodash-deep": "2.0.0",
+            "@types/yargs": "13.0.4",
+            "@zowe/perf-timing": "1.0.7",
+            "chalk": "2.4.2",
+            "cli-table3": "0.6.0",
+            "comment-json": "4.1.0",
+            "dataobject-parser": "1.2.1",
+            "deepmerge": "4.2.2",
+            "fast-glob": "3.2.7",
+            "fastest-levenshtein": "1.0.12",
+            "find-up": "4.1.0",
+            "fs-extra": "8.1.0",
+            "glob": "7.1.6",
+            "jest-diff": "27.0.6",
+            "js-yaml": "3.14.1",
+            "jsonfile": "4.0.0",
+            "jsonschema": "1.1.1",
+            "lodash": "4.17.21",
+            "lodash-deep": "2.0.0",
+            "log4js": "6.3.0",
+            "markdown-it": "12.0.4",
+            "moment": "2.20.1",
+            "mustache": "2.3.0",
+            "npm-package-arg": "8.1.1",
+            "open": "8.2.1",
+            "opener": "1.5.2",
+            "pacote": "11.1.4",
+            "prettyjson": "1.2.1",
+            "progress": "2.0.3",
+            "read": "1.0.7",
+            "readline-sync": "1.4.10",
+            "rimraf": "2.6.3",
+            "sanitize-html": "2.3.2",
+            "semver": "5.7.0",
+            "stack-trace": "0.0.10",
+            "strip-ansi": "6.0.1",
+            "wrap-ansi": "7.0.0",
+            "yamljs": "0.3.0",
+            "yargs": "15.3.1"
+          }
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "color-convert": {
+          "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+          "dev": true,
+          "requires": {
+            "color-name": "1.1.3"
+          }
+        },
+        "color-name": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+          "dev": true
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+          "dev": true
+        },
+        "glob": {
+          "version": "7.1.6",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "rimraf": {
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+          "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "semver": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
       }
     },
     "@zowe/zos-files-for-zowe-sdk": {
       "version": "file:packages/zosfiles",
       "requires": {
         "@types/node": "^12.12.24",
-        "@zowe/cli-test-utils": "7.0.0-next.202112081943",
-        "@zowe/core-for-zowe-sdk": "7.0.0-next.202112081943",
+        "@zowe/cli-test-utils": "7.0.0-next.202112102143",
+        "@zowe/core-for-zowe-sdk": "7.0.0-next.202112102143",
         "@zowe/imperative": "5.0.0-next.202112101814",
-        "@zowe/zos-uss-for-zowe-sdk": "7.0.0-next.202112081943",
+        "@zowe/zos-uss-for-zowe-sdk": "7.0.0-next.202112102143",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
         "minimatch": "3.0.4",
         "rimraf": "^2.6.3",
         "typedoc": "^0.16.0",
         "typescript": "^3.8.0"
+      },
+      "dependencies": {
+        "@zowe/imperative": {
+          "version": "5.0.0-next.202112101814",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-local-release/@zowe/imperative/-/@zowe/imperative-5.0.0-next.202112101814.tgz",
+          "integrity": "sha1-thpGvXuiYGpDdjgSyHSFD8bhaRA=",
+          "dev": true,
+          "requires": {
+            "@types/lodash-deep": "2.0.0",
+            "@types/yargs": "13.0.4",
+            "@zowe/perf-timing": "1.0.7",
+            "chalk": "2.4.2",
+            "cli-table3": "0.6.0",
+            "comment-json": "4.1.0",
+            "dataobject-parser": "1.2.1",
+            "deepmerge": "4.2.2",
+            "fast-glob": "3.2.7",
+            "fastest-levenshtein": "1.0.12",
+            "find-up": "4.1.0",
+            "fs-extra": "8.1.0",
+            "glob": "7.1.6",
+            "jest-diff": "27.0.6",
+            "js-yaml": "3.14.1",
+            "jsonfile": "4.0.0",
+            "jsonschema": "1.1.1",
+            "lodash": "4.17.21",
+            "lodash-deep": "2.0.0",
+            "log4js": "6.3.0",
+            "markdown-it": "12.0.4",
+            "moment": "2.20.1",
+            "mustache": "2.3.0",
+            "npm-package-arg": "8.1.1",
+            "open": "8.2.1",
+            "opener": "1.5.2",
+            "pacote": "11.1.4",
+            "prettyjson": "1.2.1",
+            "progress": "2.0.3",
+            "read": "1.0.7",
+            "readline-sync": "1.4.10",
+            "rimraf": "2.6.3",
+            "sanitize-html": "2.3.2",
+            "semver": "5.7.0",
+            "stack-trace": "0.0.10",
+            "strip-ansi": "6.0.1",
+            "wrap-ansi": "7.0.0",
+            "yamljs": "0.3.0",
+            "yargs": "15.3.1"
+          }
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "color-convert": {
+          "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+          "dev": true,
+          "requires": {
+            "color-name": "1.1.3"
+          }
+        },
+        "color-name": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+          "dev": true
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+          "dev": true
+        },
+        "glob": {
+          "version": "7.1.6",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "rimraf": {
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+          "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "semver": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
       }
     },
     "@zowe/zos-jobs-for-zowe-sdk": {
       "version": "file:packages/zosjobs",
       "requires": {
         "@types/node": "^12.12.24",
-        "@zowe/cli-test-utils": "7.0.0-next.202112081943",
-        "@zowe/core-for-zowe-sdk": "7.0.0-next.202112081943",
+        "@zowe/cli-test-utils": "7.0.0-next.202112102143",
+        "@zowe/core-for-zowe-sdk": "7.0.0-next.202112102143",
         "@zowe/imperative": "5.0.0-next.202112101814",
-        "@zowe/zos-files-for-zowe-sdk": "7.0.0-next.202112081943",
+        "@zowe/zos-files-for-zowe-sdk": "7.0.0-next.202112102143",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
         "rimraf": "^2.6.3",
         "typedoc": "^0.16.0",
         "typescript": "^3.8.0"
+      },
+      "dependencies": {
+        "@zowe/imperative": {
+          "version": "5.0.0-next.202112101814",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-local-release/@zowe/imperative/-/@zowe/imperative-5.0.0-next.202112101814.tgz",
+          "integrity": "sha1-thpGvXuiYGpDdjgSyHSFD8bhaRA=",
+          "dev": true,
+          "requires": {
+            "@types/lodash-deep": "2.0.0",
+            "@types/yargs": "13.0.4",
+            "@zowe/perf-timing": "1.0.7",
+            "chalk": "2.4.2",
+            "cli-table3": "0.6.0",
+            "comment-json": "4.1.0",
+            "dataobject-parser": "1.2.1",
+            "deepmerge": "4.2.2",
+            "fast-glob": "3.2.7",
+            "fastest-levenshtein": "1.0.12",
+            "find-up": "4.1.0",
+            "fs-extra": "8.1.0",
+            "glob": "7.1.6",
+            "jest-diff": "27.0.6",
+            "js-yaml": "3.14.1",
+            "jsonfile": "4.0.0",
+            "jsonschema": "1.1.1",
+            "lodash": "4.17.21",
+            "lodash-deep": "2.0.0",
+            "log4js": "6.3.0",
+            "markdown-it": "12.0.4",
+            "moment": "2.20.1",
+            "mustache": "2.3.0",
+            "npm-package-arg": "8.1.1",
+            "open": "8.2.1",
+            "opener": "1.5.2",
+            "pacote": "11.1.4",
+            "prettyjson": "1.2.1",
+            "progress": "2.0.3",
+            "read": "1.0.7",
+            "readline-sync": "1.4.10",
+            "rimraf": "2.6.3",
+            "sanitize-html": "2.3.2",
+            "semver": "5.7.0",
+            "stack-trace": "0.0.10",
+            "strip-ansi": "6.0.1",
+            "wrap-ansi": "7.0.0",
+            "yamljs": "0.3.0",
+            "yargs": "15.3.1"
+          }
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "color-convert": {
+          "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+          "dev": true,
+          "requires": {
+            "color-name": "1.1.3"
+          }
+        },
+        "color-name": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+          "dev": true
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+          "dev": true
+        },
+        "glob": {
+          "version": "7.1.6",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "rimraf": {
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+          "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "semver": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
       }
     },
     "@zowe/zos-logs-for-zowe-sdk": {
       "version": "file:packages/zoslogs",
       "requires": {
         "@types/node": "^12.12.24",
-        "@zowe/cli-test-utils": "7.0.0-next.202112081943",
-        "@zowe/core-for-zowe-sdk": "7.0.0-next.202112081943",
+        "@zowe/cli-test-utils": "7.0.0-next.202112102143",
+        "@zowe/core-for-zowe-sdk": "7.0.0-next.202112102143",
         "@zowe/imperative": "5.0.0-next.202112101814",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
         "rimraf": "^2.6.3",
         "typedoc": "^0.16.0",
         "typescript": "^3.8.0"
+      },
+      "dependencies": {
+        "@zowe/imperative": {
+          "version": "5.0.0-next.202112101814",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-local-release/@zowe/imperative/-/@zowe/imperative-5.0.0-next.202112101814.tgz",
+          "integrity": "sha1-thpGvXuiYGpDdjgSyHSFD8bhaRA=",
+          "dev": true,
+          "requires": {
+            "@types/lodash-deep": "2.0.0",
+            "@types/yargs": "13.0.4",
+            "@zowe/perf-timing": "1.0.7",
+            "chalk": "2.4.2",
+            "cli-table3": "0.6.0",
+            "comment-json": "4.1.0",
+            "dataobject-parser": "1.2.1",
+            "deepmerge": "4.2.2",
+            "fast-glob": "3.2.7",
+            "fastest-levenshtein": "1.0.12",
+            "find-up": "4.1.0",
+            "fs-extra": "8.1.0",
+            "glob": "7.1.6",
+            "jest-diff": "27.0.6",
+            "js-yaml": "3.14.1",
+            "jsonfile": "4.0.0",
+            "jsonschema": "1.1.1",
+            "lodash": "4.17.21",
+            "lodash-deep": "2.0.0",
+            "log4js": "6.3.0",
+            "markdown-it": "12.0.4",
+            "moment": "2.20.1",
+            "mustache": "2.3.0",
+            "npm-package-arg": "8.1.1",
+            "open": "8.2.1",
+            "opener": "1.5.2",
+            "pacote": "11.1.4",
+            "prettyjson": "1.2.1",
+            "progress": "2.0.3",
+            "read": "1.0.7",
+            "readline-sync": "1.4.10",
+            "rimraf": "2.6.3",
+            "sanitize-html": "2.3.2",
+            "semver": "5.7.0",
+            "stack-trace": "0.0.10",
+            "strip-ansi": "6.0.1",
+            "wrap-ansi": "7.0.0",
+            "yamljs": "0.3.0",
+            "yargs": "15.3.1"
+          }
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "color-convert": {
+          "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+          "dev": true,
+          "requires": {
+            "color-name": "1.1.3"
+          }
+        },
+        "color-name": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+          "dev": true
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+          "dev": true
+        },
+        "glob": {
+          "version": "7.1.6",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "rimraf": {
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+          "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "semver": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
       }
     },
     "@zowe/zos-tso-for-zowe-sdk": {
       "version": "file:packages/zostso",
       "requires": {
         "@types/node": "^12.12.24",
-        "@zowe/cli-test-utils": "7.0.0-next.202112081943",
-        "@zowe/core-for-zowe-sdk": "7.0.0-next.202112081943",
+        "@zowe/cli-test-utils": "7.0.0-next.202112102143",
+        "@zowe/core-for-zowe-sdk": "7.0.0-next.202112102143",
         "@zowe/imperative": "5.0.0-next.202112101814",
-        "@zowe/zosmf-for-zowe-sdk": "7.0.0-next.202112081943",
+        "@zowe/zosmf-for-zowe-sdk": "7.0.0-next.202112102143",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
         "rimraf": "^2.6.3",
         "typedoc": "^0.16.0",
         "typescript": "^3.8.0"
+      },
+      "dependencies": {
+        "@zowe/imperative": {
+          "version": "5.0.0-next.202112101814",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-local-release/@zowe/imperative/-/@zowe/imperative-5.0.0-next.202112101814.tgz",
+          "integrity": "sha1-thpGvXuiYGpDdjgSyHSFD8bhaRA=",
+          "dev": true,
+          "requires": {
+            "@types/lodash-deep": "2.0.0",
+            "@types/yargs": "13.0.4",
+            "@zowe/perf-timing": "1.0.7",
+            "chalk": "2.4.2",
+            "cli-table3": "0.6.0",
+            "comment-json": "4.1.0",
+            "dataobject-parser": "1.2.1",
+            "deepmerge": "4.2.2",
+            "fast-glob": "3.2.7",
+            "fastest-levenshtein": "1.0.12",
+            "find-up": "4.1.0",
+            "fs-extra": "8.1.0",
+            "glob": "7.1.6",
+            "jest-diff": "27.0.6",
+            "js-yaml": "3.14.1",
+            "jsonfile": "4.0.0",
+            "jsonschema": "1.1.1",
+            "lodash": "4.17.21",
+            "lodash-deep": "2.0.0",
+            "log4js": "6.3.0",
+            "markdown-it": "12.0.4",
+            "moment": "2.20.1",
+            "mustache": "2.3.0",
+            "npm-package-arg": "8.1.1",
+            "open": "8.2.1",
+            "opener": "1.5.2",
+            "pacote": "11.1.4",
+            "prettyjson": "1.2.1",
+            "progress": "2.0.3",
+            "read": "1.0.7",
+            "readline-sync": "1.4.10",
+            "rimraf": "2.6.3",
+            "sanitize-html": "2.3.2",
+            "semver": "5.7.0",
+            "stack-trace": "0.0.10",
+            "strip-ansi": "6.0.1",
+            "wrap-ansi": "7.0.0",
+            "yamljs": "0.3.0",
+            "yargs": "15.3.1"
+          }
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "color-convert": {
+          "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+          "dev": true,
+          "requires": {
+            "color-name": "1.1.3"
+          }
+        },
+        "color-name": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+          "dev": true
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+          "dev": true
+        },
+        "glob": {
+          "version": "7.1.6",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "rimraf": {
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+          "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "semver": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
       }
     },
     "@zowe/zos-uss-for-zowe-sdk": {
@@ -30918,7 +34120,7 @@
       "requires": {
         "@types/node": "^12.12.24",
         "@types/ssh2": "^0.5.44",
-        "@zowe/cli-test-utils": "7.0.0-next.202112081943",
+        "@zowe/cli-test-utils": "7.0.0-next.202112102143",
         "@zowe/imperative": "5.0.0-next.202112101814",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
@@ -30926,35 +34128,437 @@
         "ssh2": "1.4.0",
         "typedoc": "^0.16.0",
         "typescript": "^3.8.0"
+      },
+      "dependencies": {
+        "@zowe/imperative": {
+          "version": "5.0.0-next.202112101814",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-local-release/@zowe/imperative/-/@zowe/imperative-5.0.0-next.202112101814.tgz",
+          "integrity": "sha1-thpGvXuiYGpDdjgSyHSFD8bhaRA=",
+          "dev": true,
+          "requires": {
+            "@types/lodash-deep": "2.0.0",
+            "@types/yargs": "13.0.4",
+            "@zowe/perf-timing": "1.0.7",
+            "chalk": "2.4.2",
+            "cli-table3": "0.6.0",
+            "comment-json": "4.1.0",
+            "dataobject-parser": "1.2.1",
+            "deepmerge": "4.2.2",
+            "fast-glob": "3.2.7",
+            "fastest-levenshtein": "1.0.12",
+            "find-up": "4.1.0",
+            "fs-extra": "8.1.0",
+            "glob": "7.1.6",
+            "jest-diff": "27.0.6",
+            "js-yaml": "3.14.1",
+            "jsonfile": "4.0.0",
+            "jsonschema": "1.1.1",
+            "lodash": "4.17.21",
+            "lodash-deep": "2.0.0",
+            "log4js": "6.3.0",
+            "markdown-it": "12.0.4",
+            "moment": "2.20.1",
+            "mustache": "2.3.0",
+            "npm-package-arg": "8.1.1",
+            "open": "8.2.1",
+            "opener": "1.5.2",
+            "pacote": "11.1.4",
+            "prettyjson": "1.2.1",
+            "progress": "2.0.3",
+            "read": "1.0.7",
+            "readline-sync": "1.4.10",
+            "rimraf": "2.6.3",
+            "sanitize-html": "2.3.2",
+            "semver": "5.7.0",
+            "stack-trace": "0.0.10",
+            "strip-ansi": "6.0.1",
+            "wrap-ansi": "7.0.0",
+            "yamljs": "0.3.0",
+            "yargs": "15.3.1"
+          }
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "color-convert": {
+          "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+          "dev": true,
+          "requires": {
+            "color-name": "1.1.3"
+          }
+        },
+        "color-name": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+          "dev": true
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+          "dev": true
+        },
+        "glob": {
+          "version": "7.1.6",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "rimraf": {
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+          "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "semver": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
       }
     },
     "@zowe/zos-workflows-for-zowe-sdk": {
       "version": "file:packages/workflows",
       "requires": {
         "@types/node": "^12.12.24",
-        "@zowe/cli-test-utils": "7.0.0-next.202112081943",
-        "@zowe/core-for-zowe-sdk": "7.0.0-next.202112081943",
+        "@zowe/cli-test-utils": "7.0.0-next.202112102143",
+        "@zowe/core-for-zowe-sdk": "7.0.0-next.202112102143",
         "@zowe/imperative": "5.0.0-next.202112101814",
-        "@zowe/zos-files-for-zowe-sdk": "7.0.0-next.202112081943",
+        "@zowe/zos-files-for-zowe-sdk": "7.0.0-next.202112102143",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
         "rimraf": "^2.6.3",
         "typedoc": "^0.16.0",
         "typescript": "^3.8.0"
+      },
+      "dependencies": {
+        "@zowe/imperative": {
+          "version": "5.0.0-next.202112101814",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-local-release/@zowe/imperative/-/@zowe/imperative-5.0.0-next.202112101814.tgz",
+          "integrity": "sha1-thpGvXuiYGpDdjgSyHSFD8bhaRA=",
+          "dev": true,
+          "requires": {
+            "@types/lodash-deep": "2.0.0",
+            "@types/yargs": "13.0.4",
+            "@zowe/perf-timing": "1.0.7",
+            "chalk": "2.4.2",
+            "cli-table3": "0.6.0",
+            "comment-json": "4.1.0",
+            "dataobject-parser": "1.2.1",
+            "deepmerge": "4.2.2",
+            "fast-glob": "3.2.7",
+            "fastest-levenshtein": "1.0.12",
+            "find-up": "4.1.0",
+            "fs-extra": "8.1.0",
+            "glob": "7.1.6",
+            "jest-diff": "27.0.6",
+            "js-yaml": "3.14.1",
+            "jsonfile": "4.0.0",
+            "jsonschema": "1.1.1",
+            "lodash": "4.17.21",
+            "lodash-deep": "2.0.0",
+            "log4js": "6.3.0",
+            "markdown-it": "12.0.4",
+            "moment": "2.20.1",
+            "mustache": "2.3.0",
+            "npm-package-arg": "8.1.1",
+            "open": "8.2.1",
+            "opener": "1.5.2",
+            "pacote": "11.1.4",
+            "prettyjson": "1.2.1",
+            "progress": "2.0.3",
+            "read": "1.0.7",
+            "readline-sync": "1.4.10",
+            "rimraf": "2.6.3",
+            "sanitize-html": "2.3.2",
+            "semver": "5.7.0",
+            "stack-trace": "0.0.10",
+            "strip-ansi": "6.0.1",
+            "wrap-ansi": "7.0.0",
+            "yamljs": "0.3.0",
+            "yargs": "15.3.1"
+          }
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "color-convert": {
+          "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+          "dev": true,
+          "requires": {
+            "color-name": "1.1.3"
+          }
+        },
+        "color-name": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+          "dev": true
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+          "dev": true
+        },
+        "glob": {
+          "version": "7.1.6",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "rimraf": {
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+          "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "semver": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
       }
     },
     "@zowe/zosmf-for-zowe-sdk": {
       "version": "file:packages/zosmf",
       "requires": {
         "@types/node": "^12.12.24",
-        "@zowe/cli-test-utils": "7.0.0-next.202112081943",
-        "@zowe/core-for-zowe-sdk": "7.0.0-next.202112081943",
+        "@zowe/cli-test-utils": "7.0.0-next.202112102143",
+        "@zowe/core-for-zowe-sdk": "7.0.0-next.202112102143",
         "@zowe/imperative": "5.0.0-next.202112101814",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
         "rimraf": "^2.6.3",
         "typedoc": "^0.16.0",
         "typescript": "^3.8.0"
+      },
+      "dependencies": {
+        "@zowe/imperative": {
+          "version": "5.0.0-next.202112101814",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-local-release/@zowe/imperative/-/@zowe/imperative-5.0.0-next.202112101814.tgz",
+          "integrity": "sha1-thpGvXuiYGpDdjgSyHSFD8bhaRA=",
+          "dev": true,
+          "requires": {
+            "@types/lodash-deep": "2.0.0",
+            "@types/yargs": "13.0.4",
+            "@zowe/perf-timing": "1.0.7",
+            "chalk": "2.4.2",
+            "cli-table3": "0.6.0",
+            "comment-json": "4.1.0",
+            "dataobject-parser": "1.2.1",
+            "deepmerge": "4.2.2",
+            "fast-glob": "3.2.7",
+            "fastest-levenshtein": "1.0.12",
+            "find-up": "4.1.0",
+            "fs-extra": "8.1.0",
+            "glob": "7.1.6",
+            "jest-diff": "27.0.6",
+            "js-yaml": "3.14.1",
+            "jsonfile": "4.0.0",
+            "jsonschema": "1.1.1",
+            "lodash": "4.17.21",
+            "lodash-deep": "2.0.0",
+            "log4js": "6.3.0",
+            "markdown-it": "12.0.4",
+            "moment": "2.20.1",
+            "mustache": "2.3.0",
+            "npm-package-arg": "8.1.1",
+            "open": "8.2.1",
+            "opener": "1.5.2",
+            "pacote": "11.1.4",
+            "prettyjson": "1.2.1",
+            "progress": "2.0.3",
+            "read": "1.0.7",
+            "readline-sync": "1.4.10",
+            "rimraf": "2.6.3",
+            "sanitize-html": "2.3.2",
+            "semver": "5.7.0",
+            "stack-trace": "0.0.10",
+            "strip-ansi": "6.0.1",
+            "wrap-ansi": "7.0.0",
+            "yamljs": "0.3.0",
+            "yargs": "15.3.1"
+          }
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "color-convert": {
+          "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+          "dev": true,
+          "requires": {
+            "color-name": "1.1.3"
+          }
+        },
+        "color-name": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+          "dev": true
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+          "dev": true
+        },
+        "glob": {
+          "version": "7.1.6",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "rimraf": {
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+          "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "semver": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
       }
     },
     "abab": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "prepare": "husky install"
   },
   "dependencies": {
-    "@zowe/imperative": "5.0.0-next.202112101814",
+    "@zowe/imperative": "5.0.0-next.202112132158",
     "@zowe/perf-timing": "1.0.7"
   },
   "devDependencies": {

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Zowe CLI package will be documented in this file.
 
+## Recent Changes
+
+- Enhancement: Upgrade Imperative so that secure prompts do not show input and zowe.config.json secure properties are not be logged. [#1106](https://github.com/zowe/zowe-cli/issues/1106)
+
 ## `7.0.0-next.202112081943`
 
 - **Next Breaking**: Remove hardcoded `--dcd` argument sent between imperative daemon server and client.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -56,7 +56,7 @@
   },
   "dependencies": {
     "@zowe/core-for-zowe-sdk": "7.0.0-next.202112102143",
-    "@zowe/imperative": "5.0.0-next.202112101814",
+    "@zowe/imperative": "5.0.0-next.202112132158",
     "@zowe/perf-timing": "1.0.7",
     "@zowe/provisioning-for-zowe-sdk": "7.0.0-next.202112102143",
     "@zowe/zos-console-for-zowe-sdk": "7.0.0-next.202112102143",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -50,7 +50,7 @@
   "devDependencies": {
     "@types/node": "^12.12.24",
     "@zowe/cli-test-utils": "7.0.0-next.202112102143",
-    "@zowe/imperative": "5.0.0-next.202112101814",
+    "@zowe/imperative": "5.0.0-next.202112132158",
     "chalk": "^4.1.0",
     "eslint": "^7.32.0",
     "madge": "^4.0.1",

--- a/packages/provisioning/package.json
+++ b/packages/provisioning/package.json
@@ -51,7 +51,7 @@
     "@types/node": "^12.12.24",
     "@zowe/cli-test-utils": "7.0.0-next.202112102143",
     "@zowe/core-for-zowe-sdk": "7.0.0-next.202112102143",
-    "@zowe/imperative": "5.0.0-next.202112101814",
+    "@zowe/imperative": "5.0.0-next.202112132158",
     "eslint": "^7.32.0",
     "madge": "^4.0.1",
     "rimraf": "^2.6.3",

--- a/packages/workflows/package.json
+++ b/packages/workflows/package.json
@@ -50,7 +50,7 @@
     "@types/node": "^12.12.24",
     "@zowe/cli-test-utils": "7.0.0-next.202112102143",
     "@zowe/core-for-zowe-sdk": "7.0.0-next.202112102143",
-    "@zowe/imperative": "5.0.0-next.202112101814",
+    "@zowe/imperative": "5.0.0-next.202112132158",
     "eslint": "^7.32.0",
     "madge": "^4.0.1",
     "rimraf": "^2.6.3",

--- a/packages/zosconsole/package.json
+++ b/packages/zosconsole/package.json
@@ -47,7 +47,7 @@
     "@types/node": "^12.12.24",
     "@zowe/cli-test-utils": "7.0.0-next.202112102143",
     "@zowe/core-for-zowe-sdk": "7.0.0-next.202112102143",
-    "@zowe/imperative": "5.0.0-next.202112101814",
+    "@zowe/imperative": "5.0.0-next.202112132158",
     "eslint": "^7.32.0",
     "madge": "^4.0.1",
     "rimraf": "^2.6.3",

--- a/packages/zosfiles/package.json
+++ b/packages/zosfiles/package.json
@@ -51,7 +51,7 @@
     "@types/node": "^12.12.24",
     "@zowe/cli-test-utils": "7.0.0-next.202112102143",
     "@zowe/core-for-zowe-sdk": "7.0.0-next.202112102143",
-    "@zowe/imperative": "5.0.0-next.202112101814",
+    "@zowe/imperative": "5.0.0-next.202112132158",
     "@zowe/zos-uss-for-zowe-sdk": "7.0.0-next.202112102143",
     "eslint": "^7.32.0",
     "madge": "^4.0.1",

--- a/packages/zosjobs/package.json
+++ b/packages/zosjobs/package.json
@@ -51,7 +51,7 @@
     "@types/node": "^12.12.24",
     "@zowe/cli-test-utils": "7.0.0-next.202112102143",
     "@zowe/core-for-zowe-sdk": "7.0.0-next.202112102143",
-    "@zowe/imperative": "5.0.0-next.202112101814",
+    "@zowe/imperative": "5.0.0-next.202112132158",
     "eslint": "^7.32.0",
     "madge": "^4.0.1",
     "rimraf": "^2.6.3",

--- a/packages/zoslogs/package.json
+++ b/packages/zoslogs/package.json
@@ -47,7 +47,7 @@
     "@types/node": "^12.12.24",
     "@zowe/cli-test-utils": "7.0.0-next.202112102143",
     "@zowe/core-for-zowe-sdk": "7.0.0-next.202112102143",
-    "@zowe/imperative": "5.0.0-next.202112101814",
+    "@zowe/imperative": "5.0.0-next.202112132158",
     "eslint": "^7.32.0",
     "madge": "^4.0.1",
     "rimraf": "^2.6.3",

--- a/packages/zosmf/package.json
+++ b/packages/zosmf/package.json
@@ -46,7 +46,7 @@
     "@types/node": "^12.12.24",
     "@zowe/cli-test-utils": "7.0.0-next.202112102143",
     "@zowe/core-for-zowe-sdk": "7.0.0-next.202112102143",
-    "@zowe/imperative": "5.0.0-next.202112101814",
+    "@zowe/imperative": "5.0.0-next.202112132158",
     "eslint": "^7.32.0",
     "madge": "^4.0.1",
     "rimraf": "^2.6.3",

--- a/packages/zostso/package.json
+++ b/packages/zostso/package.json
@@ -50,7 +50,7 @@
     "@types/node": "^12.12.24",
     "@zowe/cli-test-utils": "7.0.0-next.202112102143",
     "@zowe/core-for-zowe-sdk": "7.0.0-next.202112102143",
-    "@zowe/imperative": "5.0.0-next.202112101814",
+    "@zowe/imperative": "5.0.0-next.202112132158",
     "eslint": "^7.32.0",
     "madge": "^4.0.1",
     "rimraf": "^2.6.3",

--- a/packages/zosuss/package.json
+++ b/packages/zosuss/package.json
@@ -50,7 +50,7 @@
     "@types/node": "^12.12.24",
     "@types/ssh2": "^0.5.44",
     "@zowe/cli-test-utils": "7.0.0-next.202112102143",
-    "@zowe/imperative": "5.0.0-next.202112101814",
+    "@zowe/imperative": "5.0.0-next.202112132158",
     "eslint": "^7.32.0",
     "madge": "^4.0.1",
     "rimraf": "^2.6.3",


### PR DESCRIPTION
Upgrade Imperative so that secure prompts do not show input and zowe.config.json secure properties are not be logged.