### PR TITLE
Fixed third "zowe zos-files create data-set" example

### DIFF
--- a/packages/cli/src/zosfiles/-strings-/en.ts
+++ b/packages/cli/src/zosfiles/-strings-/en.ts
@@ -48,7 +48,7 @@ export default {
                 EXAMPLES: {
                     EX1: "Create a data set with default parameters and like flag",
                     EX2: "Create a data set with default parameters and like flag and lrecl flag",
-                    EX3: "Create a data set with type LIBRARY"
+                    EX3: "Create a data set with default parameters and like flag and type LIBRARY"
                 }
             },
             DATA_SET_PARTITIONED: {

--- a/packages/cli/src/zosfiles/create/ds/ds.definition.ts
+++ b/packages/cli/src/zosfiles/create/ds/ds.definition.ts
@@ -65,7 +65,7 @@ export const DsDefinition: ICommandDefinition = {
         },
         {
             description: strings.ACTIONS.DATA_SET_LIKE.EXAMPLES.EX3,
-            options: "NEW.DATASET --data-set-type LIBRARY"
+            options: "NEW.DATASET --like EXISTING.DATASET --data-set-type LIBRARY"
         }
     ]
 };


### PR DESCRIPTION
Fixes #1252; Added the '--like' flag to the example

![image](https://user-images.githubusercontent.com/57257691/153887172-b690fbc4-7e01-47be-9b90-79133b194685.png)

Signed-off-by: JeffinSiby <jeffinsiby@gmail.com>