### PR TITLE
Fix failing CLI system tests and related bugs

### DIFF
--- a/__tests__/__packages__/cli-test-utils/CHANGELOG.md
+++ b/__tests__/__packages__/cli-test-utils/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the Zowe CLI test utils package will be documented in thi
 
 ## Recent Changes
 
-- BugFix: Don't assume that root directory is folder containing `lerna.json` unless it also contains a `__tests__` directory.
+- BugFix: Don't assume that folder containing `lerna.json` is root directory unless it also contains a `__tests__` subfolder.
 
 ## `7.10.1`
 

--- a/__tests__/__packages__/cli-test-utils/CHANGELOG.md
+++ b/__tests__/__packages__/cli-test-utils/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Zowe CLI test utils package will be documented in this file.
 
+## Recent Changes
+
+- BugFix: Don't assume that root directory is folder containing `lerna.json` unless it also contains a `__tests__` directory.
+
 ## `7.10.1`
 
 - BugFix: Fixed team config being created instead of v1 profiles when `createOldProfiles` was true.

--- a/__tests__/__packages__/cli-test-utils/src/TestConstants.ts
+++ b/__tests__/__packages__/cli-test-utils/src/TestConstants.ts
@@ -9,14 +9,18 @@
 *
 */
 
+import * as fs from "fs";
 import * as nodePath from "path";
 import * as findUp from "find-up";
 
 function projectRootDir() {
-    // First look for lerna.json in case we're in a monorepo
+    // First look for lerna.json to handle monorepos with tests at top level
     const lernaJson = findUp.sync("lerna.json");
     if (lernaJson != null) {
-        return nodePath.dirname(lernaJson);
+        const lernaRootDir = nodePath.dirname(lernaJson);
+        if (fs.existsSync(nodePath.join(lernaRootDir, "__tests__"))) {
+            return lernaRootDir;
+        }
     }
     // Next look for package.json in single-package repo
     const packageJson = findUp.sync("package.json");

--- a/__tests__/__packages__/cli-test-utils/src/environment/TempTestProfiles.ts
+++ b/__tests__/__packages__/cli-test-utils/src/environment/TempTestProfiles.ts
@@ -151,11 +151,13 @@ export class TempTestProfiles {
 
     /**
      * Helper to create a temporary team config profile from test properties
+     * @internal
      * @param {ITestEnvironment} testEnvironment - the test environment with env and working directory to use for output
      * @returns {Promise<string>} promise that resolves to the name of the created profile on success
      * @throws errors if the profile creation fails
      */
-    private static async createV2Profile(testEnvironment: ITestEnvironment<any>, profileType: string): Promise<string> {
+    public static async createV2Profile(testEnvironment: ITestEnvironment<any>, profileType: string,
+        profileProperties?: Record<string, any>): Promise<string> {
         // Load global config layer
         const config = await Config.load(this.BINARY_NAME, { homeDir: testEnvironment.workingDir });
         config.api.layers.activate(false, true);
@@ -163,7 +165,7 @@ export class TempTestProfiles {
         // Add profile to config JSON
         const profileName: string = uuidv4().substring(0, TempTestProfiles.MAX_UUID_LENGTH) + "_tmp_" + profileType;
         config.api.profiles.set(profileName, {
-            properties: testEnvironment.systemTestProperties[profileType]
+            properties: profileProperties ?? testEnvironment.systemTestProperties[profileType]
         });
         if (config.api.profiles.defaultGet(profileType) == null) {
             config.api.profiles.defaultSet(profileType, profileName);
@@ -201,13 +203,14 @@ export class TempTestProfiles {
 
     /**
      * Helper to delete a temporary team config profile
+     * @internal
      * @param {ITestEnvironment} testEnvironment - the test environment with env and working directory to use for output
      * @param {string} profileType - the type of profile e.g. zosmf to delete
      * @param {string} profileName - the name of the profile to delete
      * @returns {Promise<string>} promise that resolves to the name of the created profile on success
      * @throws errors if the profile delete fails
      */
-    private static async deleteV2Profile(testEnvironment: ITestEnvironment<any>, profileType: string, profileName: string): Promise<string> {
+    public static async deleteV2Profile(testEnvironment: ITestEnvironment<any>, profileType: string, profileName: string): Promise<string> {
         // Load global config layer
         const config = await Config.load(this.BINARY_NAME, { homeDir: testEnvironment.workingDir });
         config.api.layers.activate(false, true);

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the Zowe CLI package will be documented in this file.
 
+## Recent Changes
+
+- BugFix: Fixed `--range` option ignored on `zowe files view uss-file` command.
+- BugFix: Fixed `--binary` option ignored by commands that upload and download USS directories when ".zosattributes" file is used.
+- BugFix: Fixed `--include-hidden` option ignored by `zowe files upload dir-to-uss` without the `--recursive` option.
+
 ## `7.16.0`
 
 - Enhancement: Updated daemon to use `tokio` library instead of unmaintained `named_pipe` library.

--- a/packages/cli/__tests__/auth/__system__/__scripts__/auth_login_apiml.sh
+++ b/packages/cli/__tests__/auth/__system__/__scripts__/auth_login_apiml.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
 
-echo "y" | zowe auth login apiml
+echo "y" | zowe auth login apiml --user $1 --password $2
 
 exit $?

--- a/packages/cli/__tests__/auth/__system__/cli.auth.login.apiml.system.test.ts
+++ b/packages/cli/__tests__/auth/__system__/cli.auth.login.apiml.system.test.ts
@@ -9,7 +9,7 @@
 *
 */
 
-import { ITestEnvironment, runCliScript } from "@zowe/cli-test-utils";
+import { ITestEnvironment, runCliScript, TempTestProfiles } from "@zowe/cli-test-utils";
 import { TestEnvironment } from "../../../../../__tests__/__src__/environment/TestEnvironment";
 import { ITestPropertiesSchema } from "../../../../../__tests__/__src__/properties/ITestPropertiesSchema";
 import { ITestBaseSchema } from "../../../../../__tests__/__src__/properties/ITestBaseSchema";
@@ -20,8 +20,13 @@ describe("auth login/logout apiml with profile", () => {
 
     beforeAll(async () => {
         TEST_ENVIRONMENT = await TestEnvironment.setUp({
-            testName: "auth_login_logout_apiml",
-            tempProfileTypes: ["base"]
+            testName: "auth_login_logout_apiml"
+        });
+        // Create base profile without user and password
+        await TempTestProfiles.createV2Profile(TEST_ENVIRONMENT, "base", {
+            host: TEST_ENVIRONMENT.systemTestProperties.base.host,
+            port: TEST_ENVIRONMENT.systemTestProperties.base.port,
+            rejectUnauthorized: TEST_ENVIRONMENT.systemTestProperties.base.rejectUnauthorized
         });
     });
 
@@ -30,7 +35,8 @@ describe("auth login/logout apiml with profile", () => {
     });
 
     it("should successfully issue the login command", () => {
-        const response = runCliScript(__dirname + "/__scripts__/auth_login_apiml.sh", TEST_ENVIRONMENT);
+        const response = runCliScript(__dirname + "/__scripts__/auth_login_apiml.sh", TEST_ENVIRONMENT,
+            [TEST_ENVIRONMENT.systemTestProperties.base.user, TEST_ENVIRONMENT.systemTestProperties.base.password]);
         expect(response.stderr.toString()).toBe("");
         expect(response.status).toBe(0);
         expect(response.stdout.toString()).toContain("Login successful.");

--- a/packages/cli/__tests__/config/auto-init/__system__/cli.config.auto-init.system.test.ts
+++ b/packages/cli/__tests__/config/auto-init/__system__/cli.config.auto-init.system.test.ts
@@ -301,8 +301,7 @@ describe("config auto-init with profile", () => {
     beforeAll(async () => {
         TEST_ENVIRONMENT = await TestEnvironment.setUp({
             testName: "config_auto_init_apiml_with_profile",
-            tempProfileTypes: ["base"],
-            createOldProfiles: true
+            tempProfileTypes: ["base"]
         });
 
         base = TEST_ENVIRONMENT.systemTestProperties.base;
@@ -312,7 +311,7 @@ describe("config auto-init with profile", () => {
         await TestEnvironment.cleanUp(TEST_ENVIRONMENT);
     });
 
-    it("should successfully issue the auto-init command, using an old school profile", () => {
+    it("should successfully issue the auto-init command", () => {
         const response = runCliScript(__dirname + "/__scripts__/config_auto_init_profile.sh", TEST_ENVIRONMENT);
 
         const config = fs.readFileSync(path.join(TEST_ENVIRONMENT.workingDir, "zowe.config.json")).toString();
@@ -355,8 +354,7 @@ describe("config auto-init with profile and certificates", () => {
     beforeAll(async () => {
         TEST_ENVIRONMENT = await TestEnvironment.setUp({
             testName: "config_auto_init_apiml_with_profile",
-            tempProfileTypes: ["base"],
-            createOldProfiles: true
+            tempProfileTypes: ["base"]
         });
 
         base = {
@@ -372,7 +370,7 @@ describe("config auto-init with profile and certificates", () => {
         await TestEnvironment.cleanUp(TEST_ENVIRONMENT);
     });
 
-    it("should successfully issue the auto-init command, using an old school profile", () => {
+    it("should successfully issue the auto-init command", () => {
         const response = runCliScript(__dirname + "/__scripts__/config_auto_init_profile.sh", TEST_ENVIRONMENT);
 
         const config = fs.readFileSync(path.join(TEST_ENVIRONMENT.workingDir, "zowe.config.json")).toString();

--- a/packages/cli/__tests__/zosfiles/__system__/copy/dsclp/cli.files.copy.dsclp.system.test.ts
+++ b/packages/cli/__tests__/zosfiles/__system__/copy/dsclp/cli.files.copy.dsclp.system.test.ts
@@ -69,7 +69,7 @@ describe("Copy data set", () => {
 
                 try {
                     response = runCliScript(
-                        join(__dirname, "__scripts__", "command", " command_copy_data_set_cross_lpar.sh"),
+                        join(__dirname, "__scripts__", "command", "command_copy_data_set_cross_lpar.sh"),
                         TEST_ENVIRONMENT,
                         [fromDataSetName, toDataSetName]
                     );

--- a/packages/cli/__tests__/zosfiles/__system__/create/ds/__scripts__/command/command_create_ds_missing_like.sh
+++ b/packages/cli/__tests__/zosfiles/__system__/create/ds/__scripts__/command/command_create_ds_missing_like.sh
@@ -2,7 +2,7 @@
 set -e
 
 echo "================Z/OS FILES CREATE DS==============="
-zowe files create data-set "$2.test.data.set.withoutLike" --host $1 --user $2 --pw $3
+zowe files create data-set "$2.test.data.set.noLike" --host $1 --user $2 --pw $3
 if [ $? -gt 0 ]
 then
     exit $?

--- a/packages/cli/__tests__/zosfiles/__system__/create/ds/__snapshots__/cli.files.create.ds.system.test.ts.snap
+++ b/packages/cli/__tests__/zosfiles/__system__/create/ds/__snapshots__/cli.files.create.ds.system.test.ts.snap
@@ -5,3 +5,9 @@ exports[`Create Data Set Success scenarios should create a data set 1`] = `
 Data set created successfully.
 "
 `;
+
+exports[`Create Data Set Success scenarios should create a data set with missing like 1`] = `
+"================Z/OS FILES CREATE DS===============
+Data set created successfully.
+"
+`;

--- a/packages/cli/__tests__/zosfiles/__system__/create/ds/cli.files.create.ds.system.test.ts
+++ b/packages/cli/__tests__/zosfiles/__system__/create/ds/cli.files.create.ds.system.test.ts
@@ -71,11 +71,12 @@ describe("Create Data Set", () => {
                 TEST_ENVIRONMENT, [user,defaultSystem.zosjobs.iefbr14PSDataSet]);
             expect(response.stderr.toString()).toBe("");
             expect(response.status).toBe(0);
+            expect(response.stdout.toString()).toContain("Data set created successfully.");
             expect(response.stdout.toString()).toMatchSnapshot();
         });
 
-        it("should creating a data set with missing like", () => {
-            dsnameSuffix = "withoutLike";
+        it("should create a data set with missing like", () => {
+            dsnameSuffix = "noLike";
             const response = runCliScript(__dirname + "/__scripts__/command/command_create_ds_missing_like.sh",
                 TEST_ENVIRONMENT,[host,user,pass]);
             expect(response.stderr.toString()).toBe("");

--- a/packages/cli/__tests__/zosfiles/__system__/download/uss/cli.files.download.uss.system.test.ts
+++ b/packages/cli/__tests__/zosfiles/__system__/download/uss/cli.files.download.uss.system.test.ts
@@ -224,7 +224,7 @@ describe("Download USS File", () => {
                 ussname + ".dummy"
             ]);
             expect(response.status).toBe(1);
-            expect(response.stderr.toString()).toContain("File not found.");
+            expect(response.stderr.toString()).toContain("No such file or directory.");
         });
     });
 });

--- a/packages/cli/__tests__/zosfiles/__system__/upload/dtu/__data__/command_upload_dtu_dir/dir_with_hidden_files/.zosattributes
+++ b/packages/cli/__tests__/zosfiles/__system__/upload/dtu/__data__/command_upload_dtu_dir/dir_with_hidden_files/.zosattributes
@@ -1,6 +1,6 @@
 *.binary binary binary
 *.rft ISO8859-1 IBM-1047
 *.asciitext ISO8859-1 ISO8859-1
-*.project binary binary
+*.project ISO8859-1 IBM-1047
 *.nodejsapp binary binary
 *.hidden binary binary

--- a/packages/cli/__tests__/zosfiles/__system__/upload/dtu/cli.dir.upload.dtu.system.test.ts
+++ b/packages/cli/__tests__/zosfiles/__system__/upload/dtu/cli.dir.upload.dtu.system.test.ts
@@ -505,6 +505,6 @@ function testSuccessfulUpload(localDirName: string, additionalParameters?: strin
     }
 
     const response = runCliScript(shellScript, TEST_ENVIRONMENT, parms);
-    const stdoutText = response.stdout.toString();
-    expect(stdoutText).toContain("Directory uploaded successfully.");
+    expect(response.stderr.toString()).toBe("");
+    expect(response.stdout.toString()).toContain("Directory uploaded successfully.");
 }

--- a/packages/cli/__tests__/zosfiles/__system__/upload/dtu/cli.dir.upload.dtu.system.test.ts
+++ b/packages/cli/__tests__/zosfiles/__system__/upload/dtu/cli.dir.upload.dtu.system.test.ts
@@ -54,7 +54,6 @@ describe("Upload directory to USS", () => {
 
     afterAll(async () => {
         await TestEnvironment.cleanUp(TEST_ENVIRONMENT);
-        await TestEnvironment.cleanUp(TEST_ENVIRONMENT_NO_PROF);
     });
 
     describe("without profiles", () => {
@@ -82,6 +81,10 @@ describe("Upload directory to USS", () => {
             } catch (err) {
                 error = err;
             }
+        });
+
+        afterAll(async () => {
+            await TestEnvironment.cleanUp(TEST_ENVIRONMENT_NO_PROF);
         });
 
         it("should upload local directory to USS directory", async () => {
@@ -345,11 +348,10 @@ describe("Upload directory to USS", () => {
             expect(tag).toMatch("b binary");
         });
 
-        // eslint-disable-next-line jest/no-disabled-tests
-        it.skip("should tag uploaded hidden files according to remote encoding", async () => {
+        it("should tag uploaded hidden files according to remote encoding", async () => {
             const localDirName = path.join(__dirname, "__data__", "command_upload_dtu_dir/dir_with_hidden_files");
 
-            testSuccessfulUpload(localDirName);
+            testSuccessfulUpload(localDirName, ["--include-hidden"]);
 
             let tag = await getTag(REAL_SESSION,ussname + "/.project");
             expect(tag).toMatch("t IBM-1047");
@@ -357,7 +359,6 @@ describe("Upload directory to USS", () => {
             tag = await getTag(REAL_SESSION,ussname + "/.hidden");
             expect(tag).toMatch("b binary");
         });
-
 
         it("should accept zosattributes path as an argument", async () => {
             const localDirName = path.join(__dirname, "__data__", "command_upload_dtu_dir/command_upload_dtu_subdir_ascii");
@@ -408,7 +409,7 @@ describe("Upload directory to USS", () => {
             expect(tag).toMatch("b binary");
 
             tag = await getTag(REAL_SESSION,ussname + "/picCopy.png");
-            expect(tag).toMatch("t ISO8859-1");
+            expect(tag).toMatch("b binary");
 
             tag = await getTag(REAL_SESSION,ussname + "/picCopyNoTagPlease.png");
             expect(tag).toMatch("b binary");
@@ -423,7 +424,7 @@ describe("Upload directory to USS", () => {
             expect(tag).toMatch("t IBM-1140");
 
             tag = await getTag(REAL_SESSION,ussname + "/copyButDontTagMe.text");
-            expect(tag).toMatch("t ISO8859-1");
+            expect(tag).toMatch("b binary");
 
             let error: Error;
             try {

--- a/packages/cli/__tests__/zosfiles/__system__/upload/dtu/cli.dir.upload.dtu.system.test.ts
+++ b/packages/cli/__tests__/zosfiles/__system__/upload/dtu/cli.dir.upload.dtu.system.test.ts
@@ -364,7 +364,7 @@ describe("Upload directory to USS", () => {
             const localDirName = path.join(__dirname, "__data__", "command_upload_dtu_dir/command_upload_dtu_subdir_ascii");
 
             const attributesPath = path.join(__dirname, "__data__", "command_upload_dtu_dir/external.attributes");
-            testSuccessfulUpload(localDirName, ["--attributes", attributesPath]);
+            testSuccessfulUpload(localDirName, ["--attributes", path.relative(TEST_ENVIRONMENT.workingDir, attributesPath)]);
 
             let error: Error;
             try {
@@ -466,7 +466,7 @@ describe("Upload directory to USS", () => {
             const localDirName = path.join(__dirname, "__data__", "command_upload_dtu_dir/dir_with_nested_attributefile");
             const attributesPath = path.join(__dirname, "__data__",
                 "command_upload_dtu_dir/dir_with_nested_attributefile/nest_attribute_folder/.attributes");
-            testSuccessfulUpload(localDirName, ["--r --attributes", attributesPath]);
+            testSuccessfulUpload(localDirName, ["--r --attributes", path.relative(TEST_ENVIRONMENT.workingDir, attributesPath)]);
 
             let tag = await getTag(REAL_SESSION,ussname + "/baz.asciitext");
             expect(tag).toMatch("t ISO8859-1");

--- a/packages/cli/__tests__/zosfiles/__system__/view/uss/View.uss.system.test.ts
+++ b/packages/cli/__tests__/zosfiles/__system__/view/uss/View.uss.system.test.ts
@@ -27,7 +27,6 @@ let ussname: string;
 describe("View uss file", () => {
     beforeAll(async () => {
         testEnvironment = await TestEnvironment.setUp({
-            installPlugin: true,
             testName: "view_uss_file",
             tempProfileTypes: ["zosmf"]
         });
@@ -106,14 +105,14 @@ describe("View uss file", () => {
         it("should view uss file with range", async () => {
             const data: string = "abcdefghijklmnopqrstuvwxyz\nabcdefghijklmnopqrstuvwxyz\nabcdefghijklmnopqrstuvwxyz\n";
             const endpoint: string = ZosFilesConstants.RESOURCE + ZosFilesConstants.RES_USS_FILES + ussname;
-            const rc = await ZosmfRestClient.putExpectString(REAL_SESSION, endpoint, [ZosmfHeaders.X_IBM_BINARY], data);
+            const rc = await ZosmfRestClient.putExpectString(REAL_SESSION, endpoint, [], data);
 
             const shellScript = path.join(__dirname, "__scripts__", "command", "command_view_uss_file.sh");
             const response = runCliScript(shellScript, testEnvironment, [ussname.substr(1, ussname.length), "--range", "0,1"]);
 
             expect(response.stderr.toString()).toBe("");
             expect(response.status).toBe(0);
-            expect(response.stdout.toString().trim()).toEqual("abcdefghijklmnopqrstuvwxyz\n");
+            expect(response.stdout.toString().trim()).toEqual("abcdefghijklmnopqrstuvwxyz");
         });
     });
 });

--- a/packages/cli/__tests__/zosfiles/__system__/view/uss/View.uss.system.test.ts
+++ b/packages/cli/__tests__/zosfiles/__system__/view/uss/View.uss.system.test.ts
@@ -81,7 +81,7 @@ describe("View uss file", () => {
         it("should view uss file", async () => {
             const data: string = "abcdefghijklmnopqrstuvwxyz";
             const endpoint: string = ZosFilesConstants.RESOURCE + ZosFilesConstants.RES_USS_FILES + ussname;
-            const rc = await ZosmfRestClient.putExpectString(REAL_SESSION, endpoint, [], data);
+            await ZosmfRestClient.putExpectString(REAL_SESSION, endpoint, [], data);
 
             const shellScript = path.join(__dirname, "__scripts__", "command", "command_view_uss_file.sh");
             const response = runCliScript(shellScript, testEnvironment, [ussname.substr(1, ussname.length)]);
@@ -93,7 +93,7 @@ describe("View uss file", () => {
         it("should view uss file in binary", async () => {
             const data: string = "abcdefghijklmnopqrstuvwxyz";
             const endpoint: string = ZosFilesConstants.RESOURCE + ZosFilesConstants.RES_USS_FILES + ussname;
-            const rc = await ZosmfRestClient.putExpectString(REAL_SESSION, endpoint, [ZosmfHeaders.X_IBM_BINARY], data);
+            await ZosmfRestClient.putExpectString(REAL_SESSION, endpoint, [ZosmfHeaders.X_IBM_BINARY], data);
 
             const shellScript = path.join(__dirname, "__scripts__", "command", "command_view_uss_file.sh");
             const response = runCliScript(shellScript, testEnvironment, [ussname.substr(1, ussname.length), "--binary"]);
@@ -105,7 +105,7 @@ describe("View uss file", () => {
         it("should view uss file with range", async () => {
             const data: string = "abcdefghijklmnopqrstuvwxyz\nabcdefghijklmnopqrstuvwxyz\nabcdefghijklmnopqrstuvwxyz\n";
             const endpoint: string = ZosFilesConstants.RESOURCE + ZosFilesConstants.RES_USS_FILES + ussname;
-            const rc = await ZosmfRestClient.putExpectString(REAL_SESSION, endpoint, [], data);
+            await ZosmfRestClient.putExpectString(REAL_SESSION, endpoint, [], data);
 
             const shellScript = path.join(__dirname, "__scripts__", "command", "command_view_uss_file.sh");
             const response = runCliScript(shellScript, testEnvironment, [ussname.substr(1, ussname.length), "--range", "0,1"]);

--- a/packages/cli/__tests__/zosmf/__system__/check/status/zosmf.check.status.system.test.ts
+++ b/packages/cli/__tests__/zosmf/__system__/check/status/zosmf.check.status.system.test.ts
@@ -104,17 +104,12 @@ describe("zosmf check status", () => {
     describe("Expected failures", () => {
 
         it("should fail due to invalid port", async () => {
-            // create a temporary zowe profile with an invalid port
+            // update temporary zowe profile with an invalid port
             const scriptPath = testEnvironment.workingDir + "_create_profile_invalid_port";
             const bogusPort = 12345;
-            const command = "zowe profiles create zosmf " + host + "temp --host " + host + " --port " + bogusPort
-                + " --user " + user + " --password " + pass + " --ru false";
+            const command = `zowe config set profiles.${testEnvironment.tempProfiles?.zosmf[0]}.properties.port ${bogusPort} --gc`;
             await IO.writeFileAsync(scriptPath, command);
             let response = runCliScript(scriptPath, testEnvironment);
-            expect(response.status).toBe(0);
-            // default to the temporary profile
-            await IO.writeFileAsync(scriptPath, "zowe profiles set  zosmf " + host + "temp");
-            response = runCliScript(scriptPath, testEnvironment);
             expect(response.status).toBe(0);
             // now check the status
             response = runCliScript(__dirname + "/__scripts__/command/zosmf_check_status.sh", testEnvironment);

--- a/packages/cli/__tests__/zosmf/__system__/list/systems/zosmf.list.systems.system.test.ts
+++ b/packages/cli/__tests__/zosmf/__system__/list/systems/zosmf.list.systems.system.test.ts
@@ -122,17 +122,12 @@ describe("zosmf list systems", () => {
     describe("Expected failures", () => {
 
         it("should fail due to invalid port", async () => {
-            // create a temporary zowe profile with an invalid port
+            // update temporary zowe profile with an invalid port
             const scriptPath = testEnvironment.workingDir + "_create_profile_invalid_port";
             const bogusPort = 12345;
-            const command = "zowe profiles create zosmf " + host + "temp --host " + host + " --port " + bogusPort
-                + " --user " + user + " --password " + pass + " --ru false";
+            const command = `zowe config set profiles.${testEnvironment.tempProfiles?.zosmf[0]}.properties.port ${bogusPort} --gc`;
             await IO.writeFileAsync(scriptPath, command);
             let response = runCliScript(scriptPath, testEnvironment);
-            expect(response.status).toBe(0);
-            // default to the temporary profile
-            await IO.writeFileAsync(scriptPath, "zowe profiles set  zosmf " + host + "temp");
-            response = runCliScript(scriptPath, testEnvironment);
             expect(response.status).toBe(0);
             // now check the status
             response = runCliScript(__dirname + "/__scripts__/command/zosmf_list_systems.sh", testEnvironment);

--- a/packages/cli/__tests__/zostso/__system__/issue/__scripts__/as/change_proc.sh
+++ b/packages/cli/__tests__/zostso/__system__/issue/__scripts__/as/change_proc.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
 set -e
-zowe profiles create tso changed_proc_tso -a $1 --logon-procedure $2
+zowe config set profiles.changed_proc_tso.properties.account $1 --gc
+zowe config set profiles.changed_proc_tso.properties.logonProcedure $2 --gc
 zowe tso issue cmd "status" --tso-p "changed_proc_tso"

--- a/packages/cli/__tests__/zostso/__system__/issue/cli.zos-tso.issue.cmd.system.test.ts
+++ b/packages/cli/__tests__/zostso/__system__/issue/cli.zos-tso.issue.cmd.system.test.ts
@@ -62,7 +62,7 @@ describe("zos-tso issue command", () => {
             systemProps.tso.account,
             fakeProc
         ]);
-        expect(response.stderr.toString()).toMatch(/^\s*Warning:.+'profiles create' is deprecated.+'config init' command\s*$/s);
+        expect(response.stderr.toString()).toBe("");
         expect(response.status).toBe(0);
         expect(response.stdout.toString()).toContain(fakeProc);
     });

--- a/packages/cli/__tests__/zostso/__system__/start/__scripts__/address-space/change_proc.sh
+++ b/packages/cli/__tests__/zostso/__system__/start/__scripts__/address-space/change_proc.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
 set -e
-zowe profiles create tso changed_proc_tso -a $1 --logon-procedure $2
+zowe config set profiles.changed_proc_tso.properties.account $1 --gc
+zowe config set profiles.changed_proc_tso.properties.logonProcedure $2 --gc
 zowe tso start as --tso-p "changed_proc_tso"

--- a/packages/cli/__tests__/zostso/__system__/start/cli.zos-tso.start.address-space.system.test.ts
+++ b/packages/cli/__tests__/zostso/__system__/start/cli.zos-tso.start.address-space.system.test.ts
@@ -55,7 +55,7 @@ describe("zos-tso start address-space", () => {
             systemProps.tso.account,
             fakeProc
         ]);
-        expect(response.stderr.toString()).toMatch(/^\s*Warning:.+'profiles create' is deprecated.+'config init' command\s*$/s);
+        expect(response.stderr.toString()).toBe("");
         expect(response.status).toBe(0);
         expect(response.stdout.toString()).toContain(fakeProc);
     });

--- a/packages/cli/__tests__/zosuss/__system__/issue/__scripts__/issue_ssh_no_cwd.sh
+++ b/packages/cli/__tests__/zosuss/__system__/issue/__scripts__/issue_ssh_no_cwd.sh
@@ -2,4 +2,4 @@
 
 command_name=$1
 
-zowe uss issue ssh "$command_name"
+zowe uss issue ssh "$command_name" ${@:2}

--- a/packages/cli/__tests__/zosuss/__system__/issue/cli.issue.ssh.system.test.ts
+++ b/packages/cli/__tests__/zosuss/__system__/issue/cli.issue.ssh.system.test.ts
@@ -255,7 +255,8 @@ describe("zowe uss issue ssh passwords and passkeys", () => {
             { host, port, user, password });
         // now check the command can run
         const command = "uname";
-        const response = await runCliScript(__dirname + "/__scripts__/issue_ssh_no_cwd.sh", TEST_ENVIRONMENT, [command, "--ssh-p", onlyPassword]);
+        const response = await runCliScript(__dirname + "/__scripts__/issue_ssh_no_cwd.sh", TEST_ENVIRONMENT,
+            [command, "--ssh-p", onlyPassword]);
         checkResponse(response, 0);
         expect(response.stdout.toString()).toMatch("OS/390");
     });
@@ -267,7 +268,8 @@ describe("zowe uss issue ssh passwords and passkeys", () => {
             { host, port, user, password, privateKey: bogusPrivateKey, keyPassphrase });
         // now check the command can run
         const command = "uname";
-        const response = await runCliScript(__dirname + "/__scripts__/issue_ssh_no_cwd.sh", TEST_ENVIRONMENT, [command, "--ssh-p", invalidPrivateKey]);
+        const response = await runCliScript(__dirname + "/__scripts__/issue_ssh_no_cwd.sh", TEST_ENVIRONMENT,
+            [command, "--ssh-p", invalidPrivateKey]);
         expect(response.stderr.toString()).toMatch("no such file or directory, open 'bogusKey'");
     });
 });

--- a/packages/cli/__tests__/zosuss/__system__/issue/cli.issue.ssh.system.test.ts
+++ b/packages/cli/__tests__/zosuss/__system__/issue/cli.issue.ssh.system.test.ts
@@ -11,7 +11,7 @@
 
 import { Imperative, IO, Session } from "@zowe/imperative";
 import * as path from "path";
-import { ITestEnvironment, runCliScript } from "@zowe/cli-test-utils";
+import { ITestEnvironment, runCliScript, TempTestProfiles } from "@zowe/cli-test-utils";
 import { TestEnvironment } from "../../../../../../__tests__/__src__/environment/TestEnvironment";
 import { ITestPropertiesSchema } from "../../../../../../__tests__/__src__/properties/ITestPropertiesSchema";
 import { ZosFilesConstants } from "@zowe/zos-files-for-zowe-sdk";
@@ -233,10 +233,8 @@ describe("zowe uss issue ssh passwords and passkeys", () => {
     beforeAll(async () => {
         TEST_ENVIRONMENT = await TestEnvironment.setUp({
             testName: "issue_ssh",
-            tempProfileTypes: ["ssh"],
-            createOldProfiles: true
+            tempProfileTypes: ["ssh"]
         });
-
 
         defaultSystem = TEST_ENVIRONMENT.systemTestProperties;
         host = defaultSystem.ssh.host;
@@ -252,49 +250,24 @@ describe("zowe uss issue ssh passwords and passkeys", () => {
     });
 
     it("uses only user and password", async () => {
-
         // create a temporary zowe profile with an invalid port
-        let scriptPath = TEST_ENVIRONMENT.workingDir + "_create_profile_withoutprivateKey";
-        let command = "zowe profiles create ssh-profile " + host + "onlypassword --host " + host + " --port " + port
-            + " --user " + user + " --password " + password;
-        await IO.writeFileAsync(scriptPath, command);
-        let resp = runCliScript(scriptPath, TEST_ENVIRONMENT);
-        expect(resp.status).toBe(0);
-        // default to the temporary profile
-        command = "zowe profiles set  ssh " + host + "onlypassword";
-        scriptPath = TEST_ENVIRONMENT.workingDir + "_set_profile_withoutprivateKey";
-        await IO.writeFileAsync(scriptPath, command);
-        resp = runCliScript(scriptPath, TEST_ENVIRONMENT);
-        expect(resp.status).toBe(0);
+        const onlyPassword = await TempTestProfiles.createV2Profile(TEST_ENVIRONMENT, "ssh",
+            { host, port, user, password });
         // now check the command can run
-        command = "uname";
-        const response = await runCliScript(__dirname + "/__scripts__/issue_ssh_no_cwd.sh", TEST_ENVIRONMENT, [command]);
+        const command = "uname";
+        const response = await runCliScript(__dirname + "/__scripts__/issue_ssh_no_cwd.sh", TEST_ENVIRONMENT, [command, "--ssh-p", onlyPassword]);
         checkResponse(response, 0);
         expect(response.stdout.toString()).toMatch("OS/390");
-
-
     });
 
     it("use invalid privateKey", async () => {
         // create a temporary zowe profile with an invalid passkey
         const bogusPrivateKey = "bogusKey";
-        let scriptPath = TEST_ENVIRONMENT.workingDir + "_create_profile_invalid_privatekey";
-        let command = "zowe profiles create ssh-profile " + host + "invalidprivatekey --host " + host + " --port " + port
-            + " --user " + user + " --password " + password + " --privateKey " + bogusPrivateKey
-            + " --keyPassphrase " + keyPassphrase;
-
-        await IO.writeFileAsync(scriptPath, command);
-        let resp = runCliScript(scriptPath, TEST_ENVIRONMENT);
-        expect(resp.status).toBe(0);
-        // default to the temporary profile
-        command = "zowe profiles set  ssh " + host + "invalidprivatekey";
-        scriptPath = TEST_ENVIRONMENT.workingDir + "_set_profile_with_invalid_privateKey";
-        await IO.writeFileAsync(scriptPath, command);
-        resp = runCliScript(scriptPath, TEST_ENVIRONMENT);
-        expect(resp.status).toBe(0);
+        const invalidPrivateKey = await TempTestProfiles.createV2Profile(TEST_ENVIRONMENT, "ssh",
+            { host, port, user, password, privateKey: bogusPrivateKey, keyPassphrase });
         // now check the command can run
-        command = "uname";
-        const response = await runCliScript(__dirname + "/__scripts__/issue_ssh_no_cwd.sh", TEST_ENVIRONMENT, [command]);
+        const command = "uname";
+        const response = await runCliScript(__dirname + "/__scripts__/issue_ssh_no_cwd.sh", TEST_ENVIRONMENT, [command, "--ssh-p", invalidPrivateKey]);
         expect(response.stderr.toString()).toMatch("no such file or directory, open 'bogusKey'");
     });
 });

--- a/packages/cli/__tests__/zosuss/__system__/issue/cli.issue.ssh.system.test.ts
+++ b/packages/cli/__tests__/zosuss/__system__/issue/cli.issue.ssh.system.test.ts
@@ -9,7 +9,7 @@
 *
 */
 
-import { Imperative, IO, Session } from "@zowe/imperative";
+import { Imperative, Session } from "@zowe/imperative";
 import * as path from "path";
 import { ITestEnvironment, runCliScript, TempTestProfiles } from "@zowe/cli-test-utils";
 import { TestEnvironment } from "../../../../../../__tests__/__src__/environment/TestEnvironment";

--- a/packages/cli/src/zosfiles/view/uss/USSFile.handler.ts
+++ b/packages/cli/src/zosfiles/view/uss/USSFile.handler.ts
@@ -31,6 +31,7 @@ export default class USSFileHandler extends ZosFilesBaseHandler {
                 binary: commandParameters.arguments.binary,
                 encoding: commandParameters.arguments.encoding,
                 record: commandParameters.arguments.record,
+                range: commandParameters.arguments.range,
                 responseTimeout: commandParameters.arguments.responseTimeout,
                 task: task
             }

--- a/packages/workflows/__tests__/__system__/api/ListWorkflows.system.test.ts
+++ b/packages/workflows/__tests__/__system__/api/ListWorkflows.system.test.ts
@@ -189,7 +189,7 @@ describe("List workflows", () => {
             let error: ImperativeError;
             let response: any;
             try {
-                response = await ListWorkflows.getWorkflows(REAL_SESSION, null);
+                response = await ListWorkflows.getWorkflows(REAL_SESSION, { zOSMFVersion: null as any });
                 Imperative.console.info(`Response ${response}`);
             } catch (thrownError) {
                 error = thrownError;

--- a/packages/zosfiles/CHANGELOG.md
+++ b/packages/zosfiles/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to the Zowe z/OS files SDK package will be documented in this file.
 
+## Recent Changes
+
+- BugFix: Fixed `binary` option ignored by `Download.ussDir` and `Upload.dirToUSSDir` when ".zosattributes" file is used.
+- BugFix: Fixed `includeHidden` option ignored by `Upload.dirToUSSDir`.
+
 ## `7.15.0`
 
 - Enhancement: Added `Copy.dataSetCrossLPAR` method to support copying a dataset or members from one LPAR to another.  

--- a/packages/zosfiles/__tests__/__system__/methods/copy/Copy.system.test.ts
+++ b/packages/zosfiles/__tests__/__system__/methods/copy/Copy.system.test.ts
@@ -769,8 +769,11 @@ describe("Copy", () => {
                         responseTimeout: 5,
                         replace: false
                     };
+                    const contentBuffer = Buffer.from("Member contents for test");
+                    const toDatasetString = `${toDataSetName}(${file1})`;
                     try {
                         await Create.dataSet(REAL_SESSION, CreateDataSetTypeEnum.DATA_SET_PARTITIONED, toDataSetName);
+                        await Upload.bufferToDataSet(REAL_SESSION, contentBuffer, toDatasetString);
                         response = await Copy.dataSetCrossLPAR(REAL_SESSION, toDataset, options, fromOptions, TEST_TARGET_SESSION);
                     } catch (err) {
                         error = err;

--- a/packages/zosfiles/src/methods/download/Download.ts
+++ b/packages/zosfiles/src/methods/download/Download.ts
@@ -662,7 +662,7 @@ export class Download {
                         file: item.name,
                         options: {
                             ...mutableOptions,
-                            ...this.parseAttributeOptions(item.name, fileOptions.attributes)
+                            ...this.parseAttributeOptions(item.name, fileOptions)
                         },
                     });
                     downloadsTotal++;
@@ -824,15 +824,15 @@ export class Download {
         return reqHeaders;
     }
 
-    private static parseAttributeOptions(filename: string, attributes?: ZosFilesAttributes): Partial<IDownloadOptions> {
-        const downloadOptions: Partial<IDownloadOptions> = {};
-        if (attributes != null) {
-            downloadOptions.binary = attributes.getFileTransferMode(filename) === TransferMode.BINARY;
-            if (!downloadOptions.binary) {
-                downloadOptions.encoding = attributes.getRemoteEncoding(filename);
-                downloadOptions.localEncoding = attributes.getLocalEncoding(filename);
+    private static parseAttributeOptions(filename: string, options: IDownloadOptions): Partial<IDownloadOptions> {
+        const newOptions: Partial<IDownloadOptions> = {};
+        if (options.attributes != null) {
+            newOptions.binary = options.attributes.getFileTransferMode(filename, options.binary) === TransferMode.BINARY;
+            if (!newOptions.binary) {
+                newOptions.encoding = options.attributes.getRemoteEncoding(filename);
+                newOptions.localEncoding = options.attributes.getLocalEncoding(filename);
             }
         }
-        return downloadOptions;
+        return newOptions;
     }
 }

--- a/packages/zosfiles/src/methods/download/Download.ts
+++ b/packages/zosfiles/src/methods/download/Download.ts
@@ -30,7 +30,7 @@ import { IZosmfListResponse } from "../list/doc/IZosmfListResponse";
 import { IDownloadDsmResult } from "./doc/IDownloadDsmResult";
 import { IDownloadUssDirResult } from "./doc/IDownloadUssDirResult";
 import { IUSSListOptions } from "../list";
-import { TransferMode, ZosFilesAttributes } from "../../utils/ZosFilesAttributes";
+import { TransferMode } from "../../utils/ZosFilesAttributes";
 
 type IZosmfListResponseWithStatus = IZosmfListResponse & { error?: Error; status?: string };
 

--- a/packages/zosfiles/src/methods/upload/Upload.ts
+++ b/packages/zosfiles/src/methods/upload/Upload.ts
@@ -651,7 +651,7 @@ export class Upload {
                 const fileName = path.normalize(path.join(inputDirectory, file.fileName));
                 const ussFilePath = path.posix.join(ussname, file.fileName);
                 return this.uploadFile(fileName, ussFilePath, session,
-                    { ...options, binary: file.binary ?? options.binary });
+                    { ...options, binary: file.binary });
             };
 
             if (maxConcurrentRequests === 0) {
@@ -804,7 +804,7 @@ export class Upload {
                 const filePath = path.normalize(path.join(inputDirectory, file.fileName));
                 const ussFilePath = path.posix.join(ussname, file.fileName);
                 return this.uploadFile(filePath, ussFilePath, session,
-                    { ...options, binary: file.binary ?? options.binary });
+                    { ...options, binary: file.binary });
             };
             if (maxConcurrentRequests === 0) {
                 await Promise.all(filesArray.map(createUploadPromise));

--- a/packages/zosfiles/src/methods/upload/Upload.ts
+++ b/packages/zosfiles/src/methods/upload/Upload.ts
@@ -621,7 +621,7 @@ export class Upload {
             const filesArray: IUploadFile[] = [];
 
             // getting list of files from directory
-            const files = ZosFilesUtils.getFileListFromPath(inputDirectory, false);
+            const files = ZosFilesUtils.getFileListFromPath(inputDirectory, false, !options.includeHidden);
             // building list of files with full path and transfer mode
             files.forEach((file) => {
                 let tempBinary = options.binary;
@@ -636,8 +636,7 @@ export class Upload {
                 filesArray.push({
                     binary: tempBinary,
                     fileName: file
-                }
-                );
+                });
             });
 
             let uploadsInitiated = 0;
@@ -651,7 +650,8 @@ export class Upload {
                 }
                 const fileName = path.normalize(path.join(inputDirectory, file.fileName));
                 const ussFilePath = path.posix.join(ussname, file.fileName);
-                return this.uploadFile(fileName, ussFilePath, session, options);
+                return this.uploadFile(fileName, ussFilePath, session,
+                    { ...options, binary: file.binary ?? options.binary });
             };
 
             if (maxConcurrentRequests === 0) {
@@ -763,8 +763,7 @@ export class Upload {
             filesArray.push({
                 binary: tempBinary,
                 fileName: file
-            }
-            );
+            });
         });
 
         // create the directories
@@ -804,7 +803,8 @@ export class Upload {
                 }
                 const filePath = path.normalize(path.join(inputDirectory, file.fileName));
                 const ussFilePath = path.posix.join(ussname, file.fileName);
-                return this.uploadFile(filePath, ussFilePath, session, options);
+                return this.uploadFile(filePath, ussFilePath, session,
+                    { ...options, binary: file.binary ?? options.binary });
             };
             if (maxConcurrentRequests === 0) {
                 await Promise.all(filesArray.map(createUploadPromise));
@@ -834,7 +834,7 @@ export class Upload {
             if (!options.attributes.fileShouldBeUploaded(localPath)) {
                 return;
             }
-            tempOptions.binary = options.attributes.getFileTransferMode(localPath) === TransferMode.BINARY;
+            tempOptions.binary = options.attributes.getFileTransferMode(localPath, options.binary) === TransferMode.BINARY;
             const remoteEncoding = options.attributes.getRemoteEncoding(localPath);
             if (remoteEncoding != null && remoteEncoding !== Tag.BINARY) {
                 tempOptions.encoding = remoteEncoding;

--- a/packages/zosfiles/src/utils/ZosFilesAttributes.ts
+++ b/packages/zosfiles/src/utils/ZosFilesAttributes.ts
@@ -98,10 +98,10 @@ export class ZosFilesAttributes {
         return !this.fileShouldBeUploaded(path);
     }
 
-    public getFileTransferMode(path: string): TransferMode {
+    public getFileTransferMode(path: string, preferBinary?: boolean): TransferMode {
         const attributes = this.findLastMatchingAttributes(path);
         if (attributes === null) {
-            return TransferMode.TEXT;
+            return preferBinary ? TransferMode.BINARY : TransferMode.TEXT;
         }
 
         if (attributes.localEncoding === Tag.BINARY || attributes.localEncoding === attributes.remoteEncoding) {


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->
This PR fixes CLI system tests that were failing non-intermittently.
Most fixes involved changes only to test files, but a few involved fixing bugs in the CLI and z/OS Files SDK.

**How to Test**
Verify that the following bugs are fixed:
- `--range` option ignored on `zowe files view uss-file` command
  - Run the command with `--range 0,1` to display only the first line of a USS file
- `--binary` option ignored by commands that upload and download USS directories when ".zosattributes" file is used
  - Upload the directory `packages/cli/__tests__/zosfiles/__system__/upload/dtu/__data__/command_upload_dtu_zosattributes_dir` with the flags `--recursive --binary` and verify that files not defined in ".zosattributes" file like "picCopy.png" are uploaded as binary
- `--include-hidden` option ignored by `zowe files upload dir-to-uss` without the `--recursive` option
  - Upload the directory `packages\cli\__tests__\zosfiles\__system__\upload\dtu\__data__\command_upload_dtu_dir\dir_with_hidden_files` with the flag `--include-hidden` and verify that "dot files" are uploaded

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [x] added/updated automated tests
- [x] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
