### PR TITLE
Fix daemon binary startup error

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Zowe CLI package will be documented in this file.
 
+## Recent Changes
+
+- BugFix: Fixed the Zowe Daemon binary exiting with an error if the daemon server does not start within 3 seconds.
+
 ## `7.2.3`
 
 - BugFix: Updated Imperative to address `ProfileInfo` related issues.

--- a/zowex/Cargo.lock
+++ b/zowex/Cargo.lock
@@ -448,7 +448,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "zowe"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "atty",
  "base64",

--- a/zowex/Cargo.toml
+++ b/zowex/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zowe"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["Zowe Project"]
 edition = "2018"
 license = "EPL-2.0"

--- a/zowex/src/comm.rs
+++ b/zowex/src/comm.rs
@@ -88,7 +88,7 @@ pub fn comm_establish_connection(njs_zowe_path: &str, daemon_socket: &str) -> io
                 // start the daemon and continue trying to connect
                 we_started_daemon = true;
                 cmd_to_show = proc_start_daemon(njs_zowe_path);
-            } else if we_started_daemon {
+            } else if we_started_daemon && conn_retries > THREE_MIN_OF_RETRIES {
                 println!("The Zowe daemon that we started is not running on socket: {}.",
                     daemon_socket
                 );
@@ -122,7 +122,7 @@ pub fn comm_establish_connection(njs_zowe_path: &str, daemon_socket: &str) -> io
         }
 
         let retry_msg;
-        if we_started_daemon {
+        if we_started_daemon && !daemon_proc_info.is_running {
             retry_msg = "Waiting for the Zowe daemon to start";
         } else {
             retry_msg = "Attempting to connect to the Zowe daemon";


### PR DESCRIPTION
Patch Release
Fixes Daemon Binary error if the daemon server does not start within 3 seconds.
Updates error messaging to provide more accurate information during the 3 minute connection loop.

Signed-off-by: Andrew W. Harn <andrew.harn@broadcom.com>