### PR TITLE
Fix for pds member copy

### DIFF
--- a/packages/zosfiles/CHANGELOG.md
+++ b/packages/zosfiles/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to the Zowe z/OS files SDK package will be documented in thi
 ## Recent Changes
 
 - Enhancement: Added `Copy.dataSetCrossLPAR` method to support copying a dataset or members from one LPAR to another.  
+- BugFix: Correct improper overwrite error with PDS member to PDS member copy.
 
 ## `7.12.0`
 

--- a/packages/zosfiles/src/methods/copy/Copy.ts
+++ b/packages/zosfiles/src/methods/copy/Copy.ts
@@ -261,7 +261,8 @@ export class Copy {
             /*
             *  Don't overwrite an existing dataset or member if overwrite is false
             */
-            if(overwriteTarget == true || targetFound == false){
+            if(overwriteTarget == true || targetFound == false ||
+                (targetMember != undefined && targetMemberFound == false)){
                 /**
                  *  Upload the source data to the target dataset
                  */

--- a/packages/zosfiles/src/methods/copy/Copy.ts
+++ b/packages/zosfiles/src/methods/copy/Copy.ts
@@ -261,8 +261,8 @@ export class Copy {
             /*
             *  Don't overwrite an existing dataset or member if overwrite is false
             */
-            if(overwriteTarget == true || targetFound == false ||
-                (targetMember != undefined && targetMemberFound == false)){
+            if(overwriteTarget || !targetFound ||
+                (targetMember != undefined && !targetMemberFound )){
                 /**
                  *  Upload the source data to the target dataset
                  */


### PR DESCRIPTION
This PR is a small fix for the copy-cross-lpar functionality. If a PDS member is being copied from one PDS to another and that member does not exist, an exception was incorrectly being thrown. 