### PR TITLE
chore(daemon): Resolve lint warnings

### DIFF
--- a/zowex/src/comm.rs
+++ b/zowex/src/comm.rs
@@ -82,10 +82,7 @@ pub async fn comm_establish_connection(
             // https://docs.rs/tokio/latest/tokio/net/windows/named_pipe/struct.ClientOptions.html#method.open
             Err(e)
                 if e.raw_os_error() == Some(ERROR_PIPE_BUSY as i32)
-                    || e.kind() == io::ErrorKind::NotFound =>
-            {
-                ()
-            }
+                    || e.kind() == io::ErrorKind::NotFound => {}
             Err(e) => return Err(e),
         }
 

--- a/zowex/src/util.rs
+++ b/zowex/src/util.rs
@@ -178,5 +178,6 @@ pub fn util_terminal_supports_color() -> i32 {
             return 1;
         }
     }
-    return 0;
+    
+    0
 }


### PR DESCRIPTION
A couple lint warnings were introduced with the recent features and fixes incorporated into the daemon:

```
Checking zowe v1.1.0 (C:\ourstuff\repos\zowe-cli\zowex)
warning: unneeded unit expression
  --> src\comm.rs:87:17
   |
87 |                 ()
   |                 ^^ help: remove the final `()`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unused_unit
   = note: `#[warn(clippy::unused_unit)]` on by default

warning: unneeded `return` statement
   --> src\util.rs:181:5
    |
181 |     return 0;
    |     ^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_return
    = note: `#[warn(clippy::needless_return)]` on by default
    = help: remove `return`

warning: `zowe` (bin "zowe") generated 2 warnings (run `cargo clippy --fix --bin "zowe"` to apply 2 suggestions)
Finished dev [unoptimized + debuginfo] target(s) in 25.02s
```

This PR quickly resolves those issues. Since these warnings do not affect the behavior of the daemon, this PR won't require a new release of the CLI.