### PR TITLE
Disable gzip compression for binary requests

### DIFF
--- a/.github/workflows/zowe-cli.yml
+++ b/.github/workflows/zowe-cli.yml
@@ -36,6 +36,12 @@ jobs:
       NODE: ${{ matrix.node-version }}
       NODE_OPTIONS: --max_old_space_size=4096
 
+    timeout-minutes: 60
+
+    concurrency:
+      group: ${{ matrix.os }}-node-${{ matrix.node-version }}-ci-${{ github.ref }}
+      cancel-in-progress: true
+
     if: (github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository) && !contains(github.event.head_commit.message, '[ci skip]')
 
     steps:

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
         "packages/*"
       ],
       "dependencies": {
-        "@zowe/imperative": "4.17.2",
+        "@zowe/imperative": "4.17.3",
         "@zowe/perf-timing": "1.0.7"
       },
       "devDependencies": {
@@ -4849,9 +4849,9 @@
       "link": true
     },
     "node_modules/@zowe/imperative": {
-      "version": "4.17.2",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@zowe/imperative/-/@zowe/imperative-4.17.2.tgz",
-      "integrity": "sha1-6anmRgU3E6KShhplXuaTG7MLDNE=",
+      "version": "4.17.3",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@zowe/imperative/-/@zowe/imperative-4.17.3.tgz",
+      "integrity": "sha1-rn+CtQFCuZ6wQFSdXpfCqQrlOlc=",
       "license": "EPL-2.0",
       "dependencies": {
         "@types/lodash-deep": "2.0.0",
@@ -24153,7 +24153,7 @@
       "license": "EPL-2.0",
       "dependencies": {
         "@zowe/core-for-zowe-sdk": "6.37.1",
-        "@zowe/imperative": "4.17.2",
+        "@zowe/imperative": "4.17.3",
         "@zowe/perf-timing": "1.0.7",
         "@zowe/provisioning-for-zowe-sdk": "6.37.1",
         "@zowe/zos-console-for-zowe-sdk": "6.37.1",
@@ -24201,7 +24201,7 @@
       },
       "devDependencies": {
         "@types/node": "^12.12.24",
-        "@zowe/imperative": "4.17.2",
+        "@zowe/imperative": "4.17.3",
         "chalk": "^4.1.0",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
@@ -24250,7 +24250,7 @@
         "@types/js-yaml": "^3.12.5",
         "@types/node": "^12.12.24",
         "@zowe/core-for-zowe-sdk": "6.37.1",
-        "@zowe/imperative": "4.17.2",
+        "@zowe/imperative": "4.17.3",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
         "rimraf": "^2.6.3",
@@ -24272,7 +24272,7 @@
       "devDependencies": {
         "@types/node": "^12.12.24",
         "@zowe/core-for-zowe-sdk": "6.37.1",
-        "@zowe/imperative": "4.17.2",
+        "@zowe/imperative": "4.17.3",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
         "rimraf": "^2.6.3",
@@ -24291,7 +24291,7 @@
       "devDependencies": {
         "@types/node": "^12.12.24",
         "@zowe/core-for-zowe-sdk": "6.37.1",
-        "@zowe/imperative": "4.17.2",
+        "@zowe/imperative": "4.17.3",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
         "rimraf": "^2.6.3",
@@ -24313,7 +24313,7 @@
       "devDependencies": {
         "@types/node": "^12.12.24",
         "@zowe/core-for-zowe-sdk": "6.37.1",
-        "@zowe/imperative": "4.17.2",
+        "@zowe/imperative": "4.17.3",
         "@zowe/zos-uss-for-zowe-sdk": "6.37.1",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
@@ -24336,7 +24336,7 @@
       "devDependencies": {
         "@types/node": "^12.12.24",
         "@zowe/core-for-zowe-sdk": "6.37.1",
-        "@zowe/imperative": "4.17.2",
+        "@zowe/imperative": "4.17.3",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
         "rimraf": "^2.6.3",
@@ -24355,7 +24355,7 @@
       "devDependencies": {
         "@types/node": "^12.12.24",
         "@zowe/core-for-zowe-sdk": "6.37.1",
-        "@zowe/imperative": "4.17.2",
+        "@zowe/imperative": "4.17.3",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
         "rimraf": "^2.6.3",
@@ -24374,7 +24374,7 @@
       "devDependencies": {
         "@types/node": "^12.12.24",
         "@zowe/core-for-zowe-sdk": "6.37.1",
-        "@zowe/imperative": "4.17.2",
+        "@zowe/imperative": "4.17.3",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
         "rimraf": "^2.6.3",
@@ -24396,7 +24396,7 @@
       "devDependencies": {
         "@types/node": "^12.12.24",
         "@zowe/core-for-zowe-sdk": "6.37.1",
-        "@zowe/imperative": "4.17.2",
+        "@zowe/imperative": "4.17.3",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
         "rimraf": "^2.6.3",
@@ -24418,7 +24418,7 @@
       "devDependencies": {
         "@types/node": "^12.12.24",
         "@types/ssh2": "^0.5.44",
-        "@zowe/imperative": "4.17.2",
+        "@zowe/imperative": "4.17.3",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
         "rimraf": "^2.6.3",
@@ -28381,7 +28381,7 @@
       "requires": {
         "@types/node": "^12.12.24",
         "@zowe/core-for-zowe-sdk": "6.37.1",
-        "@zowe/imperative": "4.17.2",
+        "@zowe/imperative": "4.17.3",
         "@zowe/perf-timing": "1.0.7",
         "@zowe/provisioning-for-zowe-sdk": "6.37.1",
         "@zowe/zos-console-for-zowe-sdk": "6.37.1",
@@ -28413,7 +28413,7 @@
       "version": "file:packages/core",
       "requires": {
         "@types/node": "^12.12.24",
-        "@zowe/imperative": "4.17.2",
+        "@zowe/imperative": "4.17.3",
         "chalk": "^4.1.0",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
@@ -28446,9 +28446,9 @@
       }
     },
     "@zowe/imperative": {
-      "version": "4.17.2",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@zowe/imperative/-/@zowe/imperative-4.17.2.tgz",
-      "integrity": "sha1-6anmRgU3E6KShhplXuaTG7MLDNE=",
+      "version": "4.17.3",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@zowe/imperative/-/@zowe/imperative-4.17.3.tgz",
+      "integrity": "sha1-rn+CtQFCuZ6wQFSdXpfCqQrlOlc=",
       "requires": {
         "@types/lodash-deep": "2.0.0",
         "@types/yargs": "13.0.4",
@@ -28619,7 +28619,7 @@
         "@types/js-yaml": "^3.12.5",
         "@types/node": "^12.12.24",
         "@zowe/core-for-zowe-sdk": "6.37.1",
-        "@zowe/imperative": "4.17.2",
+        "@zowe/imperative": "4.17.3",
         "eslint": "^7.32.0",
         "js-yaml": "3.14.1",
         "madge": "^4.0.1",
@@ -28633,7 +28633,7 @@
       "requires": {
         "@types/node": "^12.12.24",
         "@zowe/core-for-zowe-sdk": "6.37.1",
-        "@zowe/imperative": "4.17.2",
+        "@zowe/imperative": "4.17.3",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
         "rimraf": "^2.6.3",
@@ -28646,7 +28646,7 @@
       "requires": {
         "@types/node": "^12.12.24",
         "@zowe/core-for-zowe-sdk": "6.37.1",
-        "@zowe/imperative": "4.17.2",
+        "@zowe/imperative": "4.17.3",
         "@zowe/zos-uss-for-zowe-sdk": "6.37.1",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
@@ -28661,7 +28661,7 @@
       "requires": {
         "@types/node": "^12.12.24",
         "@zowe/core-for-zowe-sdk": "6.37.1",
-        "@zowe/imperative": "4.17.2",
+        "@zowe/imperative": "4.17.3",
         "@zowe/zos-files-for-zowe-sdk": "6.37.1",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
@@ -28675,7 +28675,7 @@
       "requires": {
         "@types/node": "^12.12.24",
         "@zowe/core-for-zowe-sdk": "6.37.1",
-        "@zowe/imperative": "4.17.2",
+        "@zowe/imperative": "4.17.3",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
         "rimraf": "^2.6.3",
@@ -28688,7 +28688,7 @@
       "requires": {
         "@types/node": "^12.12.24",
         "@zowe/core-for-zowe-sdk": "6.37.1",
-        "@zowe/imperative": "4.17.2",
+        "@zowe/imperative": "4.17.3",
         "@zowe/zosmf-for-zowe-sdk": "6.37.1",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
@@ -28702,7 +28702,7 @@
       "requires": {
         "@types/node": "^12.12.24",
         "@types/ssh2": "^0.5.44",
-        "@zowe/imperative": "4.17.2",
+        "@zowe/imperative": "4.17.3",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
         "rimraf": "^2.6.3",
@@ -28716,7 +28716,7 @@
       "requires": {
         "@types/node": "^12.12.24",
         "@zowe/core-for-zowe-sdk": "6.37.1",
-        "@zowe/imperative": "4.17.2",
+        "@zowe/imperative": "4.17.3",
         "@zowe/zos-files-for-zowe-sdk": "6.37.1",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
@@ -28730,7 +28730,7 @@
       "requires": {
         "@types/node": "^12.12.24",
         "@zowe/core-for-zowe-sdk": "6.37.1",
-        "@zowe/imperative": "4.17.2",
+        "@zowe/imperative": "4.17.3",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
         "rimraf": "^2.6.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -24148,22 +24148,22 @@
     },
     "packages/cli": {
       "name": "@zowe/cli",
-      "version": "6.37.0",
+      "version": "6.37.1",
       "hasInstallScript": true,
       "license": "EPL-2.0",
       "dependencies": {
-        "@zowe/core-for-zowe-sdk": "6.36.1",
+        "@zowe/core-for-zowe-sdk": "6.37.1",
         "@zowe/imperative": "4.17.2",
         "@zowe/perf-timing": "1.0.7",
-        "@zowe/provisioning-for-zowe-sdk": "6.36.1",
-        "@zowe/zos-console-for-zowe-sdk": "6.36.1",
-        "@zowe/zos-files-for-zowe-sdk": "6.36.1",
-        "@zowe/zos-jobs-for-zowe-sdk": "6.36.1",
-        "@zowe/zos-logs-for-zowe-sdk": "6.37.0",
-        "@zowe/zos-tso-for-zowe-sdk": "6.36.1",
-        "@zowe/zos-uss-for-zowe-sdk": "6.36.1",
-        "@zowe/zos-workflows-for-zowe-sdk": "6.36.1",
-        "@zowe/zosmf-for-zowe-sdk": "6.36.1",
+        "@zowe/provisioning-for-zowe-sdk": "6.37.1",
+        "@zowe/zos-console-for-zowe-sdk": "6.37.1",
+        "@zowe/zos-files-for-zowe-sdk": "6.37.1",
+        "@zowe/zos-jobs-for-zowe-sdk": "6.37.1",
+        "@zowe/zos-logs-for-zowe-sdk": "6.37.1",
+        "@zowe/zos-tso-for-zowe-sdk": "6.37.1",
+        "@zowe/zos-uss-for-zowe-sdk": "6.37.1",
+        "@zowe/zos-workflows-for-zowe-sdk": "6.37.1",
+        "@zowe/zosmf-for-zowe-sdk": "6.37.1",
         "get-stdin": "7.0.0",
         "minimatch": "3.0.4"
       },
@@ -24194,7 +24194,7 @@
     },
     "packages/core": {
       "name": "@zowe/core-for-zowe-sdk",
-      "version": "6.36.1",
+      "version": "6.37.1",
       "license": "EPL-2.0",
       "dependencies": {
         "string-width": "4.2.3"
@@ -24241,7 +24241,7 @@
     },
     "packages/provisioning": {
       "name": "@zowe/provisioning-for-zowe-sdk",
-      "version": "6.36.1",
+      "version": "6.37.1",
       "license": "EPL-2.0",
       "dependencies": {
         "js-yaml": "3.14.1"
@@ -24249,7 +24249,7 @@
       "devDependencies": {
         "@types/js-yaml": "^3.12.5",
         "@types/node": "^12.12.24",
-        "@zowe/core-for-zowe-sdk": "6.36.1",
+        "@zowe/core-for-zowe-sdk": "6.37.1",
         "@zowe/imperative": "4.17.2",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
@@ -24264,14 +24264,14 @@
     },
     "packages/workflows": {
       "name": "@zowe/zos-workflows-for-zowe-sdk",
-      "version": "6.36.1",
+      "version": "6.37.1",
       "license": "EPL-2.0",
       "dependencies": {
-        "@zowe/zos-files-for-zowe-sdk": "6.36.1"
+        "@zowe/zos-files-for-zowe-sdk": "6.37.1"
       },
       "devDependencies": {
         "@types/node": "^12.12.24",
-        "@zowe/core-for-zowe-sdk": "6.36.1",
+        "@zowe/core-for-zowe-sdk": "6.37.1",
         "@zowe/imperative": "4.17.2",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
@@ -24286,11 +24286,11 @@
     },
     "packages/zosconsole": {
       "name": "@zowe/zos-console-for-zowe-sdk",
-      "version": "6.36.1",
+      "version": "6.37.1",
       "license": "EPL-2.0",
       "devDependencies": {
         "@types/node": "^12.12.24",
-        "@zowe/core-for-zowe-sdk": "6.36.1",
+        "@zowe/core-for-zowe-sdk": "6.37.1",
         "@zowe/imperative": "4.17.2",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
@@ -24305,16 +24305,16 @@
     },
     "packages/zosfiles": {
       "name": "@zowe/zos-files-for-zowe-sdk",
-      "version": "6.36.1",
+      "version": "6.37.1",
       "license": "EPL-2.0",
       "dependencies": {
         "minimatch": "3.0.4"
       },
       "devDependencies": {
         "@types/node": "^12.12.24",
-        "@zowe/core-for-zowe-sdk": "6.36.1",
+        "@zowe/core-for-zowe-sdk": "6.37.1",
         "@zowe/imperative": "4.17.2",
-        "@zowe/zos-uss-for-zowe-sdk": "6.36.1",
+        "@zowe/zos-uss-for-zowe-sdk": "6.37.1",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
         "rimraf": "^2.6.3",
@@ -24328,14 +24328,14 @@
     },
     "packages/zosjobs": {
       "name": "@zowe/zos-jobs-for-zowe-sdk",
-      "version": "6.36.1",
+      "version": "6.37.1",
       "license": "EPL-2.0",
       "dependencies": {
-        "@zowe/zos-files-for-zowe-sdk": "6.36.1"
+        "@zowe/zos-files-for-zowe-sdk": "6.37.1"
       },
       "devDependencies": {
         "@types/node": "^12.12.24",
-        "@zowe/core-for-zowe-sdk": "6.36.1",
+        "@zowe/core-for-zowe-sdk": "6.37.1",
         "@zowe/imperative": "4.17.2",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
@@ -24350,11 +24350,11 @@
     },
     "packages/zoslogs": {
       "name": "@zowe/zos-logs-for-zowe-sdk",
-      "version": "6.37.0",
+      "version": "6.37.1",
       "license": "EPL-2.0",
       "devDependencies": {
         "@types/node": "^12.12.24",
-        "@zowe/core-for-zowe-sdk": "6.36.1",
+        "@zowe/core-for-zowe-sdk": "6.37.1",
         "@zowe/imperative": "4.17.2",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
@@ -24369,11 +24369,11 @@
     },
     "packages/zosmf": {
       "name": "@zowe/zosmf-for-zowe-sdk",
-      "version": "6.36.1",
+      "version": "6.37.1",
       "license": "EPL-2.0",
       "devDependencies": {
         "@types/node": "^12.12.24",
-        "@zowe/core-for-zowe-sdk": "6.36.1",
+        "@zowe/core-for-zowe-sdk": "6.37.1",
         "@zowe/imperative": "4.17.2",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
@@ -24388,14 +24388,14 @@
     },
     "packages/zostso": {
       "name": "@zowe/zos-tso-for-zowe-sdk",
-      "version": "6.36.1",
+      "version": "6.37.1",
       "license": "EPL-2.0",
       "dependencies": {
-        "@zowe/zosmf-for-zowe-sdk": "6.36.1"
+        "@zowe/zosmf-for-zowe-sdk": "6.37.1"
       },
       "devDependencies": {
         "@types/node": "^12.12.24",
-        "@zowe/core-for-zowe-sdk": "6.36.1",
+        "@zowe/core-for-zowe-sdk": "6.37.1",
         "@zowe/imperative": "4.17.2",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
@@ -24410,7 +24410,7 @@
     },
     "packages/zosuss": {
       "name": "@zowe/zos-uss-for-zowe-sdk",
-      "version": "6.36.1",
+      "version": "6.37.1",
       "license": "EPL-2.0",
       "dependencies": {
         "ssh2": "1.4.0"
@@ -28380,18 +28380,18 @@
       "version": "file:packages/cli",
       "requires": {
         "@types/node": "^12.12.24",
-        "@zowe/core-for-zowe-sdk": "6.36.1",
+        "@zowe/core-for-zowe-sdk": "6.37.1",
         "@zowe/imperative": "4.17.2",
         "@zowe/perf-timing": "1.0.7",
-        "@zowe/provisioning-for-zowe-sdk": "6.36.1",
-        "@zowe/zos-console-for-zowe-sdk": "6.36.1",
-        "@zowe/zos-files-for-zowe-sdk": "6.36.1",
-        "@zowe/zos-jobs-for-zowe-sdk": "6.36.1",
-        "@zowe/zos-logs-for-zowe-sdk": "6.37.0",
-        "@zowe/zos-tso-for-zowe-sdk": "6.36.1",
-        "@zowe/zos-uss-for-zowe-sdk": "6.36.1",
-        "@zowe/zos-workflows-for-zowe-sdk": "6.36.1",
-        "@zowe/zosmf-for-zowe-sdk": "6.36.1",
+        "@zowe/provisioning-for-zowe-sdk": "6.37.1",
+        "@zowe/zos-console-for-zowe-sdk": "6.37.1",
+        "@zowe/zos-files-for-zowe-sdk": "6.37.1",
+        "@zowe/zos-jobs-for-zowe-sdk": "6.37.1",
+        "@zowe/zos-logs-for-zowe-sdk": "6.37.1",
+        "@zowe/zos-tso-for-zowe-sdk": "6.37.1",
+        "@zowe/zos-uss-for-zowe-sdk": "6.37.1",
+        "@zowe/zos-workflows-for-zowe-sdk": "6.37.1",
+        "@zowe/zosmf-for-zowe-sdk": "6.37.1",
         "eslint": "^7.32.0",
         "get-stdin": "7.0.0",
         "js-yaml": "^3.13.1",
@@ -28618,7 +28618,7 @@
       "requires": {
         "@types/js-yaml": "^3.12.5",
         "@types/node": "^12.12.24",
-        "@zowe/core-for-zowe-sdk": "6.36.1",
+        "@zowe/core-for-zowe-sdk": "6.37.1",
         "@zowe/imperative": "4.17.2",
         "eslint": "^7.32.0",
         "js-yaml": "3.14.1",
@@ -28632,7 +28632,7 @@
       "version": "file:packages/zosconsole",
       "requires": {
         "@types/node": "^12.12.24",
-        "@zowe/core-for-zowe-sdk": "6.36.1",
+        "@zowe/core-for-zowe-sdk": "6.37.1",
         "@zowe/imperative": "4.17.2",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
@@ -28645,9 +28645,9 @@
       "version": "file:packages/zosfiles",
       "requires": {
         "@types/node": "^12.12.24",
-        "@zowe/core-for-zowe-sdk": "6.36.1",
+        "@zowe/core-for-zowe-sdk": "6.37.1",
         "@zowe/imperative": "4.17.2",
-        "@zowe/zos-uss-for-zowe-sdk": "6.36.1",
+        "@zowe/zos-uss-for-zowe-sdk": "6.37.1",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
         "minimatch": "3.0.4",
@@ -28660,9 +28660,9 @@
       "version": "file:packages/zosjobs",
       "requires": {
         "@types/node": "^12.12.24",
-        "@zowe/core-for-zowe-sdk": "6.36.1",
+        "@zowe/core-for-zowe-sdk": "6.37.1",
         "@zowe/imperative": "4.17.2",
-        "@zowe/zos-files-for-zowe-sdk": "6.36.1",
+        "@zowe/zos-files-for-zowe-sdk": "6.37.1",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
         "rimraf": "^2.6.3",
@@ -28674,7 +28674,7 @@
       "version": "file:packages/zoslogs",
       "requires": {
         "@types/node": "^12.12.24",
-        "@zowe/core-for-zowe-sdk": "6.36.1",
+        "@zowe/core-for-zowe-sdk": "6.37.1",
         "@zowe/imperative": "4.17.2",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
@@ -28687,9 +28687,9 @@
       "version": "file:packages/zostso",
       "requires": {
         "@types/node": "^12.12.24",
-        "@zowe/core-for-zowe-sdk": "6.36.1",
+        "@zowe/core-for-zowe-sdk": "6.37.1",
         "@zowe/imperative": "4.17.2",
-        "@zowe/zosmf-for-zowe-sdk": "6.36.1",
+        "@zowe/zosmf-for-zowe-sdk": "6.37.1",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
         "rimraf": "^2.6.3",
@@ -28715,9 +28715,9 @@
       "version": "file:packages/workflows",
       "requires": {
         "@types/node": "^12.12.24",
-        "@zowe/core-for-zowe-sdk": "6.36.1",
+        "@zowe/core-for-zowe-sdk": "6.37.1",
         "@zowe/imperative": "4.17.2",
-        "@zowe/zos-files-for-zowe-sdk": "6.36.1",
+        "@zowe/zos-files-for-zowe-sdk": "6.37.1",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
         "rimraf": "^2.6.3",
@@ -28729,7 +28729,7 @@
       "version": "file:packages/zosmf",
       "requires": {
         "@types/node": "^12.12.24",
-        "@zowe/core-for-zowe-sdk": "6.36.1",
+        "@zowe/core-for-zowe-sdk": "6.37.1",
         "@zowe/imperative": "4.17.2",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "lint": "eslint \"packages/**/*.ts\" \"**/__tests__/**/*.ts\"",
     "lint:packages": "eslint \"packages/**/*.ts\" --ignore-pattern \"**/__tests__/**/*.ts\"",
     "lint:tests": "eslint \"**/__tests__/**/*.ts\"",
-    "update:imperative": "npm i --save --save-exact @zowe/imperative && syncpack fix-mismatches --dev --prod --filter @zowe/imperative",
+    "update:imperative": "npm i --save --save-exact @zowe/imperative@latest && syncpack fix-mismatches --dev --prod --filter @zowe/imperative",
     "test": "npm run test:unit && npm run test:integration && npm run test:system",
     "test:cleanResults": "rimraf __tests__/__results__",
     "test:cleanUpProfiles": "sh __tests__/__scripts__/clean_profiles.sh",
@@ -34,7 +34,7 @@
     "prepare": "husky install"
   },
   "dependencies": {
-    "@zowe/imperative": "4.17.2",
+    "@zowe/imperative": "4.17.3",
     "@zowe/perf-timing": "1.0.7"
   },
   "devDependencies": {

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -2,17 +2,21 @@
 
 All notable changes to the Zowe CLI package will be documented in this file.
 
+## Recent Changes
+
+- BugFix: Disable gzip compression for z/OSMF requests that download binary files. [#1170](https://github.com/zowe/zowe-cli/issues/1170)
+
 ## `6.37.1`
 
 - BugFix: Update Imperative to absorb bugfixes introduced in version `4.17.2`.
 
 ## `6.37.0`
 
-- Enhancement: Added new feature to manage zos-logs. z/OSMF version 2.4 or higher is required. Ensure that the [z/OSMF Operations Log Support is available via APAR and associated PTFs](https://www.ibm.com/support/pages/apar/PH35930). [Issue 1104](https://github.com/zowe/zowe-cli/issues/1104)
+- Enhancement: Added new feature to manage zos-logs. z/OSMF version 2.4 or higher is required. Ensure that the [z/OSMF Operations Log Support is available via APAR and associated PTFs](https://www.ibm.com/support/pages/apar/PH35930). [#1104](https://github.com/zowe/zowe-cli/issues/1104)
 
 ## `6.36.1`
 
-- BugFix: Fixed an issue where plugin install and uninstall did not work with NPM version 8. [#683](https://github.com/zowe/imperative/issues/683)
+- BugFix: Fixed an issue where plugin install and uninstall did not work with NPM version 8. [Imperative #683](https://github.com/zowe/imperative/issues/683)
 
 ## `6.36.0`
 

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -4,11 +4,11 @@ All notable changes to the Zowe CLI package will be documented in this file.
 
 ## Recent Changes
 
-- BugFix: Disable gzip compression for z/OSMF requests that download binary files. [#1170](https://github.com/zowe/zowe-cli/issues/1170)
+- BugFix: Disabled gzip compression for z/OSMF requests that download binary files. [#1170](https://github.com/zowe/zowe-cli/issues/1170)
 
 ## `6.37.1`
 
-- BugFix: Update Imperative to absorb bugfixes introduced in version `4.17.2`.
+- BugFix: Updated Imperative to absorb bugfixes introduced in version `4.17.2`.
 
 ## `6.37.0`
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -55,7 +55,7 @@
   },
   "dependencies": {
     "@zowe/core-for-zowe-sdk": "6.37.1",
-    "@zowe/imperative": "4.17.2",
+    "@zowe/imperative": "4.17.3",
     "@zowe/perf-timing": "1.0.7",
     "@zowe/provisioning-for-zowe-sdk": "6.37.1",
     "@zowe/zos-console-for-zowe-sdk": "6.37.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -48,7 +48,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.12.24",
-    "@zowe/imperative": "4.17.2",
+    "@zowe/imperative": "4.17.3",
     "chalk": "^4.1.0",
     "eslint": "^7.32.0",
     "madge": "^4.0.1",

--- a/packages/provisioning/package.json
+++ b/packages/provisioning/package.json
@@ -50,7 +50,7 @@
     "@types/js-yaml": "^3.12.5",
     "@types/node": "^12.12.24",
     "@zowe/core-for-zowe-sdk": "6.37.1",
-    "@zowe/imperative": "4.17.2",
+    "@zowe/imperative": "4.17.3",
     "eslint": "^7.32.0",
     "madge": "^4.0.1",
     "rimraf": "^2.6.3",

--- a/packages/workflows/package.json
+++ b/packages/workflows/package.json
@@ -49,7 +49,7 @@
   "devDependencies": {
     "@types/node": "^12.12.24",
     "@zowe/core-for-zowe-sdk": "6.37.1",
-    "@zowe/imperative": "4.17.2",
+    "@zowe/imperative": "4.17.3",
     "eslint": "^7.32.0",
     "madge": "^4.0.1",
     "rimraf": "^2.6.3",

--- a/packages/zosconsole/package.json
+++ b/packages/zosconsole/package.json
@@ -46,7 +46,7 @@
   "devDependencies": {
     "@types/node": "^12.12.24",
     "@zowe/core-for-zowe-sdk": "6.37.1",
-    "@zowe/imperative": "4.17.2",
+    "@zowe/imperative": "4.17.3",
     "eslint": "^7.32.0",
     "madge": "^4.0.1",
     "rimraf": "^2.6.3",

--- a/packages/zosfiles/CHANGELOG.md
+++ b/packages/zosfiles/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the Zowe z/OS files SDK package will be documented in thi
 
 ## Recent Changes
 
-- BugFix: Disable gzip compression for z/OSMF requests that download binary files. [#1170](https://github.com/zowe/zowe-cli/issues/1170)
+- BugFix: Disabled gzip compression for z/OSMF requests that download binary files. [#1170](https://github.com/zowe/zowe-cli/issues/1170)
 
 ## `6.32.1`
 

--- a/packages/zosfiles/CHANGELOG.md
+++ b/packages/zosfiles/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Zowe z/OS files SDK package will be documented in this file.
 
+## Recent Changes
+
+- BugFix: Disable gzip compression for z/OSMF requests that download binary files. [#1170](https://github.com/zowe/zowe-cli/issues/1170)
+
 ## `6.32.1`
 
 - Updated Imperative version

--- a/packages/zosfiles/__tests__/__unit__/methods/download/Download.unit.test.ts
+++ b/packages/zosfiles/__tests__/__unit__/methods/download/Download.unit.test.ts
@@ -199,7 +199,9 @@ describe("z/OS Files - Download", () => {
 
             expect(zosmfGetFullSpy).toHaveBeenCalledTimes(1);
             expect(zosmfGetFullSpy).toHaveBeenCalledWith(dummySession, {resource: endpoint,
-                reqHeaders: [ZosmfHeaders.X_IBM_BINARY, ZosmfHeaders.ACCEPT_ENCODING],
+                // TODO:gzip
+                // reqHeaders: [ZosmfHeaders.X_IBM_BINARY, ZosmfHeaders.ACCEPT_ENCODING],
+                reqHeaders: [ZosmfHeaders.X_IBM_BINARY],
                 responseStream: fakeWriteStream,
                 normalizeResponseNewLines: false /* don't normalize newlines, binary mode*/,
                 task: undefined /* no progress task */});
@@ -233,7 +235,9 @@ describe("z/OS Files - Download", () => {
 
             expect(zosmfGetFullSpy).toHaveBeenCalledTimes(1);
             expect(zosmfGetFullSpy).toHaveBeenCalledWith(dummySession, {resource: endpoint,
-                reqHeaders: [ZosmfHeaders.X_IBM_BINARY, ZosmfHeaders.ACCEPT_ENCODING],
+                // TODO:gzip
+                // reqHeaders: [ZosmfHeaders.X_IBM_BINARY, ZosmfHeaders.ACCEPT_ENCODING],
+                reqHeaders: [ZosmfHeaders.X_IBM_BINARY],
                 responseStream: fakeWriteStream,
                 normalizeResponseNewLines: false, /* no normalizing new lines, binary mode*/
                 task: undefined /*no progress task*/});
@@ -947,7 +951,9 @@ describe("z/OS Files - Download", () => {
             //     false, /* don't normalize new lines in binary*/
             //     undefined /* no progress task */);
             expect(zosmfGetFullSpy).toHaveBeenCalledWith(dummySession, {resource: endpoint,
-                reqHeaders: [ZosmfHeaders.X_IBM_BINARY, ZosmfHeaders.ACCEPT_ENCODING],
+                // TODO:gzip
+                // reqHeaders: [ZosmfHeaders.X_IBM_BINARY, ZosmfHeaders.ACCEPT_ENCODING],
+                reqHeaders: [ZosmfHeaders.X_IBM_BINARY],
                 responseStream: fakeStream,
                 normalizeResponseNewLines: false, /* don't normalize new lines in binary*/
                 task: undefined /* no progress task */});
@@ -1049,7 +1055,9 @@ describe("z/OS Files - Download", () => {
 
             expect(zosmfGetFullSpy).toHaveBeenCalledTimes(1);
             expect(zosmfGetFullSpy).toHaveBeenCalledWith(dummySession, {resource: endpoint,
-                reqHeaders: [ZosmfHeaders.X_IBM_BINARY, ZosmfHeaders.ACCEPT_ENCODING],
+                // TODO:gzip
+                // reqHeaders: [ZosmfHeaders.X_IBM_BINARY, ZosmfHeaders.ACCEPT_ENCODING],
+                reqHeaders: [ZosmfHeaders.X_IBM_BINARY],
                 responseStream: fakeStream,
                 normalizeResponseNewLines: false, /* don't normalize new lines in binary */
                 task: undefined /* no progress task */});

--- a/packages/zosfiles/__tests__/__unit__/methods/get/Get.unit.test.ts
+++ b/packages/zosfiles/__tests__/__unit__/methods/get/Get.unit.test.ts
@@ -121,7 +121,9 @@ describe("z/OS Files - View", () => {
             expect(response).toEqual(content);
 
             expect(zosmfExpectSpy).toHaveBeenCalledTimes(1);
-            expect(zosmfExpectSpy).toHaveBeenCalledWith(dummySession, endpoint, [ZosmfHeaders.X_IBM_BINARY, ZosmfHeaders.ACCEPT_ENCODING]);
+            // TODO:gzip
+            // expect(zosmfExpectSpy).toHaveBeenCalledWith(dummySession, endpoint, [ZosmfHeaders.X_IBM_BINARY, ZosmfHeaders.ACCEPT_ENCODING]);
+            expect(zosmfExpectSpy).toHaveBeenCalledWith(dummySession, endpoint, [ZosmfHeaders.X_IBM_BINARY]);
         });
 
         it("should get data set content with encoding", async () => {

--- a/packages/zosfiles/__tests__/__unit__/methods/upload/Upload.unit.test.ts
+++ b/packages/zosfiles/__tests__/__unit__/methods/upload/Upload.unit.test.ts
@@ -418,7 +418,9 @@ describe("z/OS Files - Upload", () => {
 
             it("should return with proper response when uploading with 'binary' option", async () => {
                 uploadOptions.binary = true;
-                reqHeaders = [ZosmfHeaders.X_IBM_BINARY, ZosmfHeaders.ACCEPT_ENCODING];
+                // TODO:gzip
+                // reqHeaders = [ZosmfHeaders.X_IBM_BINARY, ZosmfHeaders.ACCEPT_ENCODING];
+                reqHeaders = [ZosmfHeaders.X_IBM_BINARY];
 
                 try {
                     response = await Upload.bufferToDataSet(dummySession, buffer, dsName, uploadOptions);
@@ -697,7 +699,9 @@ describe("z/OS Files - Upload", () => {
                 binary: true
             };
             const endpoint = path.posix.join(ZosFilesConstants.RESOURCE, ZosFilesConstants.RES_DS_FILES, dsName);
-            let reqHeaders = [ZosmfHeaders.X_IBM_BINARY, ZosmfHeaders.ACCEPT_ENCODING];
+            // TODO:gzip
+            // let reqHeaders = [ZosmfHeaders.X_IBM_BINARY, ZosmfHeaders.ACCEPT_ENCODING];
+            let reqHeaders = [ZosmfHeaders.X_IBM_BINARY];
 
             try {
                 response = await Upload.streamToDataSet(dummySession, inputStream, dsName, uploadOptions);
@@ -717,7 +721,9 @@ describe("z/OS Files - Upload", () => {
 
             // Unit test for wait option
             uploadOptions.recall = "wait";
-            reqHeaders = [ZosmfHeaders.X_IBM_BINARY, ZosmfHeaders.ACCEPT_ENCODING, ZosmfHeaders.X_IBM_MIGRATED_RECALL_WAIT];
+            // TODO:gzip
+            // reqHeaders = [ZosmfHeaders.X_IBM_BINARY, ZosmfHeaders.ACCEPT_ENCODING, ZosmfHeaders.X_IBM_MIGRATED_RECALL_WAIT];
+            reqHeaders = [ZosmfHeaders.X_IBM_BINARY, ZosmfHeaders.X_IBM_MIGRATED_RECALL_WAIT];
 
             try {
                 response = await Upload.streamToDataSet(dummySession, inputStream, dsName, uploadOptions);
@@ -737,7 +743,9 @@ describe("z/OS Files - Upload", () => {
 
             // Unit test for no wait option
             uploadOptions.recall = "nowait";
-            reqHeaders = [ZosmfHeaders.X_IBM_BINARY, ZosmfHeaders.ACCEPT_ENCODING, ZosmfHeaders.X_IBM_MIGRATED_RECALL_NO_WAIT];
+            // TODO:gzip
+            // reqHeaders = [ZosmfHeaders.X_IBM_BINARY, ZosmfHeaders.ACCEPT_ENCODING, ZosmfHeaders.X_IBM_MIGRATED_RECALL_NO_WAIT];
+            reqHeaders = [ZosmfHeaders.X_IBM_BINARY, ZosmfHeaders.X_IBM_MIGRATED_RECALL_NO_WAIT];
 
             try {
                 response = await Upload.streamToDataSet(dummySession, inputStream, dsName, uploadOptions);
@@ -757,7 +765,9 @@ describe("z/OS Files - Upload", () => {
 
             // Unit test for no error option
             uploadOptions.recall = "error";
-            reqHeaders = [ZosmfHeaders.X_IBM_BINARY, ZosmfHeaders.ACCEPT_ENCODING, ZosmfHeaders.X_IBM_MIGRATED_RECALL_ERROR];
+            // TODO:gzip
+            // reqHeaders = [ZosmfHeaders.X_IBM_BINARY, ZosmfHeaders.ACCEPT_ENCODING, ZosmfHeaders.X_IBM_MIGRATED_RECALL_ERROR];
+            reqHeaders = [ZosmfHeaders.X_IBM_BINARY, ZosmfHeaders.X_IBM_MIGRATED_RECALL_ERROR];
 
             try {
                 response = await Upload.streamToDataSet(dummySession, inputStream, dsName, uploadOptions);
@@ -777,7 +787,9 @@ describe("z/OS Files - Upload", () => {
 
             // Unit test default value
             uploadOptions.recall = "non-existing";
-            reqHeaders = [ZosmfHeaders.X_IBM_BINARY, ZosmfHeaders.ACCEPT_ENCODING, ZosmfHeaders.X_IBM_MIGRATED_RECALL_NO_WAIT];
+            // TODO:gzip
+            // reqHeaders = [ZosmfHeaders.X_IBM_BINARY, ZosmfHeaders.ACCEPT_ENCODING, ZosmfHeaders.X_IBM_MIGRATED_RECALL_NO_WAIT];
+            reqHeaders = [ZosmfHeaders.X_IBM_BINARY, ZosmfHeaders.X_IBM_MIGRATED_RECALL_NO_WAIT];
 
             try {
                 response = await Upload.streamToDataSet(dummySession, inputStream, dsName, uploadOptions);
@@ -797,7 +809,9 @@ describe("z/OS Files - Upload", () => {
 
             // Unit test for pass etag option
             uploadOptions.etag = etagValue;
-            reqHeaders = [ZosmfHeaders.X_IBM_BINARY, ZosmfHeaders.ACCEPT_ENCODING, ZosmfHeaders.X_IBM_MIGRATED_RECALL_NO_WAIT,
+            // TODO:gzip
+            // reqHeaders = [ZosmfHeaders.X_IBM_BINARY, ZosmfHeaders.ACCEPT_ENCODING, ZosmfHeaders.X_IBM_MIGRATED_RECALL_NO_WAIT,
+            reqHeaders = [ZosmfHeaders.X_IBM_BINARY, ZosmfHeaders.X_IBM_MIGRATED_RECALL_NO_WAIT,
                 {"If-Match" : uploadOptions.etag}];
 
             try {
@@ -819,7 +833,8 @@ describe("z/OS Files - Upload", () => {
 
             // Unit test for return etag option
             reqHeaders = [ZosmfHeaders.X_IBM_BINARY,
-                ZosmfHeaders.ACCEPT_ENCODING,
+                // TODO:gzip
+                // ZosmfHeaders.ACCEPT_ENCODING,
                 ZosmfHeaders.X_IBM_MIGRATED_RECALL_NO_WAIT,
                 {"If-Match" : uploadOptions.etag},
                 ZosmfHeaders.X_IBM_RETURN_ETAG];
@@ -845,7 +860,8 @@ describe("z/OS Files - Upload", () => {
             // Unit test for responseTimeout
             uploadOptions.responseTimeout = 5;
             reqHeaders = [ZosmfHeaders.X_IBM_BINARY,
-                ZosmfHeaders.ACCEPT_ENCODING,
+                // TODO:gzip
+                // ZosmfHeaders.ACCEPT_ENCODING,
                 {[ZosmfHeaders.X_IBM_RESPONSE_TIMEOUT]: "5"},
                 ZosmfHeaders.X_IBM_MIGRATED_RECALL_NO_WAIT,
                 {"If-Match" : uploadOptions.etag},

--- a/packages/zosfiles/package.json
+++ b/packages/zosfiles/package.json
@@ -50,7 +50,7 @@
   "devDependencies": {
     "@types/node": "^12.12.24",
     "@zowe/core-for-zowe-sdk": "6.37.1",
-    "@zowe/imperative": "4.17.2",
+    "@zowe/imperative": "4.17.3",
     "@zowe/zos-uss-for-zowe-sdk": "6.37.1",
     "eslint": "^7.32.0",
     "madge": "^4.0.1",

--- a/packages/zosfiles/src/utils/ZosFilesUtils.ts
+++ b/packages/zosfiles/src/utils/ZosFilesUtils.ts
@@ -137,7 +137,12 @@ export class ZosFilesUtils {
             // do nothing
         }
 
-        reqHeaders.push(ZosmfHeaders.ACCEPT_ENCODING);
+        // TODO:gzip Always accept encoding after z/OSMF truncating gzipped binary data is fixed
+        // See https://github.com/zowe/zowe-cli/issues/1170
+        if (!options.binary) {
+            reqHeaders.push(ZosmfHeaders.ACCEPT_ENCODING);
+        }
+
         if (options.responseTimeout != null) {
             reqHeaders.push({[ZosmfHeaders.X_IBM_RESPONSE_TIMEOUT]: options.responseTimeout.toString()});
         }

--- a/packages/zosjobs/package.json
+++ b/packages/zosjobs/package.json
@@ -50,7 +50,7 @@
   "devDependencies": {
     "@types/node": "^12.12.24",
     "@zowe/core-for-zowe-sdk": "6.37.1",
-    "@zowe/imperative": "4.17.2",
+    "@zowe/imperative": "4.17.3",
     "eslint": "^7.32.0",
     "madge": "^4.0.1",
     "rimraf": "^2.6.3",

--- a/packages/zoslogs/package.json
+++ b/packages/zoslogs/package.json
@@ -46,7 +46,7 @@
   "devDependencies": {
     "@types/node": "^12.12.24",
     "@zowe/core-for-zowe-sdk": "6.37.1",
-    "@zowe/imperative": "4.17.2",
+    "@zowe/imperative": "4.17.3",
     "eslint": "^7.32.0",
     "madge": "^4.0.1",
     "rimraf": "^2.6.3",

--- a/packages/zosmf/package.json
+++ b/packages/zosmf/package.json
@@ -45,7 +45,7 @@
   "devDependencies": {
     "@types/node": "^12.12.24",
     "@zowe/core-for-zowe-sdk": "6.37.1",
-    "@zowe/imperative": "4.17.2",
+    "@zowe/imperative": "4.17.3",
     "eslint": "^7.32.0",
     "madge": "^4.0.1",
     "rimraf": "^2.6.3",

--- a/packages/zostso/package.json
+++ b/packages/zostso/package.json
@@ -49,7 +49,7 @@
   "devDependencies": {
     "@types/node": "^12.12.24",
     "@zowe/core-for-zowe-sdk": "6.37.1",
-    "@zowe/imperative": "4.17.2",
+    "@zowe/imperative": "4.17.3",
     "eslint": "^7.32.0",
     "madge": "^4.0.1",
     "rimraf": "^2.6.3",

--- a/packages/zosuss/package.json
+++ b/packages/zosuss/package.json
@@ -49,7 +49,7 @@
   "devDependencies": {
     "@types/node": "^12.12.24",
     "@types/ssh2": "^0.5.44",
-    "@zowe/imperative": "4.17.2",
+    "@zowe/imperative": "4.17.3",
     "eslint": "^7.32.0",
     "madge": "^4.0.1",
     "rimraf": "^2.6.3",


### PR DESCRIPTION
Workaround for #1170 until z/OSMF fixes truncation of gzipped binary data.

Added the "TODO:gzip" comment to places where we'll want to add back the "Accept-Encoding" header in the future.