### PR TITLE
[next] Fix local prebuilds not found at install time

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -173,7 +173,7 @@ node('zowe-jenkins-agent-dind') {
         shouldExecute: {
             return pipeline.protectedBranches.isProtected(BRANCH_NAME)
         },
-        timeout: [time: 10, unit: 'MINUTES'],
+        timeout: [time: 30, unit: 'MINUTES'],
         stage: {
             def daemonVer = readProperties(file: "zowex/Cargo.toml").version
             withCredentials([usernamePassword(credentialsId: 'zowe-robot-github', usernameVariable: 'USERNAME', passwordVariable: 'TOKEN')]) {

--- a/jenkins/bundleDaemon.sh
+++ b/jenkins/bundleDaemon.sh
@@ -23,5 +23,5 @@ curl -fsLOJ https://raw.githubusercontent.com/zowe/zowe-cli/native-v$daemonVersi
 curl -fsLOJ https://raw.githubusercontent.com/zowe/zowe-cli/native-v$daemonVersion/zowex/Cargo.lock
 
 cd ..
-rm -rf packages/cli/prebuilds
-mv prebuilds packages/cli/
+mkdir -p packages/cli/prebuilds
+mv prebuilds/* packages/cli/prebuilds/

--- a/jenkins/bundleKeytar.sh
+++ b/jenkins/bundleKeytar.sh
@@ -5,13 +5,15 @@ set -ex
 keytarVersion=$1
 githubAuthHeader=$2
 
-cd "$(git rev-parse --show-toplevel)/packages/cli"
+cd "$(git rev-parse --show-toplevel)"
 rm -rf prebuilds
 mkdir prebuilds && cd prebuilds
 
 curl -fs https://$githubAuthHeader@api.github.com/repos/atom/node-keytar/releases/tags/v$keytarVersion |
-    jq -r '.assets[] | select (.browser_download_url) | .browser_download_url' |
+    jq -r '.assets[] | select (.browser_download_url) | .browser_download_url' | tr -d '\r' |
     while read -r bdu; do curl -fsLOJ $bdu; done
 
-tar -czvf ../../../keytar-prebuilds.tgz *
-cd ../../..
+tar -czvf ../keytar-prebuilds.tgz *
+cd ..
+mkdir -p packages/cli/prebuilds
+mv prebuilds/* packages/cli/prebuilds/

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Zowe CLI package will be documented in this file.
 
+## Recent Changes
+
+- BugFix: Fixed daemon binaries missing from package and Keytar binaries not found at install time.
+
 ## `7.0.0-next.202202041533`
 
 - BugFix: Updated Imperative to improve log messages when Keytar module fails to load.


### PR DESCRIPTION
* Fixed Keytar binaries overwriting daemon binaries in packaging step of Jenkins pipeline
* Copied preinstall script from SCS plugin that copies prebuilds into `node_modules/keytar/prebuilds` at install time
  * It will only copy Keytar binaries that match `keytar-.*-napi-.*\.tar\.gz` and leave the daemon binaries in place
* Removed old preinstall script that is no longer needed since it worked around [bug](https://github.com/npm/cli/issues/2632) fixed in npm@8.1.0