### PR TITLE
new command: zowe files edit [ds, uss] [file location] [--editor]  

### DIFF
--- a/packages/cli/src/zosfiles/-strings-/en.ts
+++ b/packages/cli/src/zosfiles/-strings-/en.ts
@@ -725,6 +725,36 @@ export default {
             "or SSS,NNN where is is the start and NNN is the number of records retrieved."
         }
     },
+    EDIT: {
+        SUMMARY: "Edit the contents of a data set or USS file",
+        DESCRIPTION: "Edit the contents of a data set or USS file with your terminal and default editor.",
+        ACTIONS: {
+            DATA_SET: {
+                SUMMARY: "Edit content from a z/OS data set",
+                DESCRIPTION: "Edit content from a z/OS data set with your terminal and default editor.",
+                POSITIONALS: {
+                    DATASETNAME: "The name of the data set you want to display."
+                },
+                EXAMPLES: {
+                    EX1: `Edit the contents of the data set member "ibmuser.cntl(iefbr14)"`,
+                }
+            },
+            USS_FILE: {
+                SUMMARY: "Edit content from a USS file",
+                DESCRIPTION: "Edit content from a Unix System Services (USS) file with your terminal and default editor.",
+                POSITIONALS: {
+                    USSFILE: "The name of the USS file you want to edit."
+                },
+                EXAMPLES: {
+                    EX1: `Edit the contents of the USS file "/a/ibmuser/my_text.txt"`,
+                }
+            }
+        },
+        OPTIONS: {
+            EDITOR: "Set the default editor that you wish to use for editing. Set the option to the editor's executable file location" +
+            "or the program's name: ie `--editor notepad`"
+        }
+    },
     COMPARE: {
         SUMMARY: "Compare the contents of a two data set members",
         DESCRIPTION: "Compare the contents of a two data set members on your terminal (stdout).",

--- a/packages/cli/src/zosfiles/ZosFiles.definition.ts
+++ b/packages/cli/src/zosfiles/ZosFiles.definition.ts
@@ -11,20 +11,21 @@
 
 import { ICommandDefinition } from "@zowe/imperative";
 import { ZosmfSession } from "@zowe/zosmf-for-zowe-sdk";
+import { CompareDefinition } from "./compare/Compare.definition";
+import { CopyDefinition } from "./copy/Copy.definition";
 import { CreateDefinition } from "./create/Create.definition";
 import { DeleteDefinition } from "./delete/Delete.definition";
-import { InvokeDefinition } from "./invoke/Invoke.definition";
 import { DownloadDefinition } from "./download/Download.definition";
-import { ListDefinition } from "./list/List.definition";
-import { UploadDefinition } from "./upload/Upload.definition";
-import { MountDefinition } from "./mount/Mount.definition";
-import { UnmountDefinition } from "./unmount/Unmount.definition";
+import { EditDefinition } from "./edit/Edit.definition";
 import { HMigrateDefinition } from "./hMigrate/HMigrate.definition";
 import { HRecallDefinition } from "./hRecall/HRecall.definition";
-import { CopyDefinition } from "./copy/Copy.definition";
+import { InvokeDefinition } from "./invoke/Invoke.definition";
+import { ListDefinition } from "./list/List.definition";
+import { MountDefinition } from "./mount/Mount.definition";
 import { RenameDefinition } from "./rename/Rename.definition";
+import { UnmountDefinition } from "./unmount/Unmount.definition";
+import { UploadDefinition } from "./upload/Upload.definition";
 import { ViewDefinition } from "./view/View.definition";
-import { CompareDefinition } from "./compare/Compare.definition";
 import { ZosFilesOptionDefinitions } from "./ZosFiles.options";
 
 /**
@@ -40,20 +41,21 @@ const definition: ICommandDefinition = {
     summary: "Manage z/OS data sets",
     description: "Manage z/OS data sets, create data sets, and more.",
     children: [
+        CompareDefinition,
+        CopyDefinition,
         CreateDefinition,
+        DownloadDefinition,
         DeleteDefinition,
-        InvokeDefinition,
+        EditDefinition,
         HMigrateDefinition,
         HRecallDefinition,
-        DownloadDefinition,
+        InvokeDefinition,
         ListDefinition,
-        UploadDefinition,
         MountDefinition,
-        UnmountDefinition,
-        CopyDefinition,
         RenameDefinition,
-        ViewDefinition,
-        CompareDefinition
+        UnmountDefinition,
+        UploadDefinition,
+        ViewDefinition
     ],
     passOn: [
         {

--- a/packages/cli/src/zosfiles/compare/CompareBaseHelper.ts
+++ b/packages/cli/src/zosfiles/compare/CompareBaseHelper.ts
@@ -123,7 +123,7 @@ export class CompareBaseHelper {
 
     /**
      * Helper function that compare-related handlers will use to get the contents of a local file
-     * @param filePath Path to the file to compate against
+     * @param filePath Path to the file to compare against
      * @returns Buffer with the contents of the file
      */
     public prepareLocalFile(filePath: string): Buffer {
@@ -171,15 +171,15 @@ export class CompareBaseHelper {
     }
 
     /**
-     * To get the difference string in ternninal or in browser
-     * @param {string} string1 - string of file 1 comtent
-     * @param  {string} string2 - string of file 2 comtent
+     * To get the difference string in terminal or in browser
+     * @param {string} string1 - string of file 1 content
+     * @param  {string} string2 - string of file 2 content
      * @returns {IZosFilesResponse}
      * @public
      * @memberof CompareBaseHelper
      */
     public async getResponse(string1: string, string2: string): Promise<IZosFilesResponse>{
-        //  CHECHKING IIF THE BROWSER VIEW IS TRUE, OPEN UP THE DIFFS IN BROWSER
+        //  CHECKING IF THE BROWSER VIEW IS TRUE, OPEN UP THE DIFFS IN BROWSER
         if (this.browserView) {
             await DiffUtils.openDiffInbrowser(string1, string2);
             return {

--- a/packages/cli/src/zosfiles/edit/Edit.definition.ts
+++ b/packages/cli/src/zosfiles/edit/Edit.definition.ts
@@ -1,0 +1,35 @@
+/*
+* This program and the accompanying materials are made available under the terms of the
+* Eclipse Public License v2.0 which accompanies this distribution, and is available at
+* https://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Copyright Contributors to the Zowe Project.
+*
+*/
+
+import {ICommandDefinition} from "@zowe/imperative";
+import {DatasetDefinition} from "./ds/Dataset.definition";
+
+import i18nTypings from "../-strings-/en";
+import {USSFileDefinition} from "./uss/USSFile.definition";
+
+// Does not use the import in anticipation of some internationalization work to be done later.
+const strings = (require("../-strings-/en").default as typeof i18nTypings).VIEW;
+
+/**
+ * View group definition containing its description and children
+ * @type {ICommandDefinition}
+ */
+export const ViewDefinition: ICommandDefinition = {
+    name: "view",
+    aliases: ["vw"],
+    type: "group",
+    summary: strings.SUMMARY,
+    description: strings.DESCRIPTION,
+    children: [
+        DatasetDefinition,
+        USSFileDefinition
+    ],
+};

--- a/packages/cli/src/zosfiles/edit/Edit.definition.ts
+++ b/packages/cli/src/zosfiles/edit/Edit.definition.ts
@@ -16,15 +16,15 @@ import i18nTypings from "../-strings-/en";
 import {USSFileDefinition} from "./uss/USSFile.definition";
 
 // Does not use the import in anticipation of some internationalization work to be done later.
-const strings = (require("../-strings-/en").default as typeof i18nTypings).VIEW;
+const strings = (require("../-strings-/en").default as typeof i18nTypings).EDIT;
 
 /**
- * View group definition containing its description and children
+ * Edit group definition containing its description and children
  * @type {ICommandDefinition}
  */
-export const ViewDefinition: ICommandDefinition = {
-    name: "view",
-    aliases: ["vw"],
+export const EditDefinition: ICommandDefinition = {
+    name: "edit",
+    aliases: ["ed"],
     type: "group",
     summary: strings.SUMMARY,
     description: strings.DESCRIPTION,

--- a/packages/cli/src/zosfiles/edit/Edit.options.ts
+++ b/packages/cli/src/zosfiles/edit/Edit.options.ts
@@ -29,6 +29,7 @@ export const EditOptions: { [key: string]: ICommandOptionDefinition } = {
         name: "editor",
         aliases: ["e"],
         description: strings.EDITOR,
-        type: "string"
+        type: "string",
+        required: false
     }
 };

--- a/packages/cli/src/zosfiles/edit/Edit.options.ts
+++ b/packages/cli/src/zosfiles/edit/Edit.options.ts
@@ -1,0 +1,34 @@
+/*
+* This program and the accompanying materials are made available under the terms of the
+* Eclipse Public License v2.0 which accompanies this distribution, and is available at
+* https://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Copyright Contributors to the Zowe Project.
+*
+*/
+
+import { ICommandOptionDefinition } from "@zowe/imperative";
+
+import i18nTypings from "../-strings-/en";
+
+// Does not use the import in anticipation of some internationalization work to be done later.
+const strings = (require("../-strings-/en").default as typeof i18nTypings).EDIT.OPTIONS;
+
+/**
+ * Object containing all options to be used by the View API
+ */
+export const EditOptions: { [key: string]: ICommandOptionDefinition } = {
+
+    /**
+     * The option to set a default editor
+     * @type {ICommandOptionDefinition}
+     */
+    editor: {
+        name: "editor",
+        aliases: ["e"],
+        description: strings.EDITOR,
+        type: "string"
+    }
+};

--- a/packages/cli/src/zosfiles/edit/Edit.utils.ts
+++ b/packages/cli/src/zosfiles/edit/Edit.utils.ts
@@ -37,11 +37,11 @@ export class EditUtilities {
         if (isUssFile){
             // Hash in a repeatable way if uss fileName
             const crypto = require("crypto");
-            return tmpdir() +"/" + crypto.createHash("shake256", { outputLength: 8 })
+            return tmpdir() +"\\" + crypto.createHash("shake256", { outputLength: 8 })
                 .update(fileName)
                 .digest("hex");
         }else{
-            return tmpdir() + "/" + fileName;
+            return tmpdir() + "\\" + fileName + ".txt";
         }
     }
 
@@ -55,6 +55,7 @@ export class EditUtilities {
             }
         } catch(err) {
             //imperative error probably?
+            return false;
         }
     }
 
@@ -64,7 +65,7 @@ export class EditUtilities {
             case Prompt.useStash:
                 input = await CliUtils.readPrompt("Keep and continue editing found stash? Y/n");
                 if (input === null) {
-                    // abort the command ... maybe do something w esc
+                    // abort the command ... maybe do something with esc
                 }
                 if (input == lowerCase("y")){
                     // keep stash
@@ -100,8 +101,9 @@ export class EditUtilities {
     public static async fileComparison(session: AbstractSession, commandParameters: IHandlerParameters, lfFile: File): Promise<IZosFilesResponse>{
         const handler = new LocalfileDatasetHandler;
         const helper = new CompareBaseHelper(commandParameters);
+        helper.browserView = true;
 
-        commandParameters.arguments.localFilePath = lfFile.path;
+        commandParameters.arguments.localFilePath = lfFile.path; //why do i do this? idr
         const lf = await handler.getFile1(session, commandParameters.arguments, helper);
         const mfds = await handler.getFile2(session, commandParameters.arguments, helper);
         // Editor will open with local file if default editor was set
@@ -130,7 +132,7 @@ export class EditUtilities {
             if (response.errorMessage){
                 if (response.errorMessage.includes("etag")){ //or error 412
                     //alert user that the version of document they've been editing has changed
-                    //ask if they want to continue working w their stash (local file)
+                    //ask if they want to continue working with their stash (local file)
                     const continueToEdit: boolean = await this.promptUser(Prompt.continueEditing, lfFile.path);
                     if (continueToEdit){
                         // Download dataset again, refresh the etag of lfFile

--- a/packages/cli/src/zosfiles/edit/Edit.utils.ts
+++ b/packages/cli/src/zosfiles/edit/Edit.utils.ts
@@ -1,0 +1,42 @@
+/*
+* This program and the accompanying materials are made available under the terms of the
+* Eclipse Public License v2.0 which accompanies this distribution, and is available at
+* https://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Copyright Contributors to the Zowe Project.
+*
+*/
+
+import { IImperativeConfig, Imperative, ProcessUtils } from "@zowe/imperative";
+import { PathLike } from "fs";
+import { tmpdir } from "os";
+import path = require("path");
+import { ICompareFileOptions } from "../compare/doc/ICompareFileOptions";
+
+/**
+ * Get the Imperative config object which defines properties of the CLI.
+ * This allows it to be accessed without calling Imperative.init.
+ */
+export function getImperativeConfig(): IImperativeConfig {
+    return require("./imperative");
+}
+
+// 2. build tmp_dir
+export function buildTempDir(sessionInfo, fileName, isUssFile): PathLike{
+    return tmpdir
+}
+// 2a. hash uss file name
+// 3. check for tmp_dir's existance as stash
+// 4a. if prexisting tmp_dir: override stash
+// 4b. if prexisting tmp_dir: use stash
+// 4ba. perform file comparison, show output in terminal
+// 4bb. overwrite ETAG 
+// 5a. check for default editor and headless environment
+ProcessUtils.isGuiAvailable
+// 5b. open lf in editor or tell user to open up on their own if headless or no set default
+// 6. wait for user input to continue
+// 7. once input recieved, upload tmp file with saved ETAG
+// 7a. if matching ETAG: sucessful upload, destroy tmp file -> END
+// 7a. if non-matching ETAG: unsucessful upload -> 4a

--- a/packages/cli/src/zosfiles/edit/Edit.utils.ts
+++ b/packages/cli/src/zosfiles/edit/Edit.utils.ts
@@ -9,34 +9,147 @@
 *
 */
 
-import { IImperativeConfig, Imperative, ProcessUtils } from "@zowe/imperative";
+import { AbstractSession, ICommandArguments, IHandlerParameters, ImperativeError, ProcessUtils } from "@zowe/imperative";
 import { PathLike } from "fs";
 import { tmpdir } from "os";
 import path = require("path");
-import { ICompareFileOptions } from "../compare/doc/ICompareFileOptions";
+import { Download, Upload, IZosFilesOptions, IZosFilesResponse } from "@zowe/zos-files-for-zowe-sdk";
+import LocalfileDatasetHandler from "../compare/lf-ds/LocalfileDataset.handler";
+import { CompareBaseHelper } from "../compare/CompareBaseHelper";
+import { CliUtils } from "@zowe/imperative";
+import { lowerCase } from "lodash";
+import { unlink, existsSync } from "fs";
 
-/**
- * Get the Imperative config object which defines properties of the CLI.
- * This allows it to be accessed without calling Imperative.init.
- */
-export function getImperativeConfig(): IImperativeConfig {
-    return require("./imperative");
+export enum Prompt {
+    useStash,
+    doneEditing, 
+    continueEditing
 }
 
-// 2. build tmp_dir
-export function buildTempDir(sessionInfo, fileName, isUssFile): PathLike{
-    return tmpdir
+export class File {
+    path: string;
+    name: string;
+    data: IZosFilesResponse;
+    etag: string;
 }
-// 2a. hash uss file name
-// 3. check for tmp_dir's existance as stash
-// 4a. if prexisting tmp_dir: override stash
-// 4b. if prexisting tmp_dir: use stash
-// 4ba. perform file comparison, show output in terminal
-// 4bb. overwrite ETAG 
-// 5a. check for default editor and headless environment
-ProcessUtils.isGuiAvailable
-// 5b. open lf in editor or tell user to open up on their own if headless or no set default
-// 6. wait for user input to continue
-// 7. once input recieved, upload tmp file with saved ETAG
-// 7a. if matching ETAG: sucessful upload, destroy tmp file -> END
-// 7a. if non-matching ETAG: unsucessful upload -> 4a
+  
+  
+  export class EditUtilities {
+
+    // 2. build tmp_dir
+    public static async buildTempDir(session: AbstractSession, fileName: PathLike, isUssFile?: boolean): Promise<string>{
+        let tmpDir = tmpdir();
+
+        if (isUssFile){
+            // 2a. hash if uss fileName
+            const crypto = require("crypto");
+            return tmpDir +"/" + crypto.createHash("shake256", { outputLength: 8 })
+                .update(fileName)
+                .digest("hex");
+        }else{
+            return tmpDir + "/" + fileName;
+        }
+    }
+
+    // 3. check for tmp_dir's existance as stash
+    public static async checkForStash(tmpDir: string): Promise<boolean>{
+        try {
+          if (existsSync(tmpDir)) {
+            return true;
+          }else{
+            return false;
+          }
+        } catch(err) {
+          console.error(err); //change to imperative error probably?
+        }
+    }
+
+    // override stash?
+    public static async newStash(session: AbstractSession, fileName: string, isUssFile?: boolean): Promise<IZosFilesResponse>{
+        if (isUssFile){
+            return await Download.ussFile(session, fileName, {returnEtag: true});
+        }
+        return await Download.dataSet(session, fileName, {returnEtag: true});
+    }
+
+    public static async promptUser(prompt: Prompt, fileInfo?: string): Promise<boolean>{
+        let input;
+        switch (prompt){
+            case Prompt.useStash:
+                input = await CliUtils.readPrompt("Keep and continue editing found stash? Y/n");
+                if (input === null) {
+                    // abort the command
+                } 
+                if (input == lowerCase("y")){
+                    // keep stash
+                    return true;
+                } else {
+                    // override stash
+                    return false;
+                }
+            case Prompt.doneEditing:
+                input = await CliUtils.readPrompt("Enter any value in terminal once finished editing temporary file");
+                if (input === null) {
+                    // abort the command
+                }else{
+                    return true;
+                }
+            case Prompt.continueEditing:
+                ``
+                input = await CliUtils.readPrompt("The version of the document you were editing has changed. Continue to make changes? Y/n\n" + fileInfo);
+                if (input === null) {
+                    // abort the command
+                } 
+                if (input == lowerCase("y")){
+                    // keep stash
+                    return true;
+                } else {
+                    // override stash
+                    return false;
+                }
+        }
+
+    }
+
+    public static async fileComparison(session: AbstractSession, commandParameters: IHandlerParameters, lfFile: File): Promise<IZosFilesResponse>{
+        const handler = new LocalfileDatasetHandler;
+        const helper = new CompareBaseHelper(commandParameters);
+
+        // 4ba. perform file comparison, show output in terminal
+        commandParameters.arguments.localFilePath = lfFile.path;
+        const lf = await handler.getFile1(session, commandParameters.arguments, helper);
+        const mfds = await handler.getFile2(session, commandParameters.arguments, helper);
+
+        // ProcessUtils.openInDefaultApp(lfFile.path)
+
+        // // 5a. check for default editor and headless environment
+        // // 5b. open lf in editor or tell user to open up on their own if headless or no set default
+        return await helper.getResponse(helper.prepareContent(lf), helper.prepareContent(mfds));
+    }
+
+
+
+
+    public static async uploadEdits(session: AbstractSession, lfFile: File): Promise<IZosFilesResponse>{
+    // 7. once input recieved, upload tmp file with saved ETAG
+    // 7a. if matching ETAG: sucessful upload, destroy tmp file -> END
+    // 7a. if non-matching ETAG: unsucessful upload -> 4a
+        let response: IZosFilesResponse;
+        try{
+            response = await Upload.fileToDataset(session, lfFile.path, lfFile.name, {etag: lfFile.etag});
+            // successful upload
+            return response;
+        }catch(err){
+            // unsuccessful upload, potential mismatched etag
+            return response;
+        }
+    }
+
+    public static async destroyTempFile(tmpDir:string): Promise<void>{
+        unlink (tmpDir, (err) => {
+            if (err) throw new ImperativeError({
+                msg: `Temporary file could not be deleted: ${tmpDir}`
+            });
+        })
+    }
+  }

--- a/packages/cli/src/zosfiles/edit/ds/Dataset.definition.ts
+++ b/packages/cli/src/zosfiles/edit/ds/Dataset.definition.ts
@@ -1,0 +1,54 @@
+/*
+* This program and the accompanying materials are made available under the terms of the
+* Eclipse Public License v2.0 which accompanies this distribution, and is available at
+* https://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Copyright Contributors to the Zowe Project.
+*
+*/
+
+import {ICommandDefinition} from "@zowe/imperative";
+import { EditOptions } from "../Edit.options";
+import i18nTypings from "../../-strings-/en";
+
+// Does not use the import in anticipation of some internationalization work to be done later.
+const strings = (require("../../-strings-/en").default as typeof i18nTypings).EDIT;
+
+/**
+ * View data set command definition containing its description, examples and/or options
+ * @type {ICommandDefinition}
+ */
+export const DatasetDefinition: ICommandDefinition = {
+    name: "data-set",
+    aliases: ["ds"],
+    summary: strings.ACTIONS.DATA_SET.SUMMARY,
+    description: strings.ACTIONS.DATA_SET.DESCRIPTION,
+    type: "command",
+    handler: __dirname + "/Dataset.handler",
+    profile: {
+        optional: ["zosmf"],
+    },
+    positionals: [
+        {
+            name: "dataSetName",
+            description: strings.ACTIONS.DATA_SET.POSITIONALS.DATASETNAME,
+            type: "string",
+            required: true
+        },
+    ],
+    options: [
+        EditOptions.editor
+    ],
+    examples: [
+        {
+            description: strings.ACTIONS.DATA_SET.EXAMPLES.EX1,
+            options: `"notepad"`
+        },
+        {
+            description: strings.ACTIONS.DATA_SET.EXAMPLES.EX1,
+            options: `"C:\\Windows\\System32\\Notepad.exe"`
+        }
+    ]
+};

--- a/packages/cli/src/zosfiles/edit/ds/Dataset.definition.ts
+++ b/packages/cli/src/zosfiles/edit/ds/Dataset.definition.ts
@@ -44,11 +44,11 @@ export const DatasetDefinition: ICommandDefinition = {
     examples: [
         {
             description: strings.ACTIONS.DATA_SET.EXAMPLES.EX1,
-            options: `"notepad"`
+            options: `"ibmuser.cntl(iefbr14)" "--editor" "notepad"`
         },
         {
             description: strings.ACTIONS.DATA_SET.EXAMPLES.EX1,
-            options: `"C:\\Windows\\System32\\Notepad.exe"`
+            options: `"ibmuser.cntl(iefbr14)" "--editor" "C:\\Windows\\System32\\Notepad.exe"`
         }
     ]
 };

--- a/packages/cli/src/zosfiles/edit/ds/Dataset.handler.ts
+++ b/packages/cli/src/zosfiles/edit/ds/Dataset.handler.ts
@@ -31,7 +31,7 @@ export default class DatasetHandler extends ZosFilesBaseHandler {
         const Utils = EditUtilities;
         const mfFile = new File;
         const lfFile = new File;
-        mfFile.fileName, lfFile.fileName = commandParameters.arguments.file;
+        mfFile.fileName =  lfFile.fileName = commandParameters.arguments.dataSetName;
 
 
         // Build tmp_dir
@@ -44,12 +44,14 @@ export default class DatasetHandler extends ZosFilesBaseHandler {
             overrideStash = await Utils.promptUser(Prompt.useStash);
         }
         if (overrideStash || !stash) {
-            mfFile.apiData, lfFile.apiData = await Download.dataSet(session, lfFile.fileName, {returnEtag: true, file: lfFile.path});
+            mfFile.zosFilesResp = lfFile.zosFilesResp = await Download.dataSet(session, lfFile.fileName,
+                {returnEtag: true, file: lfFile.path});
         }else{
-            // Download just to get etag. Don't overwrite prexisting file (stash) during process // etag = apiData.apiResponse.etag
-            mfFile.apiData, lfFile.apiData = await Download.dataSet(session, lfFile.fileName,
+            // Download just to get etag. Don't overwrite prexisting file (stash) during process // etag = with.apiResponse.etag
+            mfFile.zosFilesResp = lfFile.zosFilesResp = await Download.dataSet(session, lfFile.fileName,
                 {returnEtag: true, file: lfFile.path, overwrite: false});
         }
+        //need to catch errors here for filenames that dont exist
 
         // Edit local copy of mf file
         await Utils.makeEdits(session, commandParameters, lfFile);
@@ -62,7 +64,7 @@ export default class DatasetHandler extends ZosFilesBaseHandler {
 
         return {
             success: true,
-            commandResponse: "",//write something here about the successful editing/uploading
+            commandResponse: "Successfully uploaded edited file to mainframe",//write something here about the successful editing/uploading
             apiResponse: {}//return IZosFilesResponse here and pertinent file deets
         };
     }

--- a/packages/cli/src/zosfiles/edit/ds/Dataset.handler.ts
+++ b/packages/cli/src/zosfiles/edit/ds/Dataset.handler.ts
@@ -12,7 +12,7 @@
 import { AbstractSession, IHandlerParameters, ITaskWithStatus, TaskStage } from "@zowe/imperative";
 import { Download, IZosFilesResponse } from "@zowe/zos-files-for-zowe-sdk";
 import { ZosFilesBaseHandler } from "../../ZosFilesBase.handler";
-import { EditUtilities, Prompt, File } from "../Edit.utils"
+import { EditUtilities, Prompt, File } from "../Edit.utils";
 
 /**
  * Handler to edit a data set's content
@@ -38,7 +38,7 @@ export default class DatasetHandler extends ZosFilesBaseHandler {
         lfFile.path = await Utils.buildTempDir(mfFile.fileName, false);
 
         // Use or override stash (either way need to retrieve etag)
-        let stash: boolean = await Utils.checkForStash(lfFile.path);
+        const stash: boolean = await Utils.checkForStash(lfFile.path);
         let overrideStash: boolean = false;
         if (stash) {
             overrideStash = await Utils.promptUser(Prompt.useStash);
@@ -46,13 +46,14 @@ export default class DatasetHandler extends ZosFilesBaseHandler {
         if (overrideStash || !stash) {
             mfFile.apiData, lfFile.apiData = await Download.dataSet(session, lfFile.fileName, {returnEtag: true, file: lfFile.path});
         }else{
-            // Download just to get etag. Don't overwrite prexisting file (stash) during process // etag = apiData.apiResponse.etag; 
-            mfFile.apiData, lfFile.apiData = await Download.dataSet(session, lfFile.fileName, {returnEtag: true, file: lfFile.path, overwrite: false});
+            // Download just to get etag. Don't overwrite prexisting file (stash) during process // etag = apiData.apiResponse.etag
+            mfFile.apiData, lfFile.apiData = await Download.dataSet(session, lfFile.fileName,
+                {returnEtag: true, file: lfFile.path, overwrite: false});
         }
-        
+
         // Edit local copy of mf file
         await Utils.makeEdits(session, commandParameters, lfFile);
-        
+
         // Once done editing, user will provide terminal input. Upload local file with saved etag
         let uploaded = await Utils.uploadEdits(session, commandParameters, lfFile, mfFile);
         while (!uploaded) {

--- a/packages/cli/src/zosfiles/edit/ds/Dataset.handler.ts
+++ b/packages/cli/src/zosfiles/edit/ds/Dataset.handler.ts
@@ -1,0 +1,56 @@
+/*
+* This program and the accompanying materials are made available under the terms of the
+* Eclipse Public License v2.0 which accompanies this distribution, and is available at
+* https://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Copyright Contributors to the Zowe Project.
+*
+*/
+
+import { AbstractSession, IHandlerParameters, ITaskWithStatus, TaskStage } from "@zowe/imperative";
+import { Get, IZosFilesResponse } from "@zowe/zos-files-for-zowe-sdk";
+import { ZosFilesBaseHandler } from "../../ZosFilesBase.handler";
+
+/**
+ * Handler to edit a data set's content
+ * @export
+ */
+export default class DatasetHandler extends ZosFilesBaseHandler {
+    public async processWithSession(commandParameters: IHandlerParameters, session: AbstractSession): Promise<IZosFilesResponse> {
+        // 1. get/set editor
+        // 2. build tmp_dir
+        // 2a. hash uss file name
+        // 3. check for tmp_dir's existance as stash
+        // 4a. if prexisting tmp_dir: override stash
+        // 4b. if prexisting tmp_dir: use stash
+        // 4ba. perform file comparison, show output in terminal
+        // 4bb. overwrite ETAG 
+        // 5a. check for default editor and headless environment
+        // 5b. open lf in editor or tell user to open up on their own if headless or no set default
+        // 6. wait for user input to continue
+        // 7. once input recieved, upload tmp file with saved ETAG
+        // 7a. if matching ETAG: sucessful upload, destroy tmp file -> END
+        // 7a. if non-matching ETAG: unsucessful upload -> 4a
+
+        const task: ITaskWithStatus = {
+            percentComplete: 0,
+            statusMessage: "Retrieving data set",
+            stageName: TaskStage.IN_PROGRESS
+        };
+        commandParameters.response.progress.startBar({task});
+
+        const dsContentBuf = await Get.dataSet(session, commandParameters.arguments.dataSetName,
+            {   
+                responseTimeout: commandParameters.arguments.responseTimeout,
+                task: task
+            }
+        );
+        return {
+            success: true,
+            commandResponse: dsContentBuf.toString(),
+            apiResponse: {}
+        };
+    }
+}

--- a/packages/cli/src/zosfiles/edit/uss/USSFile.definition.ts
+++ b/packages/cli/src/zosfiles/edit/uss/USSFile.definition.ts
@@ -1,0 +1,54 @@
+/*
+* This program and the accompanying materials are made available under the terms of the
+* Eclipse Public License v2.0 which accompanies this distribution, and is available at
+* https://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Copyright Contributors to the Zowe Project.
+*
+*/
+
+import {ICommandDefinition} from "@zowe/imperative";
+import { EditOptions } from "../Edit.options";
+import i18nTypings from "../../-strings-/en";
+
+// Does not use the import in anticipation of some internationalization work to be done later.
+const strings = (require("../../-strings-/en").default as typeof i18nTypings).EDIT;
+
+/**
+ * View USS file content command definition containing its description, examples and/or options
+ * @type {ICommandDefinition}
+ */
+export const USSFileDefinition: ICommandDefinition = {
+    name: "uss-file",
+    aliases: ["uf"],
+    summary: strings.ACTIONS.USS_FILE.SUMMARY,
+    description: strings.ACTIONS.USS_FILE.DESCRIPTION,
+    type: "command",
+    handler: __dirname + "/USSFile.handler",
+    profile: {
+        optional: ["zosmf"],
+    },
+    positionals: [
+        {
+            name: "file",
+            description: strings.ACTIONS.USS_FILE.POSITIONALS.USSFILE,
+            type: "string",
+            required: true
+        },
+    ],
+    options: [
+        EditOptions.editor
+    ],
+    examples: [
+        {
+            description: strings.ACTIONS.USS_FILE.EXAMPLES.EX1,
+            options: "`notepad`"
+        },
+        {
+            description: strings.ACTIONS.USS_FILE.EXAMPLES.EX1,
+            options: "C:\\Windows\\System32\\Notepad.exe"
+        }
+    ]
+};

--- a/packages/cli/src/zosfiles/edit/uss/USSFile.handler.ts
+++ b/packages/cli/src/zosfiles/edit/uss/USSFile.handler.ts
@@ -26,15 +26,25 @@ export default class USSFileHandler extends ZosFilesBaseHandler {
         };
         commandParameters.response.progress.startBar({task});
 
-        const dsContentBuf = await Get.USSFile(session, commandParameters.arguments.file,
-            {
-                responseTimeout: commandParameters.arguments.responseTimeout,
-                task: task
-            }
-        );
+        // 1. get/set editor
+        // 2. build tmp_dir
+        // 2a. hash uss file name
+        // 3. check for tmp_dir's existance as stash
+        // 4a. if prexisting tmp_dir: override stash
+        // 4b. if prexisting tmp_dir: use stash
+        // 4ba. perform file comparison, show output in terminal
+        // 4bb. overwrite ETAG 
+        // 5a. check for default editor and headless environment
+        // 5b. open lf in editor or tell user to open up on their own if headless or no set default
+        // 6. wait for user input to continue
+        // 7. once input recieved, upload tmp file with saved ETAG
+        // 7a. if matching ETAG: sucessful upload, destroy tmp file -> END
+        // 7a. if non-matching ETAG: unsucessful upload -> 4ba
+
+
         return {
             success: true,
-            commandResponse: dsContentBuf.toString(),
+            commandResponse: "",
             apiResponse: {}
         };
     }

--- a/packages/cli/src/zosfiles/edit/uss/USSFile.handler.ts
+++ b/packages/cli/src/zosfiles/edit/uss/USSFile.handler.ts
@@ -1,0 +1,41 @@
+/*
+* This program and the accompanying materials are made available under the terms of the
+* Eclipse Public License v2.0 which accompanies this distribution, and is available at
+* https://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Copyright Contributors to the Zowe Project.
+*
+*/
+
+import { AbstractSession, IHandlerParameters, ITaskWithStatus, TaskStage } from "@zowe/imperative";
+import { Get, IZosFilesResponse } from "@zowe/zos-files-for-zowe-sdk";
+import { ZosFilesBaseHandler } from "../../ZosFilesBase.handler";
+
+/**
+ * Handler to view USS file content
+ * @export
+ */
+export default class USSFileHandler extends ZosFilesBaseHandler {
+    public async processWithSession(commandParameters: IHandlerParameters, session: AbstractSession): Promise<IZosFilesResponse> {
+        const task: ITaskWithStatus = {
+            percentComplete: 0,
+            statusMessage: "Retrieving USS file",
+            stageName: TaskStage.IN_PROGRESS
+        };
+        commandParameters.response.progress.startBar({task});
+
+        const dsContentBuf = await Get.USSFile(session, commandParameters.arguments.file,
+            {
+                responseTimeout: commandParameters.arguments.responseTimeout,
+                task: task
+            }
+        );
+        return {
+            success: true,
+            commandResponse: dsContentBuf.toString(),
+            apiResponse: {}
+        };
+    }
+}

--- a/packages/cli/src/zosfiles/edit/uss/USSFile.handler.ts
+++ b/packages/cli/src/zosfiles/edit/uss/USSFile.handler.ts
@@ -10,7 +10,7 @@
 */
 
 import { AbstractSession, IHandlerParameters, ITaskWithStatus, TaskStage } from "@zowe/imperative";
-import { Get, IZosFilesResponse } from "@zowe/zos-files-for-zowe-sdk";
+import { IZosFilesResponse } from "@zowe/zos-files-for-zowe-sdk";
 import { ZosFilesBaseHandler } from "../../ZosFilesBase.handler";
 
 /**
@@ -33,7 +33,7 @@ export default class USSFileHandler extends ZosFilesBaseHandler {
         // 4a. if prexisting tmp_dir: override stash
         // 4b. if prexisting tmp_dir: use stash
         // 4ba. perform file comparison, show output in terminal
-        // 4bb. overwrite ETAG 
+        // 4bb. overwrite ETAG
         // 5a. check for default editor and headless environment
         // 5b. open lf in editor or tell user to open up on their own if headless or no set default
         // 6. wait for user input to continue

--- a/packages/zosfiles/src/methods/edit/Edit.ts
+++ b/packages/zosfiles/src/methods/edit/Edit.ts
@@ -1,0 +1,92 @@
+/*
+* This program and the accompanying materials are made available under the terms of the
+* Eclipse Public License v2.0 which accompanies this distribution, and is available at
+* https://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Copyright Contributors to the Zowe Project.
+*
+*/
+
+import { posix } from "path";
+import { AbstractSession, ImperativeExpect } from "@zowe/imperative";
+import { ZosFilesMessages } from "../../constants/ZosFiles.messages";
+import { ZosFilesConstants } from "../../constants/ZosFiles.constants";
+import { ZosmfRestClient, ZosmfHeaders, IHeaderContent } from "@zowe/core-for-zowe-sdk";
+import { IEditOptions } from "./doc/IEditOptions";
+import { ZosFilesUtils } from "../../utils/ZosFilesUtils";
+
+/**
+ * This class holds helper functions that are used to edit the content of data sets or USS files through the z/OSMF APIs
+ * @export
+ * @class Get
+ */
+export class Edit {
+    /**
+     * Retrieve data sets content
+     *
+     * @param {AbstractSession}  session      - z/OSMF connection info
+     * @param {string}           dataSetName  - contains the data set name
+     * @param {IViewOptions} [options={}] - contains the options to be sent
+     *
+     * @returns {Promise<Buffer>} Promise that resolves to the content of the data set
+     *
+     * @throws {ImperativeError}
+     */
+    public static async dataSet(session: AbstractSession, dataSetName: string, options: IGetOptions = {}): Promise<Buffer> {
+        ImperativeExpect.toNotBeNullOrUndefined(dataSetName, ZosFilesMessages.missingDatasetName.message);
+        ImperativeExpect.toNotBeEqual(dataSetName, "", ZosFilesMessages.missingDatasetName.message);
+
+        let endpoint = posix.join(ZosFilesConstants.RESOURCE, ZosFilesConstants.RES_DS_FILES, dataSetName);
+
+        const reqHeaders: IHeaderContent[] = ZosFilesUtils.generateHeadersBasedOnOptions(options);
+
+        if (options.range) {
+            reqHeaders.push({"X-IBM-Record-Range": options.range});
+        }
+
+        if (options.volume) {
+            endpoint = posix.join(ZosFilesConstants.RESOURCE, ZosFilesConstants.RES_DS_FILES, `-(${options.volume})`, dataSetName);
+        }
+
+        const content = await ZosmfRestClient.getExpectBuffer(session, endpoint, reqHeaders);
+
+        return content;
+    }
+
+    /**
+     * Retrieve USS file content
+     *
+     * @param {AbstractSession}  session      - z/OSMF connection info
+     * @param {string}           USSFileName  - contains the data set name
+     * @param {IViewOptions} [options={}] - contains the options to be sent
+     *
+     * @returns {Promise<Buffer>} Promise that resolves to the content of the uss file
+     *
+     * @throws {ImperativeError}
+     */
+    public static async USSFile(session: AbstractSession, USSFileName: string, options: IGetOptions = {}): Promise<Buffer> {
+        ImperativeExpect.toNotBeNullOrUndefined(USSFileName, ZosFilesMessages.missingUSSFileName.message);
+        ImperativeExpect.toNotBeEqual(USSFileName, "", ZosFilesMessages.missingUSSFileName.message);
+        ImperativeExpect.toNotBeEqual(options.record, true, ZosFilesMessages.unsupportedDataType.message);
+        USSFileName = posix.normalize(USSFileName);
+        // Get a proper destination for the file to be downloaded
+        // If the "file" is not provided, we create a folder structure similar to the uss file structure
+        if (USSFileName.substr(0, 1) === "/") {
+            USSFileName = USSFileName.substr(1);
+        }
+
+        const encodedFileName = encodeURIComponent(USSFileName);
+        const endpoint = posix.join(ZosFilesConstants.RESOURCE, ZosFilesConstants.RES_USS_FILES, encodedFileName);
+
+        const reqHeaders: IHeaderContent[] = [ZosmfHeaders.ACCEPT_ENCODING];
+
+        if (options.binary === true) {
+            reqHeaders.unshift(ZosmfHeaders.X_IBM_BINARY);
+        }
+        const content = await ZosmfRestClient.getExpectBuffer(session, endpoint, reqHeaders);
+
+        return content;
+    }
+}

--- a/packages/zosfiles/src/methods/edit/Edit.ts
+++ b/packages/zosfiles/src/methods/edit/Edit.ts
@@ -34,7 +34,7 @@ export class Edit {
      *
      * @throws {ImperativeError}
      */
-    public static async dataSet(session: AbstractSession, dataSetName: string, options: IGetOptions = {}): Promise<Buffer> {
+    public static async dataSet(session: AbstractSession, dataSetName: string, options: IEditOptions = {}): Promise<Buffer> {
         ImperativeExpect.toNotBeNullOrUndefined(dataSetName, ZosFilesMessages.missingDatasetName.message);
         ImperativeExpect.toNotBeEqual(dataSetName, "", ZosFilesMessages.missingDatasetName.message);
 
@@ -66,7 +66,7 @@ export class Edit {
      *
      * @throws {ImperativeError}
      */
-    public static async USSFile(session: AbstractSession, USSFileName: string, options: IGetOptions = {}): Promise<Buffer> {
+    public static async USSFile(session: AbstractSession, USSFileName: string, options: IEditOptions = {}): Promise<Buffer> {
         ImperativeExpect.toNotBeNullOrUndefined(USSFileName, ZosFilesMessages.missingUSSFileName.message);
         ImperativeExpect.toNotBeEqual(USSFileName, "", ZosFilesMessages.missingUSSFileName.message);
         ImperativeExpect.toNotBeEqual(options.record, true, ZosFilesMessages.unsupportedDataType.message);

--- a/packages/zosfiles/src/methods/edit/doc/IEditOptions.ts
+++ b/packages/zosfiles/src/methods/edit/doc/IEditOptions.ts
@@ -1,0 +1,28 @@
+/*
+* This program and the accompanying materials are made available under the terms of the
+* Eclipse Public License v2.0 which accompanies this distribution, and is available at
+* https://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Copyright Contributors to the Zowe Project.
+*
+*/
+
+import { IOptions } from "../../../doc/IOptions";
+
+/**
+ * This interface defines the options that can be sent to get a data set or USS file function
+ * @export
+ * @interface IGetOptions
+ */
+export interface IGetOptions extends IOptions {
+
+    /**
+     * Range of records to return
+     * @type {string}
+     * @memberof IGetOptions
+     */
+    range?: string;
+}
+

--- a/packages/zosfiles/src/methods/edit/doc/IEditOptions.ts
+++ b/packages/zosfiles/src/methods/edit/doc/IEditOptions.ts
@@ -14,14 +14,14 @@ import { IOptions } from "../../../doc/IOptions";
 /**
  * This interface defines the options that can be sent to get a data set or USS file function
  * @export
- * @interface IGetOptions
+ * @interface IEditOptions
  */
-export interface IGetOptions extends IOptions {
+export interface IEditOptions extends IOptions {
 
     /**
      * Range of records to return
      * @type {string}
-     * @memberof IGetOptions
+     * @memberof IEditOptions
      */
     range?: string;
 }

--- a/packages/zosfiles/src/methods/edit/index.ts
+++ b/packages/zosfiles/src/methods/edit/index.ts
@@ -11,4 +11,4 @@
 
 export * from "./doc/IEditOptions";
 
-export * from "./Get";
+export * from "./Edit";

--- a/packages/zosfiles/src/methods/edit/index.ts
+++ b/packages/zosfiles/src/methods/edit/index.ts
@@ -1,0 +1,14 @@
+/*
+* This program and the accompanying materials are made available under the terms of the
+* Eclipse Public License v2.0 which accompanies this distribution, and is available at
+* https://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Copyright Contributors to the Zowe Project.
+*
+*/
+
+export * from "./doc/IEditOptions";
+
+export * from "./Get";


### PR DESCRIPTION
Adding ability to edit mainframe USS and DS files locally
- users can set their default editor   
- requires user to interact with the terminal
    - users can make edits directly to file and return to terminal if no chosen editor
- has logic for editing conflicts
    - utilizes zOSMF ETAGs
    - allows for a temporary stash
- leverages preexisting CLI diff features, including browser view