### PR TITLE
Update Rust toolchain + fix linting + add auditing

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -17,14 +17,28 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
 
-    - name: Use Node.js 12.x
-      uses: actions/setup-node@v1
+    - name: Use Node.js LTS
+      uses: actions/setup-node@v2
       with:
-        node-version: 12.x
+        node-version: lts/*
 
     - name: Use NPM v8
       id: npm8
       run: npm install -g npm@^8
 
-    - name: Check Vulnerabilities
+    - name: Install Rust toolchain
+      uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: stable
+        override: true
+
+    - name: Check Node Vulnerabilities
       run: npm audit --production --audit-level=moderate
+
+    # TODO Consider using actions-rs/audit-check after https://github.com/actions-rs/audit-check/issues/116 is fixed
+    - name: Check Rust Vulnerabilities
+      working-directory: zowex
+      run: |
+        cargo install cargo-audit
+        cargo audit

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -19,10 +19,10 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
 
-    - name: Use Node.js 12.x
-      uses: actions/setup-node@v1
+    - name: Use Node.js LTS
+      uses: actions/setup-node@v2
       with:
-        node-version: 12.x
+        node-version: lts/*
 
     - name: Use NPM v8
       id: npm8

--- a/.github/workflows/rust-cli-publish.yml
+++ b/.github/workflows/rust-cli-publish.yml
@@ -68,7 +68,7 @@ jobs:
       uses: actions-rs/toolchain@v1
       with:
         profile: minimal
-        toolchain: 1.61.0
+        toolchain: stable
         override: true
 
     - uses: actions/download-artifact@v2
@@ -114,7 +114,7 @@ jobs:
       uses: actions-rs/toolchain@v1
       with:
         profile: minimal
-        toolchain: 1.61.0
+        toolchain: stable
         override: true
 
     - uses: actions/download-artifact@v2
@@ -160,7 +160,7 @@ jobs:
       uses: actions-rs/toolchain@v1
       with:
         profile: minimal
-        toolchain: 1.61.0
+        toolchain: stable
         override: true
 
     - uses: actions/download-artifact@v2

--- a/.github/workflows/rust-cli.yml
+++ b/.github/workflows/rust-cli.yml
@@ -26,7 +26,7 @@ jobs:
       uses: actions-rs/toolchain@v1
       with:
         profile: minimal
-        toolchain: 1.61.0
+        toolchain: stable
         override: true
         components: clippy
 
@@ -64,7 +64,7 @@ jobs:
       uses: actions-rs/toolchain@v1
       with:
         profile: minimal
-        toolchain: 1.61.0
+        toolchain: stable
         override: true
 
     - name: Build
@@ -95,7 +95,7 @@ jobs:
       uses: actions-rs/toolchain@v1
       with:
         profile: minimal
-        toolchain: 1.61.0
+        toolchain: stable
         override: true
 
     - name: Build

--- a/.github/workflows/zowe-cli.yml
+++ b/.github/workflows/zowe-cli.yml
@@ -184,6 +184,6 @@ jobs:
     - name: Upload Results to Codecov
       id: upload-codecov
       if: ${{ always() && steps.build.outcome == 'success' }}
-      uses: codecov/codecov-action@v1.0.7
+      uses: codecov/codecov-action@v3
       with:
         env_vars: OS,NODE

--- a/.github/workflows/zowe-cli.yml
+++ b/.github/workflows/zowe-cli.yml
@@ -77,7 +77,7 @@ jobs:
       uses: actions-rs/toolchain@v1
       with:
         profile: minimal
-        toolchain: 1.61.0  # See https://github.com/zowe/zowe-cli/issues/1466
+        toolchain: stable
         override: true
 
     - name: Checkout Imperative

--- a/zowex/src/comm.rs
+++ b/zowex/src/comm.rs
@@ -121,12 +121,11 @@ pub fn comm_establish_connection(njs_zowe_path: &str, daemon_socket: &str) -> io
             );
         }
 
-        let retry_msg;
-        if we_started_daemon && !daemon_proc_info.is_running {
-            retry_msg = "Waiting for the Zowe daemon to start";
+        let retry_msg = if we_started_daemon && !daemon_proc_info.is_running {
+            "Waiting for the Zowe daemon to start"
         } else {
-            retry_msg = "Attempting to connect to the Zowe daemon";
-        }
+            "Attempting to connect to the Zowe daemon"
+        };
         if conn_retries > 0 {
             println!("{} ({} of {})", retry_msg, conn_retries, THREE_MIN_OF_RETRIES);
         }

--- a/zowex/src/main.rs
+++ b/zowex/src/main.rs
@@ -47,11 +47,10 @@ fn main() -> io::Result<()> {
      * failure exit code. Alternatively, our Err branch represents when we
      * fail to run the command.
      */
-    let exit_code: i32;
-    match run_zowe_command(&mut cmd_line_args) {
-        Ok(ok_val) => exit_code = ok_val,
-        Err(err_val) => exit_code = err_val
-    }
+    let exit_code: i32 = match run_zowe_command(&mut cmd_line_args) {
+        Ok(ok_val) => ok_val,
+        Err(err_val) => err_val
+    };
 
     /* Rust does not enable main() to return an exit code.
      * Thus, we explicitly exit the process with our desired exit code.

--- a/zowex/src/proc.rs
+++ b/zowex/src/proc.rs
@@ -53,13 +53,12 @@ pub fn proc_get_cmd_shell() -> Result<(CmdShell, String), SimpleError> {
     for (next_pid, process) in sys.processes() {
         if next_pid == &my_pid {
             found_my_pid = true;
-            let my_parent_pid: Pid;
-            match process.parent() {
-                Some(parent_id) => my_parent_pid = parent_id,
+            let my_parent_pid: Pid = match process.parent() {
+                Some(parent_id) => parent_id,
                 None => {
                     return Err(SimpleError::new("Got invalid parent process ID from the process list."));
                 }
-            }
+            };
 
             // loop though the process list to find our parent process ID
             let mut found_parent_pid: bool = false;
@@ -197,9 +196,8 @@ fn read_pid_for_user() -> Option<sysinfo::Pid> {
     }
 
     // read in the pid file contents
-    let pid_file: File;
-    match File::open(&pid_file_path) {
-        Ok(ok_val) => pid_file = ok_val,
+    let pid_file: File = match File::open(&pid_file_path) {
+        Ok(ok_val) => ok_val,
         Err(err_val) => {
             // we should not continue if we cannot open an existing pid file
             println!("Unable to open file = {}\nDetails = {}",
@@ -207,11 +205,10 @@ fn read_pid_for_user() -> Option<sysinfo::Pid> {
             );
             std::process::exit(EXIT_CODE_FILE_IO_ERROR);
         }
-    }
+    };
     let pid_reader = BufReader::new(pid_file);
-    let daemon_pid_for_user: DaemonPidForUser;
-    match serde_json::from_reader(pid_reader) {
-        Ok(ok_val) => daemon_pid_for_user = ok_val,
+    let daemon_pid_for_user: DaemonPidForUser = match serde_json::from_reader(pid_reader) {
+        Ok(ok_val) => ok_val,
         Err(err_val) => {
             // we should not continue if we cannot read an existing pid file
             println!("Unable to read file = {}\nDetails = {}",
@@ -219,7 +216,7 @@ fn read_pid_for_user() -> Option<sysinfo::Pid> {
             );
             std::process::exit(EXIT_CODE_FILE_IO_ERROR);
         }
-    }
+    };
 
     if daemon_pid_for_user.user != username() {
         // our pid file should only contain our own user name
@@ -281,7 +278,7 @@ pub fn proc_start_daemon(njs_zowe_path: &str) -> String {
     }
 
     let daemon_arg = LAUNCH_DAEMON_OPTION;
-    match Command::new(njs_zowe_path.to_owned())
+    match Command::new(njs_zowe_path)
         .arg(daemon_arg)
         .stdout(Stdio::null())
         .stderr(Stdio::null())

--- a/zowex/src/util.rs
+++ b/zowex/src/util.rs
@@ -47,12 +47,11 @@ pub fn util_get_nodejs_zowe_path() -> String {
     let my_exe_path_buf = my_exe_result.unwrap();
     let my_exe_path = my_exe_path_buf.to_string_lossy();
 
-    let zowe_cmd;
-    if env::consts::OS == "windows" {
-        zowe_cmd = "zowe.cmd";
+    let zowe_cmd = if env::consts::OS == "windows" {
+        "zowe.cmd"
     } else {
-        zowe_cmd = "zowe";
-    }
+        "zowe"
+    };
 
     // find every program in our path that would execute a 'zowe' command
     const NOT_FOUND: &str = "notFound";


### PR DESCRIPTION
* Resolve #1466 by reverting https://github.com/zowe/zowe-cli/pull/1467 now that Rust 1.62.1 patch has been released
* Fix lint warnings in Rust code that Clippy was complaining about
* Add security audit of Rust dependencies to GitHub workflow

This PR has the "no-changelog" label since no user-facing changes were made and I don't believe it warrants publishing a new version of the daemon binary.