### PR TITLE
Fix Imperative for NPM 9

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -10,7 +10,7 @@
         "packages/*"
       ],
       "dependencies": {
-        "@zowe/imperative": "4.18.10",
+        "@zowe/imperative": "4.18.11",
         "@zowe/perf-timing": "1.0.7"
       },
       "devDependencies": {
@@ -7549,9 +7549,9 @@
       "link": true
     },
     "node_modules/@zowe/imperative": {
-      "version": "4.18.10",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@zowe/imperative/-/@zowe/imperative-4.18.10.tgz",
-      "integrity": "sha512-Japhdukv8BEJPArZOiWVWuR8ZQ4Amsww0poHqL/KkOK6M5/P4VrvA/rWPU9p3r+j6cZKYywpgRtCSDbhIWm58A==",
+      "version": "4.18.11",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@zowe/imperative/-/@zowe/imperative-4.18.11.tgz",
+      "integrity": "sha512-/W5uqACZwirnqNXT6RBLppJH7C4jagmfNpubWk/7vN1OkoJIPdlwyd2zXjO8kyP2+mluMkDGHW68SH4w3bboaw==",
       "dependencies": {
         "@types/yargs": "13.0.4",
         "@zowe/perf-timing": "1.0.7",
@@ -27359,7 +27359,7 @@
       "license": "EPL-2.0",
       "dependencies": {
         "@zowe/core-for-zowe-sdk": "6.40.9",
-        "@zowe/imperative": "4.18.10",
+        "@zowe/imperative": "4.18.11",
         "@zowe/perf-timing": "1.0.7",
         "@zowe/provisioning-for-zowe-sdk": "6.40.9",
         "@zowe/zos-console-for-zowe-sdk": "6.40.9",
@@ -27407,7 +27407,7 @@
       },
       "devDependencies": {
         "@types/node": "^12.12.24",
-        "@zowe/imperative": "4.18.10",
+        "@zowe/imperative": "4.18.11",
         "chalk": "^4.1.0",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
@@ -27456,7 +27456,7 @@
         "@types/js-yaml": "^3.12.5",
         "@types/node": "^12.12.24",
         "@zowe/core-for-zowe-sdk": "6.40.9",
-        "@zowe/imperative": "4.18.10",
+        "@zowe/imperative": "4.18.11",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
         "rimraf": "^2.6.3",
@@ -27478,7 +27478,7 @@
       "devDependencies": {
         "@types/node": "^12.12.24",
         "@zowe/core-for-zowe-sdk": "6.40.9",
-        "@zowe/imperative": "4.18.10",
+        "@zowe/imperative": "4.18.11",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
         "rimraf": "^2.6.3",
@@ -27497,7 +27497,7 @@
       "devDependencies": {
         "@types/node": "^12.12.24",
         "@zowe/core-for-zowe-sdk": "6.40.9",
-        "@zowe/imperative": "4.18.10",
+        "@zowe/imperative": "4.18.11",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
         "rimraf": "^2.6.3",
@@ -27519,7 +27519,7 @@
       "devDependencies": {
         "@types/node": "^12.12.24",
         "@zowe/core-for-zowe-sdk": "6.40.9",
-        "@zowe/imperative": "4.18.10",
+        "@zowe/imperative": "4.18.11",
         "@zowe/zos-uss-for-zowe-sdk": "6.40.9",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
@@ -27542,7 +27542,7 @@
       "devDependencies": {
         "@types/node": "^12.12.24",
         "@zowe/core-for-zowe-sdk": "6.40.9",
-        "@zowe/imperative": "4.18.10",
+        "@zowe/imperative": "4.18.11",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
         "rimraf": "^2.6.3",
@@ -27561,7 +27561,7 @@
       "devDependencies": {
         "@types/node": "^12.12.24",
         "@zowe/core-for-zowe-sdk": "6.40.9",
-        "@zowe/imperative": "4.18.10",
+        "@zowe/imperative": "4.18.11",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
         "rimraf": "^2.6.3",
@@ -27580,7 +27580,7 @@
       "devDependencies": {
         "@types/node": "^12.12.24",
         "@zowe/core-for-zowe-sdk": "6.40.9",
-        "@zowe/imperative": "4.18.10",
+        "@zowe/imperative": "4.18.11",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
         "rimraf": "^2.6.3",
@@ -27602,7 +27602,7 @@
       "devDependencies": {
         "@types/node": "^12.12.24",
         "@zowe/core-for-zowe-sdk": "6.40.9",
-        "@zowe/imperative": "4.18.10",
+        "@zowe/imperative": "4.18.11",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
         "rimraf": "^2.6.3",
@@ -27624,7 +27624,7 @@
       "devDependencies": {
         "@types/node": "^12.12.24",
         "@types/ssh2": "^0.5.44",
-        "@zowe/imperative": "4.18.10",
+        "@zowe/imperative": "4.18.11",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
         "rimraf": "^2.6.3",
@@ -33697,7 +33697,7 @@
       "requires": {
         "@types/node": "^12.12.24",
         "@zowe/core-for-zowe-sdk": "6.40.9",
-        "@zowe/imperative": "4.18.10",
+        "@zowe/imperative": "4.18.11",
         "@zowe/perf-timing": "1.0.7",
         "@zowe/provisioning-for-zowe-sdk": "6.40.9",
         "@zowe/zos-console-for-zowe-sdk": "6.40.9",
@@ -33729,7 +33729,7 @@
       "version": "file:packages/core",
       "requires": {
         "@types/node": "^12.12.24",
-        "@zowe/imperative": "4.18.10",
+        "@zowe/imperative": "4.18.11",
         "chalk": "^4.1.0",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
@@ -33762,9 +33762,9 @@
       }
     },
     "@zowe/imperative": {
-      "version": "4.18.10",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@zowe/imperative/-/@zowe/imperative-4.18.10.tgz",
-      "integrity": "sha512-Japhdukv8BEJPArZOiWVWuR8ZQ4Amsww0poHqL/KkOK6M5/P4VrvA/rWPU9p3r+j6cZKYywpgRtCSDbhIWm58A==",
+      "version": "4.18.11",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@zowe/imperative/-/@zowe/imperative-4.18.11.tgz",
+      "integrity": "sha512-/W5uqACZwirnqNXT6RBLppJH7C4jagmfNpubWk/7vN1OkoJIPdlwyd2zXjO8kyP2+mluMkDGHW68SH4w3bboaw==",
       "requires": {
         "@types/yargs": "13.0.4",
         "@zowe/perf-timing": "1.0.7",
@@ -33932,7 +33932,7 @@
         "@types/js-yaml": "^3.12.5",
         "@types/node": "^12.12.24",
         "@zowe/core-for-zowe-sdk": "6.40.9",
-        "@zowe/imperative": "4.18.10",
+        "@zowe/imperative": "4.18.11",
         "eslint": "^7.32.0",
         "js-yaml": "3.14.1",
         "madge": "^4.0.1",
@@ -33946,7 +33946,7 @@
       "requires": {
         "@types/node": "^12.12.24",
         "@zowe/core-for-zowe-sdk": "6.40.9",
-        "@zowe/imperative": "4.18.10",
+        "@zowe/imperative": "4.18.11",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
         "rimraf": "^2.6.3",
@@ -33959,7 +33959,7 @@
       "requires": {
         "@types/node": "^12.12.24",
         "@zowe/core-for-zowe-sdk": "6.40.9",
-        "@zowe/imperative": "4.18.10",
+        "@zowe/imperative": "4.18.11",
         "@zowe/zos-uss-for-zowe-sdk": "6.40.9",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
@@ -33974,7 +33974,7 @@
       "requires": {
         "@types/node": "^12.12.24",
         "@zowe/core-for-zowe-sdk": "6.40.9",
-        "@zowe/imperative": "4.18.10",
+        "@zowe/imperative": "4.18.11",
         "@zowe/zos-files-for-zowe-sdk": "6.40.9",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
@@ -33988,7 +33988,7 @@
       "requires": {
         "@types/node": "^12.12.24",
         "@zowe/core-for-zowe-sdk": "6.40.9",
-        "@zowe/imperative": "4.18.10",
+        "@zowe/imperative": "4.18.11",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
         "rimraf": "^2.6.3",
@@ -34001,7 +34001,7 @@
       "requires": {
         "@types/node": "^12.12.24",
         "@zowe/core-for-zowe-sdk": "6.40.9",
-        "@zowe/imperative": "4.18.10",
+        "@zowe/imperative": "4.18.11",
         "@zowe/zosmf-for-zowe-sdk": "6.40.9",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
@@ -34015,7 +34015,7 @@
       "requires": {
         "@types/node": "^12.12.24",
         "@types/ssh2": "^0.5.44",
-        "@zowe/imperative": "4.18.10",
+        "@zowe/imperative": "4.18.11",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
         "rimraf": "^2.6.3",
@@ -34029,7 +34029,7 @@
       "requires": {
         "@types/node": "^12.12.24",
         "@zowe/core-for-zowe-sdk": "6.40.9",
-        "@zowe/imperative": "4.18.10",
+        "@zowe/imperative": "4.18.11",
         "@zowe/zos-files-for-zowe-sdk": "6.40.9",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
@@ -34043,7 +34043,7 @@
       "requires": {
         "@types/node": "^12.12.24",
         "@zowe/core-for-zowe-sdk": "6.40.9",
-        "@zowe/imperative": "4.18.10",
+        "@zowe/imperative": "4.18.11",
         "eslint": "^7.32.0",
         "madge": "^4.0.1",
         "rimraf": "^2.6.3",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "prepare": "husky install"
   },
   "dependencies": {
-    "@zowe/imperative": "4.18.10",
+    "@zowe/imperative": "4.18.11",
     "@zowe/perf-timing": "1.0.7"
   },
   "devDependencies": {

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Zowe CLI package will be documented in this file.
 
+## Recent Changes
+
+- BugFix: Updated Imperative to absorb bugfixes introduced in version `4.18.11`.
+
 ## `6.40.9`
 
 - BugFix: Updated Imperative to absorb bugfixes introduced in version `4.18.10`.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -57,7 +57,7 @@
   },
   "dependencies": {
     "@zowe/core-for-zowe-sdk": "6.40.9",
-    "@zowe/imperative": "4.18.10",
+    "@zowe/imperative": "4.18.11",
     "@zowe/perf-timing": "1.0.7",
     "@zowe/provisioning-for-zowe-sdk": "6.40.9",
     "@zowe/zos-console-for-zowe-sdk": "6.40.9",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -49,7 +49,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.12.24",
-    "@zowe/imperative": "4.18.10",
+    "@zowe/imperative": "4.18.11",
     "chalk": "^4.1.0",
     "eslint": "^7.32.0",
     "madge": "^4.0.1",

--- a/packages/provisioning/package.json
+++ b/packages/provisioning/package.json
@@ -51,7 +51,7 @@
     "@types/js-yaml": "^3.12.5",
     "@types/node": "^12.12.24",
     "@zowe/core-for-zowe-sdk": "6.40.9",
-    "@zowe/imperative": "4.18.10",
+    "@zowe/imperative": "4.18.11",
     "eslint": "^7.32.0",
     "madge": "^4.0.1",
     "rimraf": "^2.6.3",

--- a/packages/workflows/package.json
+++ b/packages/workflows/package.json
@@ -50,7 +50,7 @@
   "devDependencies": {
     "@types/node": "^12.12.24",
     "@zowe/core-for-zowe-sdk": "6.40.9",
-    "@zowe/imperative": "4.18.10",
+    "@zowe/imperative": "4.18.11",
     "eslint": "^7.32.0",
     "madge": "^4.0.1",
     "rimraf": "^2.6.3",

--- a/packages/zosconsole/package.json
+++ b/packages/zosconsole/package.json
@@ -47,7 +47,7 @@
   "devDependencies": {
     "@types/node": "^12.12.24",
     "@zowe/core-for-zowe-sdk": "6.40.9",
-    "@zowe/imperative": "4.18.10",
+    "@zowe/imperative": "4.18.11",
     "eslint": "^7.32.0",
     "madge": "^4.0.1",
     "rimraf": "^2.6.3",

--- a/packages/zosfiles/package.json
+++ b/packages/zosfiles/package.json
@@ -51,7 +51,7 @@
   "devDependencies": {
     "@types/node": "^12.12.24",
     "@zowe/core-for-zowe-sdk": "6.40.9",
-    "@zowe/imperative": "4.18.10",
+    "@zowe/imperative": "4.18.11",
     "@zowe/zos-uss-for-zowe-sdk": "6.40.9",
     "eslint": "^7.32.0",
     "madge": "^4.0.1",

--- a/packages/zosjobs/package.json
+++ b/packages/zosjobs/package.json
@@ -51,7 +51,7 @@
   "devDependencies": {
     "@types/node": "^12.12.24",
     "@zowe/core-for-zowe-sdk": "6.40.9",
-    "@zowe/imperative": "4.18.10",
+    "@zowe/imperative": "4.18.11",
     "eslint": "^7.32.0",
     "madge": "^4.0.1",
     "rimraf": "^2.6.3",

--- a/packages/zoslogs/package.json
+++ b/packages/zoslogs/package.json
@@ -47,7 +47,7 @@
   "devDependencies": {
     "@types/node": "^12.12.24",
     "@zowe/core-for-zowe-sdk": "6.40.9",
-    "@zowe/imperative": "4.18.10",
+    "@zowe/imperative": "4.18.11",
     "eslint": "^7.32.0",
     "madge": "^4.0.1",
     "rimraf": "^2.6.3",

--- a/packages/zosmf/package.json
+++ b/packages/zosmf/package.json
@@ -46,7 +46,7 @@
   "devDependencies": {
     "@types/node": "^12.12.24",
     "@zowe/core-for-zowe-sdk": "6.40.9",
-    "@zowe/imperative": "4.18.10",
+    "@zowe/imperative": "4.18.11",
     "eslint": "^7.32.0",
     "madge": "^4.0.1",
     "rimraf": "^2.6.3",

--- a/packages/zostso/package.json
+++ b/packages/zostso/package.json
@@ -50,7 +50,7 @@
   "devDependencies": {
     "@types/node": "^12.12.24",
     "@zowe/core-for-zowe-sdk": "6.40.9",
-    "@zowe/imperative": "4.18.10",
+    "@zowe/imperative": "4.18.11",
     "eslint": "^7.32.0",
     "madge": "^4.0.1",
     "rimraf": "^2.6.3",

--- a/packages/zosuss/package.json
+++ b/packages/zosuss/package.json
@@ -50,7 +50,7 @@
   "devDependencies": {
     "@types/node": "^12.12.24",
     "@types/ssh2": "^0.5.44",
-    "@zowe/imperative": "4.18.10",
+    "@zowe/imperative": "4.18.11",
     "eslint": "^7.32.0",
     "madge": "^4.0.1",
     "rimraf": "^2.6.3",


### PR DESCRIPTION
Update imperative to allow the `zowe plugins install` command's `login` option to work with NPM version 9.