### PR TITLE
Update stale bot to close issues as "not planned"

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -11,7 +11,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v5
+      - uses: actions/stale@v6
         with:
           close-issue-message: >
             This issue has been automatically closed due to lack of activity. In an


### PR DESCRIPTION
This is the only breaking change in [v6](https://github.com/actions/stale/releases/tag/v6.0.0) of the stale bot:
> Issues/PRs default `close-issue-reason` is now `not_planned`(https://github.com/actions/stale/issues/789)

