### PR TITLE
Lock down Rust version across all workflows

### DIFF
--- a/.github/workflows/rust-cli-publish.yml
+++ b/.github/workflows/rust-cli-publish.yml
@@ -68,7 +68,7 @@ jobs:
       uses: actions-rs/toolchain@v1
       with:
         profile: minimal
-        toolchain: stable
+        toolchain: 1.61.0
         override: true
 
     - uses: actions/download-artifact@v2
@@ -110,6 +110,13 @@ jobs:
 
     steps:
 
+    - name: Install Rust toolchain
+      uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: 1.61.0
+        override: true
+
     - uses: actions/download-artifact@v2
       with:
         name: repo
@@ -148,6 +155,13 @@ jobs:
     runs-on: windows-latest
 
     steps:
+
+    - name: Install Rust toolchain
+      uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: 1.61.0
+        override: true
 
     - uses: actions/download-artifact@v2
       with:

--- a/.github/workflows/rust-cli.yml
+++ b/.github/workflows/rust-cli.yml
@@ -26,7 +26,7 @@ jobs:
       uses: actions-rs/toolchain@v1
       with:
         profile: minimal
-        toolchain: stable
+        toolchain: 1.61.0
         override: true
 
     - name: Build
@@ -53,6 +53,13 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
+    - name: Install Rust toolchain
+      uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: 1.61.0
+        override: true
+
     - name: Build
       run: cargo build --verbose --manifest-path=zowex/Cargo.toml
 
@@ -76,6 +83,13 @@ jobs:
     runs-on: windows-latest
     steps:
     - uses: actions/checkout@v2
+
+    - name: Install Rust toolchain
+      uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: 1.61.0
+        override: true
 
     - name: Build
       run: cargo build --verbose --manifest-path=zowex/Cargo.toml


### PR DESCRIPTION
Related to https://github.com/zowe/zowe-cli/issues/1466

Until the issue in Rust 1.62 is fixed, we don't want to accidentally publish new daemon binaries with broken behavior, so locking down the versions should keep us safe.

The Windows and macOS daemon builds weren't invoking the `actions-rs/toolchain` action, but probably should be to ensure that the daemon is built using the same Rust version across all platforms.