### PR TITLE
Update changelog to republish the package

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -6,10 +6,6 @@ All notable changes to the Zowe CLI package will be documented in this file.
 
 - BugFix: Included an npm-shrinkwrap file to lock-down all transitive dependencies.
 
-## `6.37.4`
-
-- BugFix: Included an npm-shrinkwrap file to lock-down all transitive dependencies.
-
 ## `6.37.3`
 
 - BugFix: Updated imperative to resolve `--hw` line-break issues. [Imperative #715](https://github.com/zowe/imperative/issues/715)

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Zowe CLI package will be documented in this file.
 
+## Recent Changes
+
+- BugFix: Included an npm-shrinkwrap file to lock-down all transitive dependencies.
+
 ## `6.37.4`
 
 - BugFix: Included an npm-shrinkwrap file to lock-down all transitive dependencies.


### PR DESCRIPTION
Opening this simple PR since the package was published to zowe artifactory without the shrinkwrap since https://github.com/zowe/zowe-cli-version-controller/pull/151 wasn't merged prior to publishing.