### PR TITLE
fixing configuration - unsure if should build validation command

### DIFF
--- a/packages/core/src/apiml/Services.ts
+++ b/packages/core/src/apiml/Services.ts
@@ -176,7 +176,7 @@ export class Services {
      *          "zosmf": {
      *              "type": "zosmf",
      *              "properties": {
-     *                  "basePath": "/zosmf/api/v1"
+     *                  "basePath": "/api/v1"
      *              }
      *          },
      *          "ibmzosmf": {


### PR DESCRIPTION
Correcting static basepath definition in zosmf profile for `zowe config auto-init` as requested in the following [issue](https://github.com/zowe/zowe-cli/issues/1145). 

