### PR TITLE
Fix secondary space being set on blank dataset type

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Zowe CLI package will be documented in this file.
 
+## Recent Changes
+
+BugFix: Fixed `secondary` option being specified as `1` on `BLANK` type datasets with the `zowe files create data-set` command [#1595](https://github.com/zowe/zowe-cli/issues/1595)
+
 ## `7.16.3`
 
 - BugFix: Updated `imperative` to fix undesired behavior in the `zowe config list` command in certain situations.

--- a/packages/zosfiles/CHANGELOG.md
+++ b/packages/zosfiles/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Zowe z/OS files SDK package will be documented in this file.
 
+## Recent Changes
+
+- BugFix: Fixed `secondary` option being specified on `BLANK` type datasets [#1595](https://github.com/zowe/zowe-cli/issues/1595)
+
 ## `7.16.1`
 
 - BugFix: Fixed `binary` option ignored by `Download.ussDir` and `Upload.dirToUSSDir` when ".zosattributes" file is used.

--- a/packages/zosfiles/__tests__/__unit__/methods/create/Create.unit.test.ts
+++ b/packages/zosfiles/__tests__/__unit__/methods/create/Create.unit.test.ts
@@ -794,10 +794,7 @@ describe("Create data set", () => {
         expect(response.commandResponse).toContain("created successfully");
         expect(mySpy).toHaveBeenCalledWith(dummySession, endpoint, [ZosmfHeaders.ACCEPT_ENCODING], JSON.stringify({
             ...CreateDefaults.DATA_SET.BLANK,
-            ...dsBlankOptions,
-            ...{
-                secondary: 1
-            }
+            ...dsBlankOptions
         }));
     });
 

--- a/packages/zosfiles/src/methods/create/Create.ts
+++ b/packages/zosfiles/src/methods/create/Create.ts
@@ -99,7 +99,9 @@ export class Create {
                 }
             } else {
                 if (isNullOrUndefined(tempOptions.secondary)) {
-                    if (dataSetType !== CreateDataSetTypeEnum.DATA_SET_BINARY) {
+                    if (dataSetType === CreateDataSetTypeEnum.DATA_SET_BLANK) {
+                        // do nothing
+                    } else if (dataSetType !== CreateDataSetTypeEnum.DATA_SET_BINARY) {
                         tempOptions.secondary = 1;
                     } else {
                         tempOptions.secondary = 10;


### PR DESCRIPTION
**What It Does**
Resolves #1595 by removing validation that sets secondary extents to 1 for `BLANK` type dataset templates.

**How to Test**
Attempt to allocate a dataset using `zowe files create ds <DSN> --dst BASIC` and view the dataset properties via ISPF. Secondary extents will be 0. Or you'll get a dynamic allocation error from z/OSMF because you didn't set the primary extents. 

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [x] added/updated automated tests
- [x] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
