### PR TITLE
Move `authConfig` definition back to CLI package

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Zowe CLI package will be documented in this file.
 
+## Recent Changes
+
+- BugFix: Moved `authConfig` object from the core SDK into the CLI's base profile definition to fix invalid handler path.
+
 ## `7.1.0`
 
 - Enhancement: Updated the `zowe config auto-init` command to allow using certificates for authentication. [#1359](https://github.com/zowe/zowe-cli/issues/1359)

--- a/packages/cli/src/imperative.ts
+++ b/packages/cli/src/imperative.ts
@@ -49,7 +49,47 @@ const config: IImperativeConfig = {
             connProfType: "zosmf"
         }
     ],
-    baseProfile: ProfileConstants.BaseProfile,
+    baseProfile: {
+        ...ProfileConstants.BaseProfile,
+        authConfig: [
+            {
+                serviceName: "apiml",
+                handler: __dirname + "/auth/ApimlAuthHandler",
+                login: {
+                    summary: ProfileConstants.APIML_LOGIN_SUMMARY,
+                    description: ProfileConstants.APIML_LOGIN_DESCRIPTION,
+                    examples: [
+                        ProfileConstants.APIML_LOGIN_EXAMPLE1,
+                        ProfileConstants.APIML_LOGIN_EXAMPLE2
+                    ],
+                    options: [
+                        ProfileConstants.BASE_OPTION_HOST,
+                        ProfileConstants.BASE_OPTION_PORT,
+                        ProfileConstants.BASE_OPTION_USER,
+                        ProfileConstants.BASE_OPTION_PASSWORD,
+                        ProfileConstants.BASE_OPTION_REJECT_UNAUTHORIZED,
+                        ProfileConstants.BASE_OPTION_CERT_FILE,
+                        ProfileConstants.BASE_OPTION_CERT_KEY_FILE
+                    ]
+                },
+                logout: {
+                    summary: ProfileConstants.APIML_LOGOUT_SUMMARY,
+                    description: ProfileConstants.APIML_LOGOUT_DESCRIPTION,
+                    examples: [
+                        ProfileConstants.APIML_LOGOUT_EXAMPLE1,
+                        ProfileConstants.APIML_LOGOUT_EXAMPLE2
+                    ],
+                    options: [
+                        ProfileConstants.BASE_OPTION_HOST,
+                        ProfileConstants.BASE_OPTION_PORT,
+                        ProfileConstants.APIML_LOGOUT_OPTION_TOKEN_TYPE,
+                        ProfileConstants.BASE_OPTION_TOKEN_VALUE,
+                        ProfileConstants.BASE_OPTION_REJECT_UNAUTHORIZED
+                    ]
+                }
+            }
+        ]
+    },
     authGroupConfig: {
         authGroup: {
             summary: ProfileConstants.AUTH_GROUP_SUMMARY,

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Zowe core SDK package will be documented in this file.
 
+## Recent Changes
+
+- BugFix: Moved `authConfig` object from the base profile definition into the CLI package because it made the handler path invalid.
+
 ## `7.1.0`
 
 - Enhancement: Exposed `base` profile type configuration.

--- a/packages/core/src/constants/Core.constants.ts
+++ b/packages/core/src/constants/Core.constants.ts
@@ -403,44 +403,6 @@ export class ProfileConstants {
                 options: "base1 --user newuser --password newp4ss",
                 description: "Update a base profile named 'base1' with a new username and password"
             }
-        ],
-        authConfig: [
-            {
-                serviceName: "apiml",
-                handler: __dirname + "/auth/ApimlAuthHandler",
-                login: {
-                    summary: ProfileConstants.APIML_LOGIN_SUMMARY,
-                    description: ProfileConstants.APIML_LOGIN_DESCRIPTION,
-                    examples: [
-                        ProfileConstants.APIML_LOGIN_EXAMPLE1,
-                        ProfileConstants.APIML_LOGIN_EXAMPLE2
-                    ],
-                    options: [
-                        ProfileConstants.BASE_OPTION_HOST,
-                        ProfileConstants.BASE_OPTION_PORT,
-                        ProfileConstants.BASE_OPTION_USER,
-                        ProfileConstants.BASE_OPTION_PASSWORD,
-                        ProfileConstants.BASE_OPTION_REJECT_UNAUTHORIZED,
-                        ProfileConstants.BASE_OPTION_CERT_FILE,
-                        ProfileConstants.BASE_OPTION_CERT_KEY_FILE
-                    ]
-                },
-                logout: {
-                    summary: ProfileConstants.APIML_LOGOUT_SUMMARY,
-                    description: ProfileConstants.APIML_LOGOUT_DESCRIPTION,
-                    examples: [
-                        ProfileConstants.APIML_LOGOUT_EXAMPLE1,
-                        ProfileConstants.APIML_LOGOUT_EXAMPLE2
-                    ],
-                    options: [
-                        ProfileConstants.BASE_OPTION_HOST,
-                        ProfileConstants.BASE_OPTION_PORT,
-                        ProfileConstants.APIML_LOGOUT_OPTION_TOKEN_TYPE,
-                        ProfileConstants.BASE_OPTION_TOKEN_VALUE,
-                        ProfileConstants.BASE_OPTION_REJECT_UNAUTHORIZED
-                    ]
-                }
-            }
         ]
     };
 }


### PR DESCRIPTION
This fixes the handler path to `ApimlAuthHandler` being invalid.