### PR TITLE
Fix v1 profile behavior in cli-test-utils

### DIFF
--- a/__tests__/__packages__/cli-test-utils/CHANGELOG.md
+++ b/__tests__/__packages__/cli-test-utils/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to the Zowe CLI test utils package will be documented in this file.
 
+## Recent Changes
+
+- BugFix: Fixed team config being created instead of v1 profiles when `createOldProfiles` was true.
+- Deprecated: Removed the utility method `isStderrEmptyForProfilesCommand`. Use `stripProfileDeprecationMessages(output).length === 0` instead.
+
 ## `7.10.0`
 
 - BugFix: Fixed plugin install failing if plugin does not contribute command definitions.

--- a/__tests__/__packages__/cli-test-utils/src/TestUtils.ts
+++ b/__tests__/__packages__/cli-test-utils/src/TestUtils.ts
@@ -65,13 +65,21 @@ export function runCliScript(scriptPath: string, testEnvironment: ITestEnvironme
 /**
  * Check if stderr output is empty for profiles command. Ignores any message
  * about profiles being deprecated.
+ * @deprecated Use `stripProfileDeprecationMessages`
  */
 export function isStderrEmptyForProfilesCommand(output: Buffer): boolean {
-    return output.toString()
+    return stripProfileDeprecationMessages(output).length === 0;
+}
+
+/**
+ * Strip v1 profile deprecation messages from stderr output.
+ */
+export function stripProfileDeprecationMessages(stderr: Buffer | string): string {
+    return stderr.toString()
         .replace(/Warning: The command 'profiles [a-z]+' is deprecated\./g, "")
         .replace(/Recommended replacement: The 'config [a-z]+' command/g, "")
         .replace(/Recommended replacement: Edit your Zowe V2 configuration\s+zowe\.config\.json/g, "")
-        .trim().length === 0;
+        .trim();
 }
 
 /**


### PR DESCRIPTION
Some more fixes for system tests in https://github.com/zowe/zowe-cli-secrets-for-kubernetes 🙂 

The reason for deprecating `isStderrEmptyForProfilesCommand` is:

* If the following expect fails, the Jest error message does not show the contents of stderr 😢 
    `expect(isStderrEmptyForProfilesCommand(response.stderr)).toBe(true);`

* If the following expect fails, the Jest error message will be more useful 🚀 
    `expect(stripProfileDeprecationMessages(response.stderr)).toEqual("");`

