### PR TITLE
Remove the call to profiles.get() function

### DIFF
--- a/packages/cli/__tests__/zosfiles/__unit__/ZosFilesBase.handler.unit.test.ts
+++ b/packages/cli/__tests__/zosfiles/__unit__/ZosFilesBase.handler.unit.test.ts
@@ -94,7 +94,7 @@ describe("ZosFilesBaseHandler", () => {
         await testClass.process(commandParameters);
 
         expect(spy).toHaveBeenCalledTimes(1);
-        expect(spy).toHaveBeenLastCalledWith(commandParameters, expectedSession, zosmfProfile);
+        expect(spy).toHaveBeenLastCalledWith(commandParameters, expectedSession);
 
         expect(commandParameters.response.console.log).toHaveBeenCalledTimes(1);
         expect(commandParameters.response.console.log).toHaveBeenLastCalledWith(apiResponse.commandResponse);

--- a/packages/cli/__tests__/zosfiles/__unit__/create/binaryPds/BinaryPDS.handler.unit.test.ts
+++ b/packages/cli/__tests__/zosfiles/__unit__/create/binaryPds/BinaryPDS.handler.unit.test.ts
@@ -36,18 +36,6 @@ describe("Create binary PDS data set handler", () => {
                 };
             });
 
-            // Mocked function references
-            const profFunc = jest.fn((args) => {
-                return {
-                    host: "fake",
-                    port: "fake",
-                    user: "fake",
-                    password: "fake",
-                    auth: "fake",
-                    rejectUnauthorized: "fake"
-                };
-            });
-
             try {
                 // Invoke the handler with a full set of mocked arguments and response functions
                 await handler.process({
@@ -79,9 +67,6 @@ describe("Create binary PDS data set handler", () => {
                                 // do nothing
                             })
                         }
-                    },
-                    profiles: {
-                        get: profFunc
                     }
                 } as any);
             } catch (e) {
@@ -89,7 +74,6 @@ describe("Create binary PDS data set handler", () => {
             }
 
             expect(error).toBeUndefined();
-            expect(profFunc).toHaveBeenCalledWith("zosmf", false);
             expect(Create.dataSet).toHaveBeenCalledTimes(1);
             expect(Create.dataSet).toHaveBeenCalledWith(fakeSession, CreateDataSetTypeEnum.DATA_SET_BINARY, dataSetName, {});
             expect(jsonObj).toMatchSnapshot();

--- a/packages/cli/__tests__/zosfiles/__unit__/create/cPds/CPDS.handler.unit.test.ts
+++ b/packages/cli/__tests__/zosfiles/__unit__/create/cPds/CPDS.handler.unit.test.ts
@@ -36,18 +36,6 @@ describe("Create C-code PDS data set handler", () => {
                 };
             });
 
-            // Mocked function references
-            const profFunc = jest.fn((args) => {
-                return {
-                    host: "fake",
-                    port: "fake",
-                    user: "fake",
-                    password: "fake",
-                    auth: "fake",
-                    rejectUnauthorized: "fake"
-                };
-            });
-
             try {
                 // Invoke the handler with a full set of mocked arguments and response functions
                 await handler.process({
@@ -79,9 +67,6 @@ describe("Create C-code PDS data set handler", () => {
                                 // do nothing
                             })
                         }
-                    },
-                    profiles: {
-                        get: profFunc
                     }
                 } as any);
             } catch (e) {
@@ -89,7 +74,6 @@ describe("Create C-code PDS data set handler", () => {
             }
 
             expect(error).toBeUndefined();
-            expect(profFunc).toHaveBeenCalledWith("zosmf", false);
             expect(Create.dataSet).toHaveBeenCalledTimes(1);
             expect(Create.dataSet).toHaveBeenCalledWith(fakeSession, CreateDataSetTypeEnum.DATA_SET_C, dataSetName, {});
             expect(jsonObj).toMatchSnapshot();

--- a/packages/cli/__tests__/zosfiles/__unit__/create/classicPds/ClassicPDS.handler.unit.test.ts
+++ b/packages/cli/__tests__/zosfiles/__unit__/create/classicPds/ClassicPDS.handler.unit.test.ts
@@ -36,18 +36,6 @@ describe("Create classic PDS data set handler", () => {
                 };
             });
 
-            // Mocked function references
-            const profFunc = jest.fn((args) => {
-                return {
-                    host: "fake",
-                    port: "fake",
-                    user: "fake",
-                    password: "fake",
-                    auth: "fake",
-                    rejectUnauthorized: "fake"
-                };
-            });
-
             try {
                 // Invoke the handler with a full set of mocked arguments and response functions
                 await handler.process({
@@ -79,9 +67,6 @@ describe("Create classic PDS data set handler", () => {
                                 // do nothing
                             })
                         }
-                    },
-                    profiles: {
-                        get: profFunc
                     }
                 } as any);
             } catch (e) {
@@ -89,7 +74,6 @@ describe("Create classic PDS data set handler", () => {
             }
 
             expect(error).toBeUndefined();
-            expect(profFunc).toHaveBeenCalledWith("zosmf", false);
             expect(Create.dataSet).toHaveBeenCalledTimes(1);
             expect(Create.dataSet).toHaveBeenCalledWith(fakeSession, CreateDataSetTypeEnum.DATA_SET_CLASSIC, dataSetName, {});
             expect(jsonObj).toMatchSnapshot();

--- a/packages/cli/__tests__/zosfiles/__unit__/create/ds/ds.handler.unit.test.ts
+++ b/packages/cli/__tests__/zosfiles/__unit__/create/ds/ds.handler.unit.test.ts
@@ -37,18 +37,6 @@ describe("Create data set handler", () => {
                 };
             });
 
-            // Mocked function references
-            const profFunc = jest.fn((args) => {
-                return {
-                    host: "fake",
-                    port: "fake",
-                    user: "fake",
-                    password: "fake",
-                    auth: "fake",
-                    rejectUnauthorized: "fake"
-                };
-            });
-
             try {
                 // Invoke the handler with a full set of mocked arguments and response functions
                 await handler.process({
@@ -81,9 +69,6 @@ describe("Create data set handler", () => {
                                 // do nothing
                             })
                         }
-                    },
-                    profiles: {
-                        get: profFunc
                     }
                 } as any);
             } catch (e) {
@@ -91,7 +76,6 @@ describe("Create data set handler", () => {
             }
 
             expect(error).toBeUndefined();
-            expect(profFunc).toHaveBeenCalledWith("zosmf", false);
             expect(Create.dataSetLike).toHaveBeenCalledTimes(1);
             expect(Create.dataSetLike).toHaveBeenCalledWith(AbstractSession, dataSetName, likeDataSetName,{});
             expect(jsonObj).toMatchSnapshot();

--- a/packages/cli/__tests__/zosfiles/__unit__/create/pds/Pds.handler.unit.test.ts
+++ b/packages/cli/__tests__/zosfiles/__unit__/create/pds/Pds.handler.unit.test.ts
@@ -36,18 +36,6 @@ describe("Create PDS data set handler", () => {
                 };
             });
 
-            // Mocked function references
-            const profFunc = jest.fn((args) => {
-                return {
-                    host: "fake",
-                    port: "fake",
-                    user: "fake",
-                    password: "fake",
-                    auth: "fake",
-                    rejectUnauthorized: "fake"
-                };
-            });
-
             try {
                 // Invoke the handler with a full set of mocked arguments and response functions
                 await handler.process({
@@ -79,9 +67,6 @@ describe("Create PDS data set handler", () => {
                                 // do nothing
                             })
                         }
-                    },
-                    profiles: {
-                        get: profFunc
                     }
                 } as any);
             } catch (e) {
@@ -89,7 +74,6 @@ describe("Create PDS data set handler", () => {
             }
 
             expect(error).toBeUndefined();
-            expect(profFunc).toHaveBeenCalledWith("zosmf", false);
             expect(Create.dataSet).toHaveBeenCalledTimes(1);
             expect(Create.dataSet).toHaveBeenCalledWith(fakeSession, CreateDataSetTypeEnum.DATA_SET_PARTITIONED, dataSetName, {});
             expect(jsonObj).toMatchSnapshot();

--- a/packages/cli/__tests__/zosfiles/__unit__/create/ps/Ps.handler.unit.test.ts
+++ b/packages/cli/__tests__/zosfiles/__unit__/create/ps/Ps.handler.unit.test.ts
@@ -36,18 +36,6 @@ describe("Create PS data set handler", () => {
                 };
             });
 
-            // Mocked function references
-            const profFunc = jest.fn((args) => {
-                return {
-                    host: "fake",
-                    port: "fake",
-                    user: "fake",
-                    password: "fake",
-                    auth: "fake",
-                    rejectUnauthorized: "fake"
-                };
-            });
-
             try {
                 // Invoke the handler with a full set of mocked arguments and response functions
                 await handler.process({
@@ -79,9 +67,6 @@ describe("Create PS data set handler", () => {
                                 // do nothing
                             })
                         }
-                    },
-                    profiles: {
-                        get: profFunc
                     }
                 } as any);
             } catch (e) {
@@ -89,7 +74,6 @@ describe("Create PS data set handler", () => {
             }
 
             expect(error).toBeUndefined();
-            expect(profFunc).toHaveBeenCalledWith("zosmf", false);
             expect(Create.dataSet).toHaveBeenCalledTimes(1);
             expect(Create.dataSet).toHaveBeenCalledWith(fakeSession, CreateDataSetTypeEnum.DATA_SET_SEQUENTIAL, dataSetName, {});
             expect(jsonObj).toMatchSnapshot();

--- a/packages/cli/__tests__/zosfiles/__unit__/create/ussDir/ussDir.handler.unit.test.ts
+++ b/packages/cli/__tests__/zosfiles/__unit__/create/ussDir/ussDir.handler.unit.test.ts
@@ -38,18 +38,6 @@ describe("Create USS Directory", () => {
                 };
             });
 
-            // Mocked function references
-            const profFunc = jest.fn((args) => {
-                return {
-                    host: "fake",
-                    port: "fake",
-                    user: "fake",
-                    password: "fake",
-                    auth: "fake",
-                    rejectUnauthorized: "fake"
-                };
-            });
-
             try {
                 // Invoke the handler with a full set of mocked arguments and response functions
                 await handler.process({
@@ -81,9 +69,6 @@ describe("Create USS Directory", () => {
                                 // do nothing
                             })
                         }
-                    },
-                    profiles: {
-                        get: profFunc
                     }
                 } as any);
             } catch (e) {
@@ -91,7 +76,6 @@ describe("Create USS Directory", () => {
             }
 
             expect(error).toBeUndefined();
-            expect(profFunc).toHaveBeenCalledWith("zosmf", false);
             expect(Create.uss).toHaveBeenCalledTimes(1);
             expect(Create.uss).toHaveBeenCalledWith(fakeSession, undefined, "directory", undefined, zosFilesOptions);
             expect(jsonObj).toMatchSnapshot();

--- a/packages/cli/__tests__/zosfiles/__unit__/create/ussFile/ussFile.handler.unit.test.ts
+++ b/packages/cli/__tests__/zosfiles/__unit__/create/ussFile/ussFile.handler.unit.test.ts
@@ -38,18 +38,6 @@ describe("Create USS file", () => {
                 };
             });
 
-            // Mocked function references
-            const profFunc = jest.fn((args) => {
-                return {
-                    host: "fake",
-                    port: "fake",
-                    user: "fake",
-                    password: "fake",
-                    auth: "fake",
-                    rejectUnauthorized: "fake"
-                };
-            });
-
             try {
                 // Invoke the handler with a full set of mocked arguments and response functions
                 await handler.process({
@@ -81,9 +69,6 @@ describe("Create USS file", () => {
                                 // do nothing
                             })
                         }
-                    },
-                    profiles: {
-                        get: profFunc
                     }
                 } as any);
             } catch (e) {
@@ -91,7 +76,6 @@ describe("Create USS file", () => {
             }
 
             expect(error).toBeUndefined();
-            expect(profFunc).toHaveBeenCalledWith("zosmf", false);
             expect(Create.uss).toHaveBeenCalledTimes(1);
             expect(Create.uss).toHaveBeenCalledWith(fakeSession, undefined, "file", undefined, zosFilesOptions);
             expect(jsonObj).toMatchSnapshot();

--- a/packages/cli/__tests__/zosfiles/__unit__/create/vsam/Vsam.handler.unit.test.ts
+++ b/packages/cli/__tests__/zosfiles/__unit__/create/vsam/Vsam.handler.unit.test.ts
@@ -39,18 +39,6 @@ describe("Create VSAM data set handler", () => {
                 };
             });
 
-            // Mocked function references
-            const profFunc = jest.fn((args) => {
-                return {
-                    host: "fake",
-                    port: "fake",
-                    user: "fake",
-                    password: "fake",
-                    auth: "fake",
-                    rejectUnauthorized: "fake"
-                };
-            });
-
             try {
                 // Invoke the handler with a full set of mocked arguments and response functions
                 await handler.process({
@@ -82,9 +70,6 @@ describe("Create VSAM data set handler", () => {
                                 // do nothing
                             })
                         }
-                    },
-                    profiles: {
-                        get: profFunc
                     }
                 } as any);
             } catch (e) {
@@ -92,7 +77,6 @@ describe("Create VSAM data set handler", () => {
             }
 
             expect(error).toBeUndefined();
-            expect(profFunc).toHaveBeenCalledWith("zosmf", false);
             expect(Create.vsam).toHaveBeenCalledTimes(1);
             expect(Create.vsam).toHaveBeenCalledWith(fakeSession, dataSetName, {});
             expect(jsonObj).toMatchSnapshot();
@@ -123,18 +107,6 @@ describe("Create VSAM data set handler", () => {
             throw impErr;
         });
 
-        // Mocked function references
-        const profFunc = jest.fn((args) => {
-            return {
-                host: "fake",
-                port: "fake",
-                user: "fake",
-                password: "fake",
-                auth: "fake",
-                rejectUnauthorized: "fake"
-            };
-        });
-
         try {
             // Invoke the handler with a full set of mocked arguments and response functions
             await handler.process({
@@ -159,9 +131,6 @@ describe("Create VSAM data set handler", () => {
                             logMessage += "\n" + logArgs;
                         })
                     }
-                },
-                profiles: {
-                    get: profFunc
                 }
             } as any);
         } catch (e) {
@@ -169,7 +138,6 @@ describe("Create VSAM data set handler", () => {
         }
 
         expect(error).toBeDefined();
-        expect(profFunc).toHaveBeenCalledWith("zosmf", false);
         expect(Create.vsam).toHaveBeenCalledTimes(1);
         expect(Create.vsam).toHaveBeenCalledWith(fakeSession, dataSetName, {});
     });

--- a/packages/cli/__tests__/zosfiles/__unit__/create/zfs/zfs.handler.unit.test.ts
+++ b/packages/cli/__tests__/zosfiles/__unit__/create/zfs/zfs.handler.unit.test.ts
@@ -39,18 +39,6 @@ describe("Create z/OS file system handler", () => {
                 };
             });
 
-            // Mocked function references
-            const profFunc = jest.fn((args) => {
-                return {
-                    host: "fake",
-                    port: "fake",
-                    user: "fake",
-                    password: "fake",
-                    auth: "fake",
-                    rejectUnauthorized: "fake"
-                };
-            });
-
             try {
                 // Invoke the handler with a full set of mocked arguments and response functions
                 await handler.process({
@@ -82,9 +70,6 @@ describe("Create z/OS file system handler", () => {
                                 // do nothing
                             })
                         }
-                    },
-                    profiles: {
-                        get: profFunc
                     }
                 } as any);
             } catch (e) {
@@ -92,7 +77,6 @@ describe("Create z/OS file system handler", () => {
             }
 
             expect(error).toBeUndefined();
-            expect(profFunc).toHaveBeenCalledWith("zosmf", false);
             expect(Create.zfs).toHaveBeenCalledTimes(1);
             expect(Create.zfs).toHaveBeenCalledWith(fakeSession, fileSystemName, {});
             expect(jsonObj).toMatchSnapshot();
@@ -123,18 +107,6 @@ describe("Create z/OS file system handler", () => {
             throw impErr;
         });
 
-        // Mocked function references
-        const profFunc = jest.fn((args) => {
-            return {
-                host: "fake",
-                port: "fake",
-                user: "fake",
-                password: "fake",
-                auth: "fake",
-                rejectUnauthorized: "fake"
-            };
-        });
-
         try {
             // Invoke the handler with a full set of mocked arguments and response functions
             await handler.process({
@@ -159,9 +131,6 @@ describe("Create z/OS file system handler", () => {
                             logMessage += "\n" + logArgs;
                         })
                     }
-                },
-                profiles: {
-                    get: profFunc
                 }
             } as any);
         } catch (e) {
@@ -169,7 +138,6 @@ describe("Create z/OS file system handler", () => {
         }
 
         expect(error).toBeDefined();
-        expect(profFunc).toHaveBeenCalledWith("zosmf", false);
         expect(Create.zfs).toHaveBeenCalledTimes(1);
         expect(Create.zfs).toHaveBeenCalledWith(fakeSession, fileSystemName, {});
     });

--- a/packages/cli/__tests__/zosfiles/__unit__/download/am/AllMembers.handler.unit.test.ts
+++ b/packages/cli/__tests__/zosfiles/__unit__/download/am/AllMembers.handler.unit.test.ts
@@ -36,18 +36,6 @@ describe("Download AllMembers handler", () => {
                 };
             });
 
-            // Mocked function references
-            const profFunc = jest.fn((args) => {
-                return {
-                    host: "fake",
-                    port: "fake",
-                    user: "fake",
-                    password: "fake",
-                    auth: "fake",
-                    rejectUnauthorized: "fake"
-                };
-            });
-
             try {
                 // Invoke the handler with a full set of mocked arguments and response functions
                 await handler.process({
@@ -79,9 +67,6 @@ describe("Download AllMembers handler", () => {
                                 // do nothing
                             })
                         }
-                    },
-                    profiles: {
-                        get: profFunc
                     }
                 } as any);
             } catch (e) {
@@ -89,7 +74,6 @@ describe("Download AllMembers handler", () => {
             }
 
             expect(error).toBeUndefined();
-            expect(profFunc).toHaveBeenCalledWith("zosmf", false);
             expect(Download.allMembers).toHaveBeenCalledTimes(1);
             expect(Download.allMembers).toHaveBeenCalledWith(fakeSession, dataSetName, {
                 task: {
@@ -126,18 +110,6 @@ describe("Download AllMembers handler", () => {
                 };
             });
 
-            // Mocked function references
-            const profFunc = jest.fn((args) => {
-                return {
-                    host: "fake",
-                    port: "fake",
-                    user: "fake",
-                    password: "fake",
-                    auth: "fake",
-                    rejectUnauthorized: "fake"
-                };
-            });
-
             try {
                 // Invoke the handler with a full set of mocked arguments and response functions
                 await handler.process({
@@ -170,9 +142,6 @@ describe("Download AllMembers handler", () => {
                                 // do nothing
                             })
                         }
-                    },
-                    profiles: {
-                        get: profFunc
                     }
                 } as any);
             } catch (e) {
@@ -180,7 +149,6 @@ describe("Download AllMembers handler", () => {
             }
 
             expect(error).toBeUndefined();
-            expect(profFunc).toHaveBeenCalledWith("zosmf", false);
             expect(Download.allMembers).toHaveBeenCalledTimes(1);
             expect(Download.allMembers).toHaveBeenCalledWith(fakeSession, dataSetName, {
                 binary,
@@ -218,18 +186,6 @@ describe("Download AllMembers handler", () => {
                 };
             });
 
-            // Mocked function references
-            const profFunc = jest.fn((args) => {
-                return {
-                    host: "fake",
-                    port: "fake",
-                    user: "fake",
-                    password: "fake",
-                    auth: "fake",
-                    rejectUnauthorized: "fake"
-                };
-            });
-
             try {
                 // Invoke the handler with a full set of mocked arguments and response functions
                 await handler.process({
@@ -262,9 +218,6 @@ describe("Download AllMembers handler", () => {
                                 // do nothing
                             })
                         }
-                    },
-                    profiles: {
-                        get: profFunc
                     }
                 } as any);
             } catch (e) {
@@ -272,7 +225,6 @@ describe("Download AllMembers handler", () => {
             }
 
             expect(error).toBeUndefined();
-            expect(profFunc).toHaveBeenCalledWith("zosmf", false);
             expect(Download.allMembers).toHaveBeenCalledTimes(1);
             expect(Download.allMembers).toHaveBeenCalledWith(fakeSession, dataSetName, {
                 record,

--- a/packages/cli/__tests__/zosfiles/__unit__/download/ds/Dataset.handler.unit.test.ts
+++ b/packages/cli/__tests__/zosfiles/__unit__/download/ds/Dataset.handler.unit.test.ts
@@ -36,18 +36,6 @@ describe("Download data set handler", () => {
                 };
             });
 
-            // Mocked function references
-            const profFunc = jest.fn((args) => {
-                return {
-                    host: "fake",
-                    port: "fake",
-                    user: "fake",
-                    password: "fake",
-                    auth: "fake",
-                    rejectUnauthorized: "fake"
-                };
-            });
-
             try {
                 // Invoke the handler with a full set of mocked arguments and response functions
                 await handler.process({
@@ -79,9 +67,6 @@ describe("Download data set handler", () => {
                                 // do nothing
                             })
                         }
-                    },
-                    profiles: {
-                        get: profFunc
                     }
                 } as any);
             } catch (e) {
@@ -89,7 +74,6 @@ describe("Download data set handler", () => {
             }
 
             expect(error).toBeUndefined();
-            expect(profFunc).toHaveBeenCalledWith("zosmf", false);
             expect(Download.dataSet).toHaveBeenCalledTimes(1);
             expect(Download.dataSet).toHaveBeenCalledWith(fakeSession, dataSetName, {
                 task: {
@@ -126,18 +110,6 @@ describe("Download data set handler", () => {
                 };
             });
 
-            // Mocked function references
-            const profFunc = jest.fn((args) => {
-                return {
-                    host: "fake",
-                    port: "fake",
-                    user: "fake",
-                    password: "fake",
-                    auth: "fake",
-                    rejectUnauthorized: "fake"
-                };
-            });
-
             try {
                 // Invoke the handler with a full set of mocked arguments and response functions
                 await handler.process({
@@ -170,9 +142,6 @@ describe("Download data set handler", () => {
                                 // do nothing
                             })
                         }
-                    },
-                    profiles: {
-                        get: profFunc
                     }
                 } as any);
             } catch (e) {
@@ -180,7 +149,6 @@ describe("Download data set handler", () => {
             }
 
             expect(error).toBeUndefined();
-            expect(profFunc).toHaveBeenCalledWith("zosmf", false);
             expect(Download.dataSet).toHaveBeenCalledTimes(1);
             expect(Download.dataSet).toHaveBeenCalledWith(fakeSession, dataSetName, {
                 record,
@@ -218,18 +186,6 @@ describe("Download data set handler", () => {
                 };
             });
 
-            // Mocked function references
-            const profFunc = jest.fn((args) => {
-                return {
-                    host: "fake",
-                    port: "fake",
-                    user: "fake",
-                    password: "fake",
-                    auth: "fake",
-                    rejectUnauthorized: "fake"
-                };
-            });
-
             try {
                 // Invoke the handler with a full set of mocked arguments and response functions
                 await handler.process({
@@ -262,9 +218,6 @@ describe("Download data set handler", () => {
                                 // do nothing
                             })
                         }
-                    },
-                    profiles: {
-                        get: profFunc
                     }
                 } as any);
             } catch (e) {
@@ -272,7 +225,6 @@ describe("Download data set handler", () => {
             }
 
             expect(error).toBeUndefined();
-            expect(profFunc).toHaveBeenCalledWith("zosmf", false);
             expect(Download.dataSet).toHaveBeenCalledTimes(1);
             expect(Download.dataSet).toHaveBeenCalledWith(fakeSession, dataSetName, {
                 binary,

--- a/packages/cli/__tests__/zosfiles/__unit__/download/uss/UssFile.handler.unit.test.ts
+++ b/packages/cli/__tests__/zosfiles/__unit__/download/uss/UssFile.handler.unit.test.ts
@@ -36,18 +36,6 @@ describe("Download uss file handler", () => {
                 };
             });
 
-            // Mocked function references
-            const profFunc = jest.fn((args) => {
-                return {
-                    host: "fake",
-                    port: "fake",
-                    user: "fake",
-                    password: "fake",
-                    auth: "fake",
-                    rejectUnauthorized: "fake"
-                };
-            });
-
             try {
                 // Invoke the handler with a full set of mocked arguments and response functions
                 await handler.process({
@@ -79,9 +67,6 @@ describe("Download uss file handler", () => {
                                 // do nothing
                             })
                         }
-                    },
-                    profiles: {
-                        get: profFunc
                     }
                 } as any);
             } catch (e) {
@@ -89,7 +74,6 @@ describe("Download uss file handler", () => {
             }
 
             expect(error).toBeUndefined();
-            expect(profFunc).toHaveBeenCalledWith("zosmf", false);
             expect(Download.ussFile).toHaveBeenCalledTimes(1);
             expect(Download.ussFile).toHaveBeenCalledWith(fakeSession, ussFileName, {
                 task: {

--- a/packages/cli/__tests__/zosfiles/__unit__/invoke/amsFile/AmsFile.handler.unit.test.ts
+++ b/packages/cli/__tests__/zosfiles/__unit__/invoke/amsFile/AmsFile.handler.unit.test.ts
@@ -19,18 +19,6 @@ describe("Invoke AMS files handler", () => {
         const handler = new handlerReq.default();
         let fakeSession: any = null;
 
-        // Mocked function references
-        const profFunc = jest.fn((args) => {
-            return {
-                host: "fake",
-                port: "fake",
-                user: "fake",
-                password: "fake",
-                auth: "fake",
-                rejectUnauthorized: "fake"
-            };
-        });
-
         beforeEach(() => {
             // Mock the submit JCL function
             Invoke.ams = jest.fn((session) => {
@@ -84,9 +72,6 @@ describe("Invoke AMS files handler", () => {
                                 // do nothing
                             })
                         }
-                    },
-                    profiles: {
-                        get: profFunc
                     }
                 } as any);
             } catch (e) {
@@ -94,7 +79,6 @@ describe("Invoke AMS files handler", () => {
             }
 
             expect(error).toBeUndefined();
-            expect(profFunc).toHaveBeenCalledWith("zosmf", false);
             expect(Invoke.ams).toHaveBeenCalledTimes(1);
             expect(Invoke.ams).toHaveBeenCalledWith(fakeSession, controlStatementsFile, options);
             expect(jsonObj).toMatchSnapshot();

--- a/packages/cli/__tests__/zosfiles/__unit__/invoke/amsStatements/AmsStatements.handler.unit.test.ts
+++ b/packages/cli/__tests__/zosfiles/__unit__/invoke/amsStatements/AmsStatements.handler.unit.test.ts
@@ -19,18 +19,6 @@ describe("Invoke AMS statements handler", () => {
         const handler = new handlerReq.default();
         let fakeSession: any = null;
 
-        // Mocked function references
-        const profFunc = jest.fn((args) => {
-            return {
-                host: "fake",
-                port: "fake",
-                user: "fake",
-                password: "fake",
-                auth: "fake",
-                rejectUnauthorized: "fake"
-            };
-        });
-
         beforeEach(() => {
             // Mock the submit JCL function
             Invoke.ams = jest.fn((session) => {
@@ -84,9 +72,6 @@ describe("Invoke AMS statements handler", () => {
                                 // do nothing
                             })
                         }
-                    },
-                    profiles: {
-                        get: profFunc
                     }
                 } as any);
             } catch (e) {
@@ -94,7 +79,6 @@ describe("Invoke AMS statements handler", () => {
             }
 
             expect(error).toBeUndefined();
-            expect(profFunc).toHaveBeenCalledWith("zosmf", false);
             expect(Invoke.ams).toHaveBeenCalledTimes(1);
             expect(Invoke.ams).toHaveBeenCalledWith(fakeSession, [controlStatements], options);
             expect(jsonObj).toMatchSnapshot();

--- a/packages/cli/__tests__/zosfiles/__unit__/list/am/AllMembers.handler.unit.test.ts
+++ b/packages/cli/__tests__/zosfiles/__unit__/list/am/AllMembers.handler.unit.test.ts
@@ -39,18 +39,6 @@ describe("List AllMembers handler", () => {
                 };
             });
 
-            // Mocked function references
-            const profFunc = jest.fn((args) => {
-                return {
-                    host: "fake",
-                    port: "fake",
-                    user: "fake",
-                    password: "fake",
-                    auth: "fake",
-                    rejectUnauthorized: "fake"
-                };
-            });
-
             try {
                 // Invoke the handler with a full set of mocked arguments and response functions
                 await handler.process({
@@ -82,9 +70,6 @@ describe("List AllMembers handler", () => {
                                 // do nothing
                             })
                         }
-                    },
-                    profiles: {
-                        get: profFunc
                     }
                 } as any);
             } catch (e) {
@@ -92,7 +77,6 @@ describe("List AllMembers handler", () => {
             }
 
             expect(error).toBeUndefined();
-            expect(profFunc).toHaveBeenCalledWith("zosmf", false);
             expect(List.allMembers).toHaveBeenCalledTimes(1);
             expect(List.allMembers).toHaveBeenCalledWith(fakeSession, dataSetName, {});
             expect(jsonObj).toMatchSnapshot();

--- a/packages/cli/__tests__/zosfiles/__unit__/list/ds/Dataset.handler.unit.test.ts
+++ b/packages/cli/__tests__/zosfiles/__unit__/list/ds/Dataset.handler.unit.test.ts
@@ -38,18 +38,6 @@ describe("List Dataset handler", () => {
                 };
             });
 
-            // Mocked function references
-            const profFunc = jest.fn((args) => {
-                return {
-                    host: "fake",
-                    port: "fake",
-                    user: "fake",
-                    password: "fake",
-                    auth: "fake",
-                    rejectUnauthorized: "fake"
-                };
-            });
-
             // Invoke the handler with a full set of mocked arguments and response functions
             await handler.process({
                 arguments: {
@@ -80,13 +68,9 @@ describe("List Dataset handler", () => {
                             // do nothing
                         })
                     }
-                },
-                profiles: {
-                    get: profFunc
                 }
             } as any);
 
-            expect(profFunc).toHaveBeenCalledWith("zosmf", false);
             expect(List.dataSet).toHaveBeenCalledTimes(1);
             expect(List.dataSet).toHaveBeenCalledWith(fakeSession, dataSetName, {});
             expect(jsonObj).toMatchSnapshot();

--- a/packages/cli/__tests__/zosfiles/__unit__/list/fs/Fs.handler.unit.test.ts
+++ b/packages/cli/__tests__/zosfiles/__unit__/list/fs/Fs.handler.unit.test.ts
@@ -38,18 +38,6 @@ describe("fs handler", () => {
                 };
             });
 
-            // Mocked function references
-            const profFunc = jest.fn((args) => {
-                return {
-                    host: "fake",
-                    port: "fake",
-                    user: "fake",
-                    password: "fake",
-                    auth: "fake",
-                    rejectUnauthorized: "fake"
-                };
-            });
-
             try {
                 // Invoke the handler with a full set of mocked arguments and response functions
                 await handler.process({
@@ -81,9 +69,6 @@ describe("fs handler", () => {
                                 // do nothing
                             })
                         }
-                    },
-                    profiles: {
-                        get: profFunc
                     }
                 } as any);
             } catch (e) {
@@ -91,7 +76,6 @@ describe("fs handler", () => {
             }
 
             //            expect(error).toBeUndefined();
-            expect(profFunc).toHaveBeenCalledWith("zosmf", false);
             expect(List.fs).toHaveBeenCalledTimes(1);
             expect(List.fs).toHaveBeenCalledWith(fakeSession, {fsname: undefined, maxLength: undefined, path: null});
             expect(jsonObj).toMatchSnapshot();
@@ -121,18 +105,6 @@ describe("fs handler", () => {
                     apiResponse: {
                         items: ["test-items"]
                     }
-                };
-            });
-
-            // Mocked function references
-            const profFunc = jest.fn((args) => {
-                return {
-                    host: "fake",
-                    port: "fake",
-                    user: "fake",
-                    password: "fake",
-                    auth: "fake",
-                    rejectUnauthorized: "fake"
                 };
             });
 
@@ -167,9 +139,6 @@ describe("fs handler", () => {
                                 // do nothing
                             })
                         }
-                    },
-                    profiles: {
-                        get: profFunc
                     }
                 } as any);
             } catch (e) {
@@ -177,7 +146,6 @@ describe("fs handler", () => {
             }
 
             //            expect(error).toBeUndefined();
-            expect(profFunc).toHaveBeenCalledWith("zosmf", false);
             expect(List.fsWithPath).toHaveBeenCalledTimes(1);
             expect(List.fsWithPath).toHaveBeenCalledWith(fakeSession, {fsname: null, maxLength: undefined, path: "testing"});
             expect(jsonObj).toMatchSnapshot();

--- a/packages/cli/__tests__/zosfiles/__unit__/list/uss/Uss.handler.unit.test.ts
+++ b/packages/cli/__tests__/zosfiles/__unit__/list/uss/Uss.handler.unit.test.ts
@@ -39,18 +39,6 @@ describe("USS file handler", () => {
                 };
             });
 
-            // Mocked function references
-            const profFunc = jest.fn((args) => {
-                return {
-                    host: "fake",
-                    port: "fake",
-                    user: "fake",
-                    password: "fake",
-                    auth: "fake",
-                    rejectUnauthorized: "fake"
-                };
-            });
-
             try {
                 // Invoke the handler with a full set of mocked arguments and response functions
                 await handler.process({
@@ -82,9 +70,6 @@ describe("USS file handler", () => {
                                 // do nothing
                             })
                         }
-                    },
-                    profiles: {
-                        get: profFunc
                     }
                 } as any);
             } catch (e) {
@@ -92,7 +77,6 @@ describe("USS file handler", () => {
             }
 
             //            expect(error).toBeUndefined();
-            expect(profFunc).toHaveBeenCalledWith("zosmf", false);
             expect(List.fileList).toHaveBeenCalledTimes(1);
             expect(List.fileList).toHaveBeenCalledWith(fakeSession, path, {});
             expect(jsonObj).toMatchSnapshot();

--- a/packages/cli/__tests__/zosfiles/__unit__/mount/fs/fs.handler.unit.test.ts
+++ b/packages/cli/__tests__/zosfiles/__unit__/mount/fs/fs.handler.unit.test.ts
@@ -40,18 +40,6 @@ describe("Mount file system handler", () => {
                 };
             });
 
-            // Mocked function references
-            const profFunc = jest.fn((args) => {
-                return {
-                    host: "fake",
-                    port: "fake",
-                    user: "fake",
-                    password: "fake",
-                    auth: "fake",
-                    rejectUnauthorized: "fake"
-                };
-            });
-
             try {
                 // Invoke the handler with a full set of mocked arguments and response functions
                 await handler.process({
@@ -84,9 +72,6 @@ describe("Mount file system handler", () => {
                                 // do nothing
                             })
                         }
-                    },
-                    profiles: {
-                        get: profFunc
                     }
                 } as any);
             } catch (e) {
@@ -94,7 +79,6 @@ describe("Mount file system handler", () => {
             }
 
             expect(error).toBeUndefined();
-            expect(profFunc).toHaveBeenCalledWith("zosmf", false);
             expect(Mount.fs).toHaveBeenCalledTimes(1);
             expect(Mount.fs).toHaveBeenCalledWith(fakeSession, fileSystemName, mountPoint, {});
             expect(jsonObj).toMatchSnapshot();
@@ -126,18 +110,6 @@ describe("Mount file system handler", () => {
             throw impErr;
         });
 
-        // Mocked function references
-        const profFunc = jest.fn((args) => {
-            return {
-                host: "fake",
-                port: "fake",
-                user: "fake",
-                password: "fake",
-                auth: "fake",
-                rejectUnauthorized: "fake"
-            };
-        });
-
         try {
             // Invoke the handler with a full set of mocked arguments and response functions
             await handler.process({
@@ -163,9 +135,6 @@ describe("Mount file system handler", () => {
                             logMessage += "\n" + logArgs;
                         })
                     }
-                },
-                profiles: {
-                    get: profFunc
                 }
             } as any);
         } catch (e) {
@@ -173,7 +142,6 @@ describe("Mount file system handler", () => {
         }
 
         expect(error).toBeDefined();
-        expect(profFunc).toHaveBeenCalledWith("zosmf", false);
         expect(Mount.fs).toHaveBeenCalledTimes(1);
         expect(Mount.fs).toHaveBeenCalledWith(fakeSession, fileSystemName, mountPoint, {});
     });

--- a/packages/cli/__tests__/zosfiles/__unit__/upload/dtp/DirToPds.handler.unit.test.ts
+++ b/packages/cli/__tests__/zosfiles/__unit__/upload/dtp/DirToPds.handler.unit.test.ts
@@ -42,18 +42,6 @@ describe("Upload dir-to-pds handler", () => {
                 };
             });
 
-            // Mocked function references
-            const profFunc = jest.fn((args) => {
-                return {
-                    host: "fake",
-                    port: "fake",
-                    user: "fake",
-                    password: "fake",
-                    auth: "fake",
-                    rejectUnauthorized: "fake"
-                };
-            });
-
             try {
                 // Invoke the handler with a full set of mocked arguments and response functions
                 await handler.process({
@@ -86,9 +74,6 @@ describe("Upload dir-to-pds handler", () => {
                                 // do nothing
                             })
                         }
-                    },
-                    profiles: {
-                        get: profFunc
                     }
                 } as any);
             } catch (e) {
@@ -96,7 +81,6 @@ describe("Upload dir-to-pds handler", () => {
             }
 
             expect(error).toBeDefined();
-            expect(profFunc).toHaveBeenCalledWith("zosmf", false);
             expect(Upload.dirToPds).toHaveBeenCalledTimes(1);
             expect(Upload.dirToPds).toHaveBeenCalledWith(fakeSession, inputdir, dataSetName, {
                 task: {
@@ -139,18 +123,6 @@ describe("Upload dir-to-pds handler", () => {
                 };
             });
 
-            // Mocked function references
-            const profFunc = jest.fn((args) => {
-                return {
-                    host: "fake",
-                    port: "fake",
-                    user: "fake",
-                    password: "fake",
-                    auth: "fake",
-                    rejectUnauthorized: "fake"
-                };
-            });
-
             try {
                 // Invoke the handler with a full set of mocked arguments and response functions
                 await handler.process({
@@ -184,9 +156,6 @@ describe("Upload dir-to-pds handler", () => {
                                 // do nothing
                             })
                         }
-                    },
-                    profiles: {
-                        get: profFunc
                     }
                 } as any);
             } catch (e) {
@@ -194,7 +163,6 @@ describe("Upload dir-to-pds handler", () => {
             }
 
             expect(error).toBeDefined();
-            expect(profFunc).toHaveBeenCalledWith("zosmf", false);
             expect(Upload.dirToPds).toHaveBeenCalledTimes(1);
             expect(Upload.dirToPds).toHaveBeenCalledWith(fakeSession, inputdir, dataSetName, {
                 binary,
@@ -238,18 +206,6 @@ describe("Upload dir-to-pds handler", () => {
                 };
             });
 
-            // Mocked function references
-            const profFunc = jest.fn((args) => {
-                return {
-                    host: "fake",
-                    port: "fake",
-                    user: "fake",
-                    password: "fake",
-                    auth: "fake",
-                    rejectUnauthorized: "fake"
-                };
-            });
-
             try {
                 // Invoke the handler with a full set of mocked arguments and response functions
                 await handler.process({
@@ -283,9 +239,6 @@ describe("Upload dir-to-pds handler", () => {
                                 // do nothing
                             })
                         }
-                    },
-                    profiles: {
-                        get: profFunc
                     }
                 } as any);
             } catch (e) {
@@ -293,7 +246,6 @@ describe("Upload dir-to-pds handler", () => {
             }
 
             expect(error).toBeDefined();
-            expect(profFunc).toHaveBeenCalledWith("zosmf", false);
             expect(Upload.dirToPds).toHaveBeenCalledTimes(1);
             expect(Upload.dirToPds).toHaveBeenCalledWith(fakeSession, inputdir, dataSetName, {
                 record,

--- a/packages/cli/__tests__/zosfiles/__unit__/upload/dtu/DirToUSS.handler.unit.test.ts
+++ b/packages/cli/__tests__/zosfiles/__unit__/upload/dtu/DirToUSS.handler.unit.test.ts
@@ -64,18 +64,6 @@ describe("Upload dir-to-uss handler", () => {
                         // do nothing
                     })
                 }
-            },
-            profiles: {
-                get: jest.fn((args) => {
-                    return {
-                        host: "fake",
-                        port: "fake",
-                        user: "fake",
-                        password: "fake",
-                        auth: "fake",
-                        rejectUnauthorized: "fake"
-                    };
-                })
             }
         };
 
@@ -190,7 +178,6 @@ describe("Upload dir-to-uss handler", () => {
             }
 
             expect(error).toBeDefined();
-            expect(params.profiles.get).toHaveBeenCalledWith("zosmf", false);
             expect(jsonObj).toMatchSnapshot();
             expect(apiMessage).toMatchSnapshot();
             expect(logMessage).toMatchSnapshot();

--- a/packages/cli/__tests__/zosfiles/__unit__/upload/ftds/FileToDataSet.handler.unit.test.ts
+++ b/packages/cli/__tests__/zosfiles/__unit__/upload/ftds/FileToDataSet.handler.unit.test.ts
@@ -40,18 +40,6 @@ describe("Upload file-to-data-set handler", () => {
                 };
             });
 
-            // Mocked function references
-            const profFunc = jest.fn((args) => {
-                return {
-                    host: "fake",
-                    port: "fake",
-                    user: "fake",
-                    password: "fake",
-                    auth: "fake",
-                    rejectUnauthorized: "fake"
-                };
-            });
-
             try {
                 // Invoke the handler with a full set of mocked arguments and response functions
                 await handler.process({
@@ -84,9 +72,6 @@ describe("Upload file-to-data-set handler", () => {
                                 // do nothing
                             })
                         }
-                    },
-                    profiles: {
-                        get: profFunc
                     }
                 } as any);
             } catch (e) {
@@ -94,7 +79,6 @@ describe("Upload file-to-data-set handler", () => {
             }
 
             expect(error).toBeUndefined();
-            expect(profFunc).toHaveBeenCalledWith("zosmf", false);
             expect(Upload.fileToDataset).toHaveBeenCalledTimes(1);
             expect(Upload.fileToDataset).toHaveBeenCalledWith(fakeSession, inputfile, dataSetName, {
                 task: {
@@ -135,18 +119,6 @@ describe("Upload file-to-data-set handler", () => {
                 };
             });
 
-            // Mocked function references
-            const profFunc = jest.fn((args) => {
-                return {
-                    host: "fake",
-                    port: "fake",
-                    user: "fake",
-                    password: "fake",
-                    auth: "fake",
-                    rejectUnauthorized: "fake"
-                };
-            });
-
             try {
                 // Invoke the handler with a full set of mocked arguments and response functions
                 await handler.process({
@@ -180,9 +152,6 @@ describe("Upload file-to-data-set handler", () => {
                                 // do nothing
                             })
                         }
-                    },
-                    profiles: {
-                        get: profFunc
                     }
                 } as any);
             } catch (e) {
@@ -190,7 +159,6 @@ describe("Upload file-to-data-set handler", () => {
             }
 
             expect(error).toBeUndefined();
-            expect(profFunc).toHaveBeenCalledWith("zosmf", false);
             expect(Upload.fileToDataset).toHaveBeenCalledTimes(1);
             expect(Upload.fileToDataset).toHaveBeenCalledWith(fakeSession, inputfile, dataSetName, {
                 binary,
@@ -232,18 +200,6 @@ describe("Upload file-to-data-set handler", () => {
                 };
             });
 
-            // Mocked function references
-            const profFunc = jest.fn((args) => {
-                return {
-                    host: "fake",
-                    port: "fake",
-                    user: "fake",
-                    password: "fake",
-                    auth: "fake",
-                    rejectUnauthorized: "fake"
-                };
-            });
-
             try {
                 // Invoke the handler with a full set of mocked arguments and response functions
                 await handler.process({
@@ -277,9 +233,6 @@ describe("Upload file-to-data-set handler", () => {
                                 // do nothing
                             })
                         }
-                    },
-                    profiles: {
-                        get: profFunc
                     }
                 } as any);
             } catch (e) {
@@ -287,7 +240,6 @@ describe("Upload file-to-data-set handler", () => {
             }
 
             expect(error).toBeUndefined();
-            expect(profFunc).toHaveBeenCalledWith("zosmf", false);
             expect(Upload.fileToDataset).toHaveBeenCalledTimes(1);
             expect(Upload.fileToDataset).toHaveBeenCalledWith(fakeSession, inputfile, dataSetName, {
                 record,
@@ -328,18 +280,6 @@ describe("Upload file-to-data-set handler", () => {
                 };
             });
 
-            // Mocked function references
-            const profFunc = jest.fn((args) => {
-                return {
-                    host: "fake",
-                    port: "fake",
-                    user: "fake",
-                    password: "fake",
-                    auth: "fake",
-                    rejectUnauthorized: "fake"
-                };
-            });
-
             try {
                 // Invoke the handler with a full set of mocked arguments and response functions
                 await handler.process({
@@ -371,9 +311,6 @@ describe("Upload file-to-data-set handler", () => {
                             startBar: jest.fn(),
                             endBar: jest.fn()
                         }
-                    },
-                    profiles: {
-                        get: profFunc
                     }
                 } as any);
             } catch (e) {
@@ -382,7 +319,6 @@ describe("Upload file-to-data-set handler", () => {
 
             expect(error).toBeDefined();
             expect(error.message).toBe("uploaded");
-            expect(profFunc).toHaveBeenCalledWith("zosmf", false);
             expect(Upload.fileToDataset).toHaveBeenCalledTimes(1);
             expect(Upload.fileToDataset).toHaveBeenCalledWith(fakeSession, inputfile, dataSetName, {
                 binary: undefined,

--- a/packages/cli/__tests__/zosfiles/__unit__/upload/ftds/FileToDataSet.handler.unit.test.ts
+++ b/packages/cli/__tests__/zosfiles/__unit__/upload/ftds/FileToDataSet.handler.unit.test.ts
@@ -331,7 +331,13 @@ describe("Upload file-to-data-set handler", () => {
             });
             expect(jsonObj).toMatchSnapshot();
             expect(apiMessage).toMatchSnapshot();
-            expect(logMessage).toMatchSnapshot();
+            expect(logMessage).toMatch(/success:.*false/);
+            expect(logMessage).toMatch(/from:.*test-file/);
+            expect(logMessage).toMatch(/file_to_upload:.*1/);
+            expect(logMessage).toMatch(/success:.*0/);
+            expect(logMessage).toMatch(/error:.*1/);
+            expect(logMessage).toMatch(/skipped:.*0/);
+            expect(logMessage).toMatch(/uploaded/);
         });
     });
 });

--- a/packages/cli/__tests__/zosfiles/__unit__/upload/ftds/__snapshots__/FileToDataSet.handler.unit.test.ts.snap
+++ b/packages/cli/__tests__/zosfiles/__unit__/upload/ftds/__snapshots__/FileToDataSet.handler.unit.test.ts.snap
@@ -18,11 +18,11 @@ exports[`Upload file-to-data-set handler process method should display error whe
 
 exports[`Upload file-to-data-set handler process method should display error when upload file to data set 3`] = `
 "
-[31m[33msuccess: [31m[31mfalse[31m[39m
-[31m[33mfrom: [31m   test-file[39m
-[31m[33mto: [31m     testing[39m
-[31m[39m
-[31m[39m
+[33msuccess: [39m[31mfalse[39m
+[33mfrom: [39m   test-file
+[33mto: [39m     testing
+
+
 [33mfile_to_upload: [39m[34m1[39m
 [33msuccess: [39m       [34m0[39m
 [33merror: [39m         [34m1[39m

--- a/packages/cli/__tests__/zosfiles/__unit__/upload/ftds/__snapshots__/FileToDataSet.handler.unit.test.ts.snap
+++ b/packages/cli/__tests__/zosfiles/__unit__/upload/ftds/__snapshots__/FileToDataSet.handler.unit.test.ts.snap
@@ -16,22 +16,6 @@ Object {
 
 exports[`Upload file-to-data-set handler process method should display error when upload file to data set 2`] = `""`;
 
-exports[`Upload file-to-data-set handler process method should display error when upload file to data set 3`] = `
-"
-[33msuccess: [39m[31mfalse[39m
-[33mfrom: [39m   test-file
-[33mto: [39m     testing
-
-
-[33mfile_to_upload: [39m[34m1[39m
-[33msuccess: [39m       [34m0[39m
-[33merror: [39m         [34m1[39m
-[33mskipped: [39m       [34m0[39m
-
-
-uploaded"
-`;
-
 exports[`Upload file-to-data-set handler process method should upload a file to a data set if requested 1`] = `
 Object {
   "apiResponse": Array [

--- a/packages/cli/__tests__/zosfiles/__unit__/upload/ftu/FileToUSS.handler.unit.test.ts
+++ b/packages/cli/__tests__/zosfiles/__unit__/upload/ftu/FileToUSS.handler.unit.test.ts
@@ -40,18 +40,6 @@ describe("Upload file-to-uss handler", () => {
                 };
             });
 
-            // Mocked function references
-            const profFunc = jest.fn((args) => {
-                return {
-                    host: "fake",
-                    port: "fake",
-                    user: "fake",
-                    password: "fake",
-                    auth: "fake",
-                    rejectUnauthorized: "fake"
-                };
-            });
-
             try {
                 // Invoke the handler with a full set of mocked arguments and response functions
                 await handler.process({
@@ -84,9 +72,6 @@ describe("Upload file-to-uss handler", () => {
                                 // do nothing
                             })
                         }
-                    },
-                    profiles: {
-                        get: profFunc
                     }
                 } as any);
             } catch (e) {
@@ -94,7 +79,6 @@ describe("Upload file-to-uss handler", () => {
             }
 
             expect(error).toBeUndefined();
-            expect(profFunc).toHaveBeenCalledWith("zosmf", false);
             expect(Upload.fileToUssFile).toHaveBeenCalledTimes(1);
             expect(Upload.fileToUssFile).toHaveBeenCalledWith(fakeSession, inputfile, USSFileName, {
                 binary: undefined,

--- a/packages/cli/__tests__/zosfiles/__unit__/upload/stds/StdinToDataSet.handler.unit.test.ts
+++ b/packages/cli/__tests__/zosfiles/__unit__/upload/stds/StdinToDataSet.handler.unit.test.ts
@@ -37,18 +37,6 @@ describe("Upload stdin-to-data-set handler", () => {
                 };
             });
 
-            // Mocked function references
-            const profFunc = jest.fn((args) => {
-                return {
-                    host: "fake",
-                    port: "fake",
-                    user: "fake",
-                    password: "fake",
-                    auth: "fake",
-                    rejectUnauthorized: "fake"
-                };
-            });
-
             process.nextTick(() => {
                 process.stdin.emit("data", Buffer.from("test-data"));
                 process.stdin.emit("end");
@@ -86,9 +74,6 @@ describe("Upload stdin-to-data-set handler", () => {
                                 // do nothing
                             })
                         }
-                    },
-                    profiles: {
-                        get: profFunc
                     }
                 } as any);
             } catch (e) {
@@ -96,7 +81,6 @@ describe("Upload stdin-to-data-set handler", () => {
             }
 
             expect(error).toBeUndefined();
-            expect(profFunc).toHaveBeenCalledWith("zosmf", false);
             expect(Upload.streamToDataSet).toHaveBeenCalledTimes(1);
         });
 
@@ -121,18 +105,6 @@ describe("Upload stdin-to-data-set handler", () => {
                 return {
                     success: true,
                     commandResponse: "uploaded"
-                };
-            });
-
-            // Mocked function references
-            const profFunc = jest.fn((args) => {
-                return {
-                    host: "fake",
-                    port: "fake",
-                    user: "fake",
-                    password: "fake",
-                    auth: "fake",
-                    rejectUnauthorized: "fake"
                 };
             });
 
@@ -174,9 +146,6 @@ describe("Upload stdin-to-data-set handler", () => {
                                 // do nothing
                             })
                         }
-                    },
-                    profiles: {
-                        get: profFunc
                     }
                 } as any);
             } catch (e) {
@@ -192,7 +161,6 @@ describe("Upload stdin-to-data-set handler", () => {
                     statusMessage: "Uploading stdin to data set"
                 }
             });
-            expect(profFunc).toHaveBeenCalledWith("zosmf", false);
             expect(Upload.streamToDataSet).toHaveBeenCalledTimes(1);
         });
 
@@ -217,18 +185,6 @@ describe("Upload stdin-to-data-set handler", () => {
                 return {
                     success: true,
                     commandResponse: "uploaded"
-                };
-            });
-
-            // Mocked function references
-            const profFunc = jest.fn((args) => {
-                return {
-                    host: "fake",
-                    port: "fake",
-                    user: "fake",
-                    password: "fake",
-                    auth: "fake",
-                    rejectUnauthorized: "fake"
                 };
             });
 
@@ -270,9 +226,6 @@ describe("Upload stdin-to-data-set handler", () => {
                                 // do nothing
                             })
                         }
-                    },
-                    profiles: {
-                        get: profFunc
                     }
                 } as any);
             } catch (e) {
@@ -288,7 +241,6 @@ describe("Upload stdin-to-data-set handler", () => {
                     statusMessage: "Uploading stdin to data set"
                 }
             });
-            expect(profFunc).toHaveBeenCalledWith("zosmf", false);
             expect(Upload.streamToDataSet).toHaveBeenCalledTimes(1);
         });
     });

--- a/packages/cli/src/zosfiles/ZosFilesBase.handler.ts
+++ b/packages/cli/src/zosfiles/ZosFilesBase.handler.ts
@@ -41,8 +41,6 @@ export abstract class ZosFilesBaseHandler implements ICommandHandler {
      * @returns {Promise<void>}
      */
     public async process(commandParameters: IHandlerParameters) {
-        const profile = commandParameters.profiles.get("zosmf", false);
-
         const sessCfg: ISession = ZosmfSession.createSessCfgFromArgs(
             commandParameters.arguments
         );
@@ -51,7 +49,7 @@ export abstract class ZosFilesBaseHandler implements ICommandHandler {
         );
 
         const session = new Session(sessCfgWithCreds);
-        const response = await this.processWithSession(commandParameters, session, profile);
+        const response = await this.processWithSession(commandParameters, session);
 
         commandParameters.response.progress.endBar(); // end any progress bars
         // Print out the response
@@ -85,6 +83,11 @@ export abstract class ZosFilesBaseHandler implements ICommandHandler {
     public abstract async processWithSession(
         commandParameters: IHandlerParameters,
         session: AbstractSession,
-        zosmfProfile: IProfile
+        /* Never use the following deprecated zosmfProfile parameter.
+         * It should have been removed for the V2 version of Zowe, but we missed it.
+         * There is no good reason to use it. Better techniques exist, and are
+         * implemented in all of the implementations of this abstract function.
+         */
+        zosmfProfile?: IProfile
     ): Promise<IZosFilesResponse>;
 }

--- a/packages/cli/src/zosfiles/ZosFilesBase.handler.ts
+++ b/packages/cli/src/zosfiles/ZosFilesBase.handler.ts
@@ -77,17 +77,17 @@ export abstract class ZosFilesBaseHandler implements ICommandHandler {
      * @param {IHandlerParameters} commandParameters Command parameters sent to the handler.
      * @param {AbstractSession} session The session object generated from the zosmf profile.
      * @param {IProfile} zosmfProfile The zosmf profile that was loaded for the command.
+     * @deprecated
+     *        Never use this deprecated zosmfProfile parameter.
+     *        It should have been removed for the V2 version of Zowe, but we missed it.
+     *        There is no good reason to use it. Better techniques exist, and are
+     *        implemented in all of the implementations of this abstract class.
      *
      * @returns {Promise<IZosFilesResponse>} The response from the underlying zos-files api call.
      */
     public abstract async processWithSession(
         commandParameters: IHandlerParameters,
         session: AbstractSession,
-        /* Never use the following deprecated zosmfProfile parameter.
-         * It should have been removed for the V2 version of Zowe, but we missed it.
-         * There is no good reason to use it. Better techniques exist, and are
-         * implemented in all of the implementations of this abstract function.
-         */
         zosmfProfile?: IProfile
     ): Promise<IZosFilesResponse>;
 }


### PR DESCRIPTION
This PR removes the call to the deprecated function commandParameters.profiles.get() which was made in ZosFilesBase.handler. The call was harmless because the results were unused, but it was also very misleading - it implied that the deprecated function should be called.

Removal of the call to that function has no external effects. It did require that about a million unit tests be modified.