### PR TITLE
[next] Add linting to Rust code

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   ],
   "scripts": {
     "build": "gulp updateLicense && lerna run build && npm run lint && npm run checkTestsCompile && npm run circularDependencyCheck",
-    "build:exe": "cd zowex && cargo build && cargo test",
+    "build:exe": "cd zowex && cargo build && cargo clippy && cargo test",
     "clean": "lerna run --parallel clean",
     "clean:exe": "cd zowex && cargo clean",
     "installWithBuild": "npm install && npm run build",
@@ -28,7 +28,7 @@
     "test:system": "cross-env FORCE_COLOR=1 jest \".*__tests__.*\\**\\.system\\.(spec|test)\\.ts\\$\" --coverage false",
     "test:unit": "cross-env FORCE_COLOR=1 jest \".*__tests__.*\\**\\.unit\\.(spec|test)\\.ts\\$\" --coverage",
     "watch": "lerna run --parallel watch",
-    "watch:exe": "cd zowex && cargo install cargo-watch && cargo watch -x build -x test",
+    "watch:exe": "cd zowex && cargo install cargo-watch && cargo watch -x build -x clippy -x test",
     "watch:test": "jest --watch",
     "doc:clean": "rimraf docs/CLIReadme.md",
     "doc:generate": "npm run doc:clean && gulp doc",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "test:system": "cross-env FORCE_COLOR=1 jest \".*__tests__.*\\**\\.system\\.(spec|test)\\.ts\\$\" --coverage false",
     "test:unit": "cross-env FORCE_COLOR=1 jest \".*__tests__.*\\**\\.unit\\.(spec|test)\\.ts\\$\" --coverage",
     "watch": "lerna run --parallel watch",
+    "watch:exe": "cd zowex && cargo install cargo-watch && cargo watch -x build -x test",
     "watch:test": "jest --watch",
     "doc:clean": "rimraf docs/CLIReadme.md",
     "doc:generate": "npm run doc:clean && gulp doc",

--- a/zowex/src/main.rs
+++ b/zowex/src/main.rs
@@ -739,5 +739,7 @@ mod tests {
         env::set_var("ZOWE_DAEMON", "777");
         let env = get_zowe_env();
         assert_eq!(env.keys().len(), 1);
+
+        env::remove_var("ZOWE_DAEMON");
     }
 }

--- a/zowex/src/main.rs
+++ b/zowex/src/main.rs
@@ -94,7 +94,7 @@ struct DaemonResponse {
 //     >> } | Measure-Object -Property TotalSeconds -Average
 // 3.6393932 and 0.76156812 zowe average over 10 run sample = 2.87782508 sec faster on windows
 
-fn main() -> std::io::Result<()> {
+fn main() -> io::Result<()> {
     // turn args into vector
     let mut _args: Vec<String> = env::args().collect();
     let cmd_result: Result<i32, i32>;
@@ -261,7 +261,7 @@ fn get_zowe_env() -> HashMap<String, String> {
     ).collect()
 }
 
-fn run_daemon_command(args: &mut Vec<String>) -> std::io::Result<()> {
+fn run_daemon_command(args: &mut Vec<String>) -> io::Result<()> {
     let cwd = env::current_dir()?;
     let mut stdin = Vec::new();
     if !atty::is(Stream::Stdin) {
@@ -293,7 +293,7 @@ fn run_daemon_command(args: &mut Vec<String>) -> std::io::Result<()> {
  * Attempt to make a TCP connection to the daemon.
  * Iterate to enable a slow system to start the daemon.
  */
-fn establish_connection(host: String, port: String) -> std::io::Result<TcpStream> {
+fn establish_connection(host: String, port: String) -> io::Result<TcpStream> {
     const THREE_SEC_DELAY: u64 = 3;
     const THREE_MIN_OF_RETRIES: i32 = 60;
     const RETRY_TO_SHOW_DIAG: i32 = 5;


### PR DESCRIPTION
* Add `cargo clippy` command to the build process for Rust EXE. Clippy is the default Rust linter shipped with `rustup`.
* Add "watch:exe" NPM script that runs `cargo watch` to automatically rebuild the binary when main.rs changes on disk.
* Replace placeholder unit test in Rust code with a meaningful one.
* Address all of Clippy's complaints. I've opened this PR in draft mode, so we can discuss whether or not we want these changes. 
  * Most of the changes suggested by the linter are stylistic and I don't see a problem with accepting them unless we dislike the style it enforces.
  * One change that stands out as more than just stylistic is `stream.write` -> `stream.write_all`. This seems like a good change that fixes a potential bug, based on the documentation of the linting rule [here](https://github.com/rust-lang/rust-clippy/blob/60e68d68c655ad0d29343fcc4c0e1deddc4d596d/clippy_lints/src/unused_io_amount.rs#L8-L18).