### PR TITLE
Fix Sonar Hotspots v1 - Part 1

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -16,10 +16,10 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
 
-    - name: Use Node.js 12.x
-      uses: actions/setup-node@v1
+    - name: Use Node.js 14.x
+      uses: actions/setup-node@v3
       with:
-        node-version: 12.x
+        node-version: 14.x
 
     - name: Check Vulnerabilities
       run: npm audit --production --audit-level=moderate

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -18,10 +18,10 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
 
-    - name: Use Node.js 12.x
-      uses: actions/setup-node@v1
+    - name: Use Node.js 14.x
+      uses: actions/setup-node@v3
       with:
-        node-version: 12.x
+        node-version: 14.x
 
     - name: Install Node Package Dependencies
       run: npm ci

--- a/.github/workflows/zowe-cli.yml
+++ b/.github/workflows/zowe-cli.yml
@@ -51,7 +51,7 @@ jobs:
         fetch-depth: 0
 
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
 

--- a/.github/workflows/zowe-cli.yml
+++ b/.github/workflows/zowe-cli.yml
@@ -47,6 +47,8 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
 
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v1

--- a/packages/cli/src/zosfiles/ZosFiles.utils.ts
+++ b/packages/cli/src/zosfiles/ZosFiles.utils.ts
@@ -18,12 +18,11 @@ import { IDataSet } from "@zowe/zos-files-for-zowe-sdk";
  * @param {string} name  - the name in the form USER.DATA.SET | USER.DATA.SET(mem1)
  */
 export function getDataSet(name: string): IDataSet {
-    const match = name.match(/(.*)\((.*)\)/);
-    if (match) {
-        const [, dataSetName, memberName] = match;
+    const parts = name.replace(')', '').split('(');
+    if (parts.length > 1) {
         return {
-            dataSetName,
-            memberName
+            dataSetName: parts[0],
+            memberName: parts[1]
         };
     } else {
         return {

--- a/packages/workflows/src/Properties.ts
+++ b/packages/workflows/src/Properties.ts
@@ -71,7 +71,7 @@ export class PropertiesWorkflow {
 
         for(const step of steps) {
             let miscValue: string = "N/A";
-            if(step.submitAs && step.submitAs.match(/.*JCL/)) {
+            if(step.submitAs?.includes('JCL')) {
                 if(step.jobInfo && step.jobInfo.jobstatus) {
                     miscValue = step.jobInfo.jobstatus.jobid;
                 }


### PR DESCRIPTION
Fixes the pipeline so Sonar's scans can locate all of the hotspots in the v1 branch. Implements fixes in V2 that are known to be hotspots. Once Sonarcloud is reconfigured, this pull request can be merged, but the branch SHOULD NOT be deleted, as a second pull request may be required to fix additional hotspots after the scans are complete.