### PR TITLE
Fix zowex version in Rust publish workflow

### DIFF
--- a/.github/workflows/rust-cli-publish.yml
+++ b/.github/workflows/rust-cli-publish.yml
@@ -21,9 +21,8 @@ jobs:
 
     - name: Get version
       id: get-version
-      run: |
-        cd zowex
-        echo "::set-output name=ZOWEX_VERSION::$(cargo pkgid | cut -d# -f2 | cut -d: -f2)"
+      working-directory: zowex
+      run: echo "::set-output name=ZOWEX_VERSION::$(cargo metadata --no-deps | jq -r .packages[0].version)"
 
     - name: Create Release
       id: create_release


### PR DESCRIPTION
When #1471 was merged, it unintentionally published a new release of the daemon:
![image](https://user-images.githubusercontent.com/22344007/180253318-d4877c76-61cd-435b-9e85-abe9effe33f2.png)

I deleted the accidental release and tag (should not have happened since we didn't bump the daemon version number in Cargo.toml). This PR should prevent it from happening again.

Apparently the output of `cargo pkgid` changed so we can no longer parse a version number from it the same way as before. Hopefully `cargo metadata` is a more robust solution since it outputs JSON.