### PR TITLE
Attempt to fix the daemon broken pipe issue on Windows

### DIFF
--- a/.github/workflows/rust-cli-publish.yml
+++ b/.github/workflows/rust-cli-publish.yml
@@ -168,6 +168,8 @@ jobs:
 
     - name: Build
       run: cargo build --verbose --release
+      env:
+        RUSTFLAGS: "-Ctarget-feature=+crt-static"
 
     - name: Get Upload URL
       id: get_upload_url

--- a/.github/workflows/rust-cli.yml
+++ b/.github/workflows/rust-cli.yml
@@ -100,6 +100,8 @@ jobs:
 
     - name: Build
       run: cargo build --verbose --manifest-path=zowex/Cargo.toml
+      env:
+        RUSTFLAGS: "-Ctarget-feature=+crt-static"
 
     - name: Create Archive
       run: |

--- a/.github/workflows/zowe-cli.yml
+++ b/.github/workflows/zowe-cli.yml
@@ -5,11 +5,7 @@ name: Zowe CLI
 
 on:
   push:
-    paths-ignore:
-      - zowex/**
   pull_request:
-    paths-ignore:
-      - zowex/**
   workflow_dispatch:
     inputs:
       binary-type:
@@ -106,10 +102,19 @@ jobs:
 
     - name: Build Binary
       id: build-binary
-      if: github.event.inputs.test-type == 'binary' || github.event_name == 'push'
+      if: matrix.os != 'windows-latest' && (github.event.inputs.test-type == 'binary' || github.event_name == 'push')
       run: |
         cargo build --verbose ${{ github.event.inputs.binary-type == 'release' && '--release' || '' }} --manifest-path=zowex/Cargo.toml
-        tar -cvzf zowe.tgz -C zowex/target/${{ github.event.inputs.binary-type == 'release' && 'release' || 'debug' }} zowe${{ matrix.os == 'windows-latest' && '.exe' || '' }}
+        tar -cvzf zowe.tgz -C zowex/target/${{ github.event.inputs.binary-type == 'release' && 'release' || 'debug' }} zowe
+
+    - name: Build Binary (Windows)
+      id: build-windows-binary
+      if: matrix.os == 'windows-latest' && (github.event.inputs.test-type == 'binary' || github.event_name == 'push')
+      run: |
+        cargo build --verbose ${{ github.event.inputs.binary-type == 'release' && '--release' || '' }} --manifest-path=zowex/Cargo.toml
+        tar -cvzf zowe.tgz -C zowex/target/${{ github.event.inputs.binary-type == 'release' && 'release' || 'debug' }} zowe.exe
+      env:
+        RUSTFLAGS: "-Ctarget-feature=+crt-static"
 
     - name: Archive Binary
       if: github.event.inputs.test-type == 'binary' || github.event_name == 'push'

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,8 +1,14 @@
 # Change Log
 
 All notable changes to the Zowe CLI package will be documented in this file.
+
+## Recent Changes
+
+- BugFix: Fixed daemon broken pipe error on Windows [#1538](https://github.com/zowe/zowe-cli/issues/1538)
+
 ## `7.9.4`
-- BugFix: Removing all line break encodings from strings for `zos-files compare local-file-data-set` [#1528](https://github.com/zowe/zowe-cli/issues/1528)
+
+- BugFix: Removed all line break encodings from strings for `zos-files compare local-file-data-set` [#1528](https://github.com/zowe/zowe-cli/issues/1528)
 
 ## `7.9.3`
 

--- a/zowex/Cargo.lock
+++ b/zowex/Cargo.lock
@@ -448,7 +448,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "zowe"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "atty",
  "base64",

--- a/zowex/Cargo.toml
+++ b/zowex/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zowe"
-version = "1.0.1"
+version = "1.0.2"
 authors = ["Zowe Project"]
 edition = "2018"
 license = "EPL-2.0"

--- a/zowex/src/comm.rs
+++ b/zowex/src/comm.rs
@@ -243,6 +243,12 @@ pub fn comm_talk(message: &[u8], stream: &mut DaemonClient) -> io::Result<i32> {
 
                     exit_code = p.exitCode.unwrap_or(EXIT_CODE_SUCCESS);
                     _progress = p.progress.unwrap_or(false);
+
+                    if p.exitCode.is_some() {
+                        // we have the exit code, assume the transmission is over
+                        // fixes the broken pipe error in #1538
+                        break;
+                    }
                 } else {
                     // end of reading
                     break;

--- a/zowex/src/comm.rs
+++ b/zowex/src/comm.rs
@@ -244,6 +244,7 @@ pub fn comm_talk(message: &[u8], stream: &mut DaemonClient) -> io::Result<i32> {
                     exit_code = p.exitCode.unwrap_or(EXIT_CODE_SUCCESS);
                     _progress = p.progress.unwrap_or(false);
 
+                    #[cfg(target_family = "windows")]
                     if p.exitCode.is_some() {
                         // we have the exit code, assume the transmission is over
                         // fixes the broken pipe error in #1538

--- a/zowex/src/comm.rs
+++ b/zowex/src/comm.rs
@@ -73,7 +73,7 @@ pub fn comm_establish_connection(njs_zowe_path: &str, daemon_socket: &str) -> io
     let mut cmd_to_show: String = String::new();
 
     let stream = loop {
-        let conn_result = DaemonClient::connect(&daemon_socket);
+        let conn_result = DaemonClient::connect(daemon_socket);
         if let Ok(good_stream) = conn_result {
             // We made our connection. Break with the actual stream value
             break good_stream;

--- a/zowex/src/proc.rs
+++ b/zowex/src/proc.rs
@@ -148,7 +148,7 @@ pub fn proc_get_daemon_info() -> DaemonProcInfo {
            next_process.cmd()[2].to_lowercase() == LAUNCH_DAEMON_OPTION
         {
             // ensure we have found the daemon for the current user
-            if my_daemon_pid_opt != None && &my_daemon_pid_opt.unwrap() == next_pid {
+            if my_daemon_pid_opt.is_some() && &my_daemon_pid_opt.unwrap() == next_pid {
                 // convert the process's command line from a vector to a string
                 let mut proc_cmd: String = String::new();
                 for cmd_part in next_process.cmd() {


### PR DESCRIPTION
Fixes #1538 

Stops the daemon client from polling the server once it receives an exit code, in addition to when the daemon receives a zero byte response from the server. This fixes an obscure situation in Windows where:

1) The daemon reads the named pipe until it is empty and the last character in the pipe is a form feed (0xC)
2) Windows closes the pipe (because it is empty and Node closed the connection once the pipe was empty)
3) The daemon processes the data it just received up to and including the line feed (final character in the pipe)
4) When the daemon attempts to read from the pipe again, instead a zero byte response, it gets a broken pipe error

Signed-off-by: Andrew W. Harn <andrew.harn@broadcom.com>