### PR TITLE
Use Node 16 and npm@8 in release workflow

### DIFF
--- a/.github/workflows/zowe-cli.yml
+++ b/.github/workflows/zowe-cli.yml
@@ -186,10 +186,11 @@ jobs:
         persist-credentials: false
         ref: ${{ github.ref }}
 
-    - name: Use Node.js LTS
+    # Use Node 16 until npm@9 bundled with Node 18 becomes more stable
+    - name: Use Node.js 16
       uses: actions/setup-node@v2
       with:
-        node-version: 'lts/*'
+        node-version: '16'
 
     - name: Install Dependencies
       run: npm ci


### PR DESCRIPTION
This PR should be tagged as `release-minor` after merging since https://github.com/zowe/zowe-cli/pull/1641 failed to release.

The error in [last night's workflow](https://github.com/zowe/zowe-cli/actions/runs/4293661617/jobs/7505677407) seems specific to npm@9.3.x. Updating to a newer version (npm@9.5.x) may fix it, but reverting to a known good version (npm@8) seems like a safer option until npm@9 becomes more stable.