### PR TITLE
Update failing system tests

### DIFF
--- a/packages/cli/__tests__/zosfiles/__system__/compare/ds/Compare.ds.system.test.ts
+++ b/packages/cli/__tests__/zosfiles/__system__/compare/ds/Compare.ds.system.test.ts
@@ -60,7 +60,7 @@ describe("Compare Data Sets", () => {
         });
 
         it("should compare data sets", async () => {
-            const shellScript = path.join(__dirname, "__scripts__/compare_data_set.sh");
+            const shellScript = path.join(__dirname, "__scripts__", "compare_data_set.sh");
             const response = runCliScript(shellScript, testEnvironment, [dsname+"(MEMB1)", dsname+"(MEMB2)"]);
             expect(response.stderr.toString()).toBe("");
             expect(response.status).toBe(0);
@@ -69,7 +69,7 @@ describe("Compare Data Sets", () => {
     });
     describe("Expected failures", () => {
         it("should fail due to specified data set name does not exist", async () => {
-            const shellScript = path.join(__dirname, "__scripts__", "command", "command_compare_data_set.sh");
+            const shellScript = path.join(__dirname, "__scripts__", "compare_data_set.sh");
             const response = runCliScript(shellScript, testEnvironment, [dsname+".dummy(MEMB1)", dsname+"(MEMB2)"]);
             expect(response.status).toBe(1);
             expect(response.stderr.toString()).toContain("Data set not found.");

--- a/packages/cli/__tests__/zosjobs/__system__/cancel/__scripts__/job/cancel_job_v1.sh
+++ b/packages/cli/__tests__/zosjobs/__system__/cancel/__scripts__/job/cancel_job_v1.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# Max attempt count
+ATTEMPTS=10
+
+# Wait time between attempts
+WAIT=10
+
+# Submit the job and ensure the RC is 0
+JOBID=`zowe jobs submit lf "$1" --rff jobid --rft string`
+RC=$?
+if [ $RC -gt 0 ]
+then
+    echo $JOBID 1>&2
+    echo "Submit returned a non-zero return code" 1>&2
+    exit $RC
+fi
+
+# Cancel the job 1
+zowe jobs cancel job $JOBID --modify-version 1.0
+RC=$?
+
+if [ $RC -gt 0 ]
+then
+    echo "The cancel job command returned on first cancel with a non-zero rc: $RC" 1>&2
+    exit $RC
+fi

--- a/packages/cli/__tests__/zosjobs/__system__/cancel/__scripts__/job/cancel_job_v1_fully_qualified.sh
+++ b/packages/cli/__tests__/zosjobs/__system__/cancel/__scripts__/job/cancel_job_v1_fully_qualified.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+JCL=$1
+HOST=$2
+PORT=$3
+USER=$4
+PASS=$5
+
+# Max attempt count
+ATTEMPTS=10
+
+# Wait time between attempts
+WAIT=10
+
+# Submit the job and ensure the RC is 0
+JOBID=`zowe jobs submit lf "$JCL" --host $HOST --port $PORT --user $USER --password $PASS --ru=false --rff jobid --rft string`
+RC=$?
+if [ $RC -gt 0 ]
+then
+    echo $JOBID 1>&2
+    echo "Submit returned a non-zero return code" 1>&2
+    exit $RC
+fi
+
+# Cancel the job
+zowe jobs cancel job $JOBID --host $HOST --port $PORT --user $USER --password $PASS --ru=false --modify-version 1.0
+RC=$?
+
+if [ $RC -gt 0 ]
+then
+    echo "The cancel job command returned a non-zero rc: $RC" 1>&2
+    exit $RC
+fi

--- a/packages/cli/__tests__/zosjobs/__system__/cancel/cli.zos-jobs.cancel.job.system.test.ts
+++ b/packages/cli/__tests__/zosjobs/__system__/cancel/cli.zos-jobs.cancel.job.system.test.ts
@@ -61,8 +61,8 @@ describe("zos-jobs cancel job command", () => {
     });
 
     describe("successful scenario", () => {
-        it("should cancel a job", () => {
-            const response = runCliScript(__dirname + "/__scripts__/job/cancel_job.sh", TEST_ENVIRONMENT, [LOCAL_JCL_FILE]);
+        it("should cancel a job v1", () => {
+            const response = runCliScript(__dirname + "/__scripts__/job/cancel_job_v1.sh", TEST_ENVIRONMENT, [LOCAL_JCL_FILE]);
             expect(response.stderr.toString()).toBe("");
             expect(response.status).toBe(0);
             expect(response.stdout.toString()).toContain("Successfully submitted request to cancel job");
@@ -70,6 +70,14 @@ describe("zos-jobs cancel job command", () => {
 
         it("should cancel a job v2", () => {
             const response = runCliScript(__dirname + "/__scripts__/job/cancel_job_v2.sh", TEST_ENVIRONMENT, [LOCAL_JCL_FILE]);
+            expect(response.stderr.toString()).toBe("");
+            expect(response.status).toBe(0);
+            expect(response.stdout.toString()).toContain("Successfully canceled job");
+            expect(response.stdout.toString()).not.toContain("Failed to cancel job");
+        });
+
+        it("should cancel a job default", () => {
+            const response = runCliScript(__dirname + "/__scripts__/job/cancel_job.sh", TEST_ENVIRONMENT, [LOCAL_JCL_FILE]);
             expect(response.stderr.toString()).toBe("");
             expect(response.status).toBe(0);
             expect(response.stdout.toString()).toContain("Successfully canceled job");
@@ -94,8 +102,8 @@ describe("zos-jobs cancel job command", () => {
                 await TestEnvironment.cleanUp(TEST_ENVIRONMENT_NO_PROF);
             });
 
-            it("cancel a job without a profile", async () => {
-                const response = runCliScript(__dirname + "/__scripts__/job/cancel_job_fully_qualified.sh",
+            it("cancel a job without a profile 1.0", async () => {
+                const response = runCliScript(__dirname + "/__scripts__/job/cancel_job_v1_fully_qualified.sh",
                     TEST_ENVIRONMENT_NO_PROF,
                     [
                         LOCAL_JCL_FILE,
@@ -111,6 +119,21 @@ describe("zos-jobs cancel job command", () => {
 
             it("cancel a job without a profile 2.0", async () => {
                 const response = runCliScript(__dirname + "/__scripts__/job/cancel_job_v2_fully_qualified.sh",
+                    TEST_ENVIRONMENT_NO_PROF,
+                    [
+                        LOCAL_JCL_FILE,
+                        DEFAULT_SYSTEM_PROPS.zosmf.host,
+                        DEFAULT_SYSTEM_PROPS.zosmf.port,
+                        DEFAULT_SYSTEM_PROPS.zosmf.user,
+                        DEFAULT_SYSTEM_PROPS.zosmf.password,
+                    ]);
+                expect(response.stderr.toString()).toBe("");
+                expect(response.status).toBe(0);
+                expect(response.stdout.toString()).toContain("Successfully canceled job");
+            });
+
+            it("cancel a job without a profile default", async () => {
+                const response = runCliScript(__dirname + "/__scripts__/job/cancel_job_fully_qualified.sh",
                     TEST_ENVIRONMENT_NO_PROF,
                     [
                         LOCAL_JCL_FILE,

--- a/packages/cli/__tests__/zosjobs/__system__/delete/__scripts__/job/delete_job_v1.sh
+++ b/packages/cli/__tests__/zosjobs/__system__/delete/__scripts__/job/delete_job_v1.sh
@@ -6,10 +6,9 @@ ATTEMPTS=10
 # Wait time between attempts
 WAIT=10
 
-# Submit a job and ensure the RC is 0
+# Submit the job and ensure the RC is 0
 JOBID=`zowe jobs submit ds "$1" --rff jobid --rft string`
 RC=$?
-shift
 if [ $RC -gt 0 ]
 then
     echo $JOBID 1>&2
@@ -41,12 +40,12 @@ if [ $ATTEMPTS -eq 0 -a "$STATUS" != "OUTPUT" ]; then
     exit 1
 fi
 
-# Purge the jobs
-zowe jobs delete old-jobs $@
+# Purge the job
+zowe jobs delete job $JOBID --modify-version 1.0
 RC=$?
 
 if [ $RC -gt 0 ]
 then
-    echo "The delete old-jobs command returned a non-zero rc: $RC" 1>&2
+    echo "The delete job command returned a non-zero rc: $RC" 1>&2
     exit $RC
 fi

--- a/packages/cli/__tests__/zosjobs/__system__/delete/cli.zos-jobs.delete.job.system.test.ts
+++ b/packages/cli/__tests__/zosjobs/__system__/delete/cli.zos-jobs.delete.job.system.test.ts
@@ -40,8 +40,8 @@ describe("zos-jobs delete job command", () => {
     });
 
     describe("successful scenario", () => {
-        it("should delete a job", () => {
-            const response = runCliScript(__dirname + "/__scripts__/job/delete_job.sh",
+        it("should delete a job 1.0", () => {
+            const response = runCliScript(__dirname + "/__scripts__/job/delete_job_v1.sh",
                 TEST_ENVIRONMENT, [IEFBR14_JCL]);
             expect(response.stderr.toString()).toBe("");
             expect(response.status).toBe(0);
@@ -50,6 +50,14 @@ describe("zos-jobs delete job command", () => {
 
         it("should delete a job 2.0", () => {
             const response = runCliScript(__dirname + "/__scripts__/job/delete_job_v2.sh",
+                TEST_ENVIRONMENT, [IEFBR14_JCL]);
+            expect(response.stderr.toString()).toBe("");
+            expect(response.status).toBe(0);
+            expect(response.stdout.toString()).toContain("Successfully deleted job");
+        });
+
+        it("should delete a job default", () => {
+            const response = runCliScript(__dirname + "/__scripts__/job/delete_job.sh",
                 TEST_ENVIRONMENT, [IEFBR14_JCL]);
             expect(response.stderr.toString()).toBe("");
             expect(response.status).toBe(0);
@@ -74,7 +82,7 @@ describe("zos-jobs delete job command", () => {
                 await TestEnvironment.cleanUp(TEST_ENVIRONMENT_NO_PROF);
             });
 
-            it("delete a job without a profile", async () => {
+            it("delete a job without a profile 1.0", async () => {
                 const ZOWE_OPT_BASE_PATH = "ZOWE_OPT_BASE_PATH";
 
                 // if API Mediation layer is being used (basePath has a value) then
@@ -83,7 +91,7 @@ describe("zos-jobs delete job command", () => {
                     TEST_ENVIRONMENT_NO_PROF.env[ZOWE_OPT_BASE_PATH] = DEFAULT_SYSTEM_PROPS.zosmf.basePath;
                 }
 
-                const response = runCliScript(__dirname + "/__scripts__/job/delete_job_fully_qualified.sh",
+                const response = runCliScript(__dirname + "/__scripts__/job/delete_job_v1_fully_qualified.sh",
                     TEST_ENVIRONMENT_NO_PROF,
                     [
                         IEFBR14_JCL,
@@ -107,6 +115,29 @@ describe("zos-jobs delete job command", () => {
                 }
 
                 const response = runCliScript(__dirname + "/__scripts__/job/delete_job_v2_fully_qualified.sh",
+                    TEST_ENVIRONMENT_NO_PROF,
+                    [
+                        IEFBR14_JCL,
+                        DEFAULT_SYSTEM_PROPS.zosmf.host,
+                        DEFAULT_SYSTEM_PROPS.zosmf.port,
+                        DEFAULT_SYSTEM_PROPS.zosmf.user,
+                        DEFAULT_SYSTEM_PROPS.zosmf.password,
+                    ]);
+                expect(response.stderr.toString()).toBe("");
+                expect(response.status).toBe(0);
+                expect(response.stdout.toString()).toContain("Successfully deleted job");
+            });
+
+            it("delete a job without a profile default", async () => {
+                const ZOWE_OPT_BASE_PATH = "ZOWE_OPT_BASE_PATH";
+
+                // if API Mediation layer is being used (basePath has a value) then
+                // set an ENVIRONMENT variable to be used by zowe.
+                if (DEFAULT_SYSTEM_PROPS.zosmf.basePath != null) {
+                    TEST_ENVIRONMENT_NO_PROF.env[ZOWE_OPT_BASE_PATH] = DEFAULT_SYSTEM_PROPS.zosmf.basePath;
+                }
+
+                const response = runCliScript(__dirname + "/__scripts__/job/delete_job_fully_qualified.sh",
                     TEST_ENVIRONMENT_NO_PROF,
                     [
                         IEFBR14_JCL,

--- a/packages/cli/__tests__/zosjobs/__system__/delete/cli.zos-jobs.delete.old-jobs.system.test.ts
+++ b/packages/cli/__tests__/zosjobs/__system__/delete/cli.zos-jobs.delete.old-jobs.system.test.ts
@@ -37,7 +37,7 @@ describe("zos-jobs delete old-jobs command", () => {
     });
 
     describe("successful scenario", () => {
-        it("should delete all old jobs sequentially", () => {
+        it("should delete all old jobs sequentially default", () => {
             const response = runCliScript(__dirname + "/__scripts__/old-jobs/delete_old_jobs.sh",
                 TEST_ENVIRONMENT, [IEFBR14_JCL]);
             expect(response.status).toBe(0);
@@ -45,7 +45,7 @@ describe("zos-jobs delete old-jobs command", () => {
             expect(response.stdout.toString()).toContain("Successfully deleted");
         });
 
-        it("should delete all old jobs in parallel", () => {
+        it("should delete all old jobs in parallel default", () => {
             const response = runCliScript(__dirname + "/__scripts__/old-jobs/delete_old_jobs.sh",
                 TEST_ENVIRONMENT, [IEFBR14_JCL, "--mcr", "0"]);
             expect(response.status).toBe(0);
@@ -53,9 +53,33 @@ describe("zos-jobs delete old-jobs command", () => {
             expect(response.stdout.toString()).toContain("Successfully deleted");
         });
 
-        it("should delete all old jobs with modifyVersion 2.0", () => {
+        it("should delete all old jobs with modifyVersion 1.0 sequentially", () => {
+            const response = runCliScript(__dirname + "/__scripts__/old-jobs/delete_old_jobs.sh",
+                TEST_ENVIRONMENT, [IEFBR14_JCL, "--modify-version", "1.0"]);
+            expect(response.status).toBe(0);
+            expect(response.stderr.toString()).toBe("");
+            expect(response.stdout.toString()).toContain("Successfully deleted");
+        });
+
+        it("should delete all old jobs with modifyVersion 1.0 parallel", () => {
+            const response = runCliScript(__dirname + "/__scripts__/old-jobs/delete_old_jobs.sh",
+                TEST_ENVIRONMENT, [IEFBR14_JCL, "--mcr", "0", "--modify-version", "1.0"]);
+            expect(response.status).toBe(0);
+            expect(response.stderr.toString()).toBe("");
+            expect(response.stdout.toString()).toContain("Successfully deleted");
+        });
+
+        it("should delete all old jobs with modifyVersion 2.0 sequentially", () => {
             const response = runCliScript(__dirname + "/__scripts__/old-jobs/delete_old_jobs.sh",
                 TEST_ENVIRONMENT, [IEFBR14_JCL, "--modify-version", "2.0"]);
+            expect(response.status).toBe(0);
+            expect(response.stderr.toString()).toBe("");
+            expect(response.stdout.toString()).toContain("Successfully deleted");
+        });
+
+        it("should delete all old jobs with modifyVersion 2.0 parallel", () => {
+            const response = runCliScript(__dirname + "/__scripts__/old-jobs/delete_old_jobs.sh",
+                TEST_ENVIRONMENT, [IEFBR14_JCL, "--mcr", "0", "--modify-version", "2.0"]);
             expect(response.status).toBe(0);
             expect(response.stderr.toString()).toBe("");
             expect(response.stdout.toString()).toContain("Successfully deleted");

--- a/packages/zosjobs/__tests__/__system__/CancelJobs.system.test.ts
+++ b/packages/zosjobs/__tests__/__system__/CancelJobs.system.test.ts
@@ -92,7 +92,7 @@ describe("CancelJobs System tests", () => {
             expect(response).not.toBeUndefined();
             expect(response?.status).toEqual("0"); // intermittent failure
         }, LONG_TIMEOUT);
-         
+
         it("should be able to cancel a job using cancelJobCommon (job version 1)", async () => {
             const job = await SubmitJobs.submitJclNotifyCommon(REAL_SESSION, {jcl: iefbr14JCL, status: "INPUT"});
             expect(job.retcode).toBeNull(); // job is not complete, no CC

--- a/packages/zosjobs/__tests__/__system__/CancelJobs.system.test.ts
+++ b/packages/zosjobs/__tests__/__system__/CancelJobs.system.test.ts
@@ -10,7 +10,7 @@
 */
 
 import { ImperativeError, Session, RestClientError } from "@zowe/imperative";
-import { CancelJobs, SubmitJobs, IJob } from "../../src";
+import { CancelJobs, SubmitJobs, IJob, ICancelJobParms } from "../../src";
 import { ITestEnvironment } from "@zowe/cli-test-utils";
 import { TestEnvironment } from "../../../../__tests__/__src__/environment/TestEnvironment";
 import { ITestPropertiesSchema } from "../../../../__tests__/__src__/properties/ITestPropertiesSchema";
@@ -47,24 +47,56 @@ describe("CancelJobs System tests", () => {
     });
 
     describe("Positive tests", () => {
-        it("should be able to cancel a job using cancelJob", async () => {
+        it("should be able to cancel a job using cancelJob (modify version 1)", async () => {
+            const job = await SubmitJobs.submitJclNotifyCommon(REAL_SESSION, {jcl: iefbr14JCL, status: "INPUT"});
+            expect(job.retcode).toBeNull(); // job is not complete, no CC
+            const response = await CancelJobs.cancelJob(REAL_SESSION, job.jobname, job.jobid, "1.0");
+            expect(response).toBeUndefined();
+        }, LONG_TIMEOUT);
+
+        it("should be able to cancel a job using cancelJob (modify version 2)", async () => {
+            const job = await SubmitJobs.submitJclNotifyCommon(REAL_SESSION, {jcl: iefbr14JCL, status: "INPUT"});
+            expect(job.retcode).toBeNull(); // job is not complete, no CC
+            const response = await CancelJobs.cancelJob(REAL_SESSION, job.jobname, job.jobid, "2.0");
+            expect(response).not.toBeUndefined();
+            expect(response?.status).toEqual(0); // intermittent failure
+        }, LONG_TIMEOUT);
+
+        it("should be able to cancel a job using cancelJob (modify version default)", async () => {
             const job = await SubmitJobs.submitJclNotifyCommon(REAL_SESSION, {jcl: iefbr14JCL, status: "INPUT"});
             expect(job.retcode).toBeNull(); // job is not complete, no CC
             const response = await CancelJobs.cancelJob(REAL_SESSION, job.jobname, job.jobid);
+            expect(response).not.toBeUndefined();
+            expect(response?.status).toEqual(0); // intermittent failure
+        }, LONG_TIMEOUT);
+
+        it("should be able to cancel a job using cancelJobForJob (modify version 1)", async () => {
+            const job = await SubmitJobs.submitJclNotifyCommon(REAL_SESSION, {jcl: iefbr14JCL, status: "INPUT"});
+            expect(job.retcode).toBeNull(); // job is not complete, no CC
+            const response = await CancelJobs.cancelJobForJob(REAL_SESSION, job, "1.0");
             expect(response).toBeUndefined();
         }, LONG_TIMEOUT);
 
-        it("should be able to cancel a job using cancelJobForJob", async () => {
+        it("should be able to cancel a job using cancelJobForJob (modify version 2)", async () => {
+            const job = await SubmitJobs.submitJclNotifyCommon(REAL_SESSION, {jcl: iefbr14JCL, status: "INPUT"});
+            expect(job.retcode).toBeNull(); // job is not complete, no CC
+            const response = await CancelJobs.cancelJobForJob(REAL_SESSION, job, "2.0");
+            expect(response).not.toBeUndefined();
+            expect(response?.status).toEqual(0); // intermittent failure
+        }, LONG_TIMEOUT);
+
+        it("should be able to cancel a job using cancelJobForJob (modify version default)", async () => {
             const job = await SubmitJobs.submitJclNotifyCommon(REAL_SESSION, {jcl: iefbr14JCL, status: "INPUT"});
             expect(job.retcode).toBeNull(); // job is not complete, no CC
             const response = await CancelJobs.cancelJobForJob(REAL_SESSION, job);
-            expect(response).toBeUndefined();
+            expect(response).not.toBeUndefined();
+            expect(response?.status).toEqual(0); // intermittent failure
         }, LONG_TIMEOUT);
-
-        it("should be able to cancel a job using cancelJobCommon", async () => {
+         
+        it("should be able to cancel a job using cancelJobCommon (job version 1)", async () => {
             const job = await SubmitJobs.submitJclNotifyCommon(REAL_SESSION, {jcl: iefbr14JCL, status: "INPUT"});
             expect(job.retcode).toBeNull(); // job is not complete, no CC
-            const response = await CancelJobs.cancelJobCommon(REAL_SESSION, {jobname: job.jobname, jobid: job.jobid});
+            const response = await CancelJobs.cancelJobCommon(REAL_SESSION, {jobname: job.jobname, jobid: job.jobid, version: "1.0"});
             expect(response).toBeUndefined();
         }, LONG_TIMEOUT);
 
@@ -72,16 +104,24 @@ describe("CancelJobs System tests", () => {
             const job = await SubmitJobs.submitJclNotifyCommon(REAL_SESSION, {jcl: iefbr14JCL, status: "INPUT"});
             expect(job.retcode).toBeNull(); // job is not complete, no CC
             const response = await CancelJobs.cancelJobCommon(REAL_SESSION, {jobname: job.jobname, jobid: job.jobid, version: "2.0"});
-            expect(response.status).toEqual("0"); // intermittent failure
+            expect(response).toBeDefined();
+            expect(response?.status).toEqual("0"); // intermittent failure
+        }, LONG_TIMEOUT);
+
+        it("should be able to cancel a job using cancelJobCommon (job version default)", async () => {
+            const job = await SubmitJobs.submitJclNotifyCommon(REAL_SESSION, {jcl: iefbr14JCL, status: "INPUT"});
+            expect(job.retcode).toBeNull(); // job is not complete, no CC
+            const response = await CancelJobs.cancelJobCommon(REAL_SESSION, {jobname: job.jobname, jobid: job.jobid});
+            expect(response?.status).toEqual("0"); // intermittent failure
         }, LONG_TIMEOUT);
 
         it("should be able to cancel a job using cancelJobCommon (job version 2.0 - synchronous) and return an error feedback object", async () => {
             const job = await SubmitJobs.submitJclNotifyCommon(REAL_SESSION, {jcl: iefbr14JCL, status: "INPUT"});
             expect(job.retcode).toBeNull(); // job is not complete, no CC
             let response = await CancelJobs.cancelJobCommon(REAL_SESSION, {jobname: job.jobname, jobid: job.jobid, version: "2.0"});
-            expect(response.status).toEqual("0");
+            expect(response?.status).toEqual("0");
             response = await CancelJobs.cancelJobCommon(REAL_SESSION, {jobname: job.jobname, jobid: job.jobid, version: "2.0"});
-            expect(response.status).toEqual("156");
+            expect(response?.status).toEqual("156");
         }, LONG_TIMEOUT);
     });
 

--- a/packages/zosjobs/__tests__/__system__/CancelJobs.system.test.ts
+++ b/packages/zosjobs/__tests__/__system__/CancelJobs.system.test.ts
@@ -59,7 +59,7 @@ describe("CancelJobs System tests", () => {
             expect(job.retcode).toBeNull(); // job is not complete, no CC
             const response = await CancelJobs.cancelJob(REAL_SESSION, job.jobname, job.jobid, "2.0");
             expect(response).not.toBeUndefined();
-            expect(response?.status).toEqual(0); // intermittent failure
+            expect(response?.status).toEqual("0"); // intermittent failure
         }, LONG_TIMEOUT);
 
         it("should be able to cancel a job using cancelJob (modify version default)", async () => {
@@ -67,7 +67,7 @@ describe("CancelJobs System tests", () => {
             expect(job.retcode).toBeNull(); // job is not complete, no CC
             const response = await CancelJobs.cancelJob(REAL_SESSION, job.jobname, job.jobid);
             expect(response).not.toBeUndefined();
-            expect(response?.status).toEqual(0); // intermittent failure
+            expect(response?.status).toEqual("0"); // intermittent failure
         }, LONG_TIMEOUT);
 
         it("should be able to cancel a job using cancelJobForJob (modify version 1)", async () => {
@@ -82,7 +82,7 @@ describe("CancelJobs System tests", () => {
             expect(job.retcode).toBeNull(); // job is not complete, no CC
             const response = await CancelJobs.cancelJobForJob(REAL_SESSION, job, "2.0");
             expect(response).not.toBeUndefined();
-            expect(response?.status).toEqual(0); // intermittent failure
+            expect(response?.status).toEqual("0"); // intermittent failure
         }, LONG_TIMEOUT);
 
         it("should be able to cancel a job using cancelJobForJob (modify version default)", async () => {
@@ -90,7 +90,7 @@ describe("CancelJobs System tests", () => {
             expect(job.retcode).toBeNull(); // job is not complete, no CC
             const response = await CancelJobs.cancelJobForJob(REAL_SESSION, job);
             expect(response).not.toBeUndefined();
-            expect(response?.status).toEqual(0); // intermittent failure
+            expect(response?.status).toEqual("0"); // intermittent failure
         }, LONG_TIMEOUT);
          
         it("should be able to cancel a job using cancelJobCommon (job version 1)", async () => {

--- a/packages/zosjobs/__tests__/__system__/CancelJobs.system.test.ts
+++ b/packages/zosjobs/__tests__/__system__/CancelJobs.system.test.ts
@@ -10,7 +10,7 @@
 */
 
 import { ImperativeError, Session, RestClientError } from "@zowe/imperative";
-import { CancelJobs, SubmitJobs, IJob, ICancelJobParms } from "../../src";
+import { CancelJobs, SubmitJobs, IJob } from "../../src";
 import { ITestEnvironment } from "@zowe/cli-test-utils";
 import { TestEnvironment } from "../../../../__tests__/__src__/environment/TestEnvironment";
 import { ITestPropertiesSchema } from "../../../../__tests__/__src__/properties/ITestPropertiesSchema";


### PR DESCRIPTION
Updates and adds system tests around the recent change to modifyVersion in the zos-jobs SDK
Also fixes an incorrect shell script test path in the zos-files compare SDK system tests