### PR TITLE
fix: update packages for technical currency

### DIFF
--- a/.github/workflows/zowe-cli.yml
+++ b/.github/workflows/zowe-cli.yml
@@ -52,6 +52,7 @@ jobs:
       uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
+        check-latest: true
 
     - name: Disable Lint Annotations
       run: |

--- a/.github/workflows/zowe-cli.yml
+++ b/.github/workflows/zowe-cli.yml
@@ -174,7 +174,8 @@ jobs:
         env_vars: OS,NODE
 
   release:
-    if: github.event_name == 'push' && github.ref_protected
+    # if: github.event_name == 'push' && github.ref_protected
+    if: github.event_name == 'push'
     needs: test
     runs-on: ubuntu-latest
 

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "7.9.7",
+  "version": "7.9.8",
   "command": {
     "publish": {
       "ignoreChanges": [

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -23013,7 +23013,7 @@
     },
     "packages/cli": {
       "name": "@zowe/cli",
-      "version": "7.9.7",
+      "version": "7.9.8",
       "hasInstallScript": true,
       "license": "EPL-2.0",
       "dependencies": {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -12451,9 +12451,9 @@
       "dev": true
     },
     "node_modules/http-cache-semantics": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
-      "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ=="
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
+      "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ=="
     },
     "node_modules/http-proxy-agent": {
       "version": "5.0.0",
@@ -16210,13 +16210,10 @@
       "dev": true
     },
     "node_modules/json5": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
-      "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "dev": true,
-      "dependencies": {
-        "minimist": "^1.2.5"
-      },
       "bin": {
         "json5": "lib/cli.js"
       },
@@ -22254,18 +22251,6 @@
         }
       }
     },
-    "node_modules/ts-jest/node_modules/json5": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-      "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
-      "dev": true,
-      "bin": {
-        "json5": "lib/cli.js"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/ts-jest/node_modules/yargs-parser": {
       "version": "21.1.1",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
@@ -22288,9 +22273,9 @@
       }
     },
     "node_modules/tsconfig-paths/node_modules/json5": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-      "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
       "dev": true,
       "dependencies": {
         "minimist": "^1.2.0"
@@ -33231,9 +33216,9 @@
       "dev": true
     },
     "http-cache-semantics": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
-      "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ=="
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
+      "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ=="
     },
     "http-proxy-agent": {
       "version": "5.0.0",
@@ -36111,13 +36096,10 @@
       "dev": true
     },
     "json5": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
-      "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
-      "dev": true,
-      "requires": {
-        "minimist": "^1.2.5"
-      }
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true
     },
     "jsonc-parser": {
       "version": "3.2.0",
@@ -40710,12 +40692,6 @@
         "yargs-parser": "^21.0.1"
       },
       "dependencies": {
-        "json5": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-          "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
-          "dev": true
-        },
         "yargs-parser": {
           "version": "21.1.1",
           "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
@@ -40737,9 +40713,9 @@
       },
       "dependencies": {
         "json5": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-          "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+          "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
           "dev": true,
           "requires": {
             "minimist": "^1.2.0"

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Zowe CLI package will be documented in this file.
 
+## Recent Changes
+
+- BugFix: Updated Imperative to include bugfixes in version `5.7.8`.
+
 ## `7.9.7`
 
 - BugFix: Updated Imperative to include bugfixes in version `5.7.7`.

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to the Zowe CLI package will be documented in this file.
 
-## Recent Changes
+## `7.9.8`
 
 - BugFix: Updated dependencies in npm-shrinkwrap for technical currency.
 

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the Zowe CLI package will be documented in this file.
 
 ## Recent Changes
 
-- BugFix: Updated Imperative to include bugfixes in version `5.7.8`.
+- BugFix: Updated dependencies in npm-shrinkwrap for technical currency.
 
 ## `7.9.7`
 

--- a/packages/cli/__tests__/zosjobs/__integration__/submit/stdin/__scripts__/submit_help.sh
+++ b/packages/cli/__tests__/zosjobs/__integration__/submit/stdin/__scripts__/submit_help.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 set -e
 
 zowe zos-jobs submit stdin -h

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zowe/cli",
-  "version": "7.9.7",
+  "version": "7.9.8",
   "description": "Zowe CLI is a command line interface (CLI) that provides a simple and streamlined way to interact with IBM z/OS.",
   "author": "Zowe",
   "license": "EPL-2.0",

--- a/release.config.js
+++ b/release.config.js
@@ -31,7 +31,7 @@ module.exports = {
             smokeTest: true
         }],
         ["@octorelease/github", {
-            checkPrLabels: true
+            // checkPrLabels: true
         }],
         "@octorelease/git"
     ]

--- a/release.config.js
+++ b/release.config.js
@@ -1,15 +1,19 @@
 module.exports = {
     branches: [
         {
-            name: "master",
-            level: "minor",
-            dependencies: ["@zowe/perf-timing", "@zowe/imperative"]
-        },
-        {
-            name: "zowe-v?-lts",
-            level: "patch",
-            dependencies: ["@zowe/perf-timing", "@zowe/imperative"]
+            name: "fix-7.9.8",
+            level: "patch"
         }
+        // {
+        //     name: "master",
+        //     level: "minor",
+        //     dependencies: ["@zowe/perf-timing", "@zowe/imperative"]
+        // },
+        // {
+        //     name: "zowe-v?-lts",
+        //     level: "patch",
+        //     dependencies: ["@zowe/perf-timing", "@zowe/imperative"]
+        // }
         // {
         //     name: "next",
         //     prerelease: true,


### PR DESCRIPTION
ℹ️ Note:
- This branch was created from the `v7.9.7` tag.
- This should allow us to publish directly from this branch if we don't want to release any new enhancements for Zowe v2.6.1

---

Once we publish (if we decide to do so) we can rebase the branch with master instead of the v7.9.7 tag

---

**Context**
- Similar to https://github.com/zowe/imperative/pull/935

---

UPDATE:

**TODO**
- [x] Update changelog to `Updated dependencies in npm-shrinkwrap for technical currency`
- [x] publish a patch release from this branch
- [ ] rebase with master
- [ ] merge