### PR TITLE
Update zowe-v1-lts to include Imperative 4.18.10

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Zowe CLI package will be documented in this file.
 
+## Recent Changes
+
+- BugFix: Updated Imperative to absorb bugfixes introduced in version `4.18.10`.
+
 ## `6.40.8`
 
 - BugFix: Updated `minimatch` dependency for technical currency.


### PR DESCRIPTION
When we merged the last PR, the automation updated Imperative to 4.18.10. This PR includes the changelog entry so that we can release a patch version.