### PR TITLE
Check for invalid block size

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Zowe CLI package will be documented in this file.
 
+## Recent Changes
+
+- BugFix: Add check for invalid block size when creating a sequential dataset. [#1439](https://github.com/zowe/zowe-cli/issues/1439)
+
 ## `7.16.4`
 
 BugFix: Fixed `secondary` option being specified as `1` on `BLANK` type datasets with the `zowe files create data-set` command [#1595](https://github.com/zowe/zowe-cli/issues/1595)

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to the Zowe core SDK package will be documented in this file.
 
+```
+## Recent Changes
+
+- BugFix: Prevent invalid block size when creating a sequential dataset. [#1439](https://github.com/zowe/zowe-cli/issues/1439)
+
 ## `7.12.0`
 
 - BugFix: Added missing headers to ZosmfHeaders

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,11 +2,6 @@
 
 All notable changes to the Zowe core SDK package will be documented in this file.
 
-```
-## Recent Changes
-
-- BugFix: Prevent invalid block size when creating a sequential dataset. [#1439](https://github.com/zowe/zowe-cli/issues/1439)
-
 ## `7.12.0`
 
 - BugFix: Added missing headers to ZosmfHeaders

--- a/packages/zosfiles/CHANGELOG.md
+++ b/packages/zosfiles/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to the Zowe z/OS files SDK package will be documented in this file.
 
+## Recent Changes
+
+- BugFix: Add check for invalid block size when creating a sequential dataset using the `Create.dataset` SDK method. [#1439](https://github.com/zowe/zowe-cli/issues/1439)
+
+
 ## `7.16.4`
 
 - BugFix: Fixed `secondary` option being specified on `BLANK` type datasets [#1595](https://github.com/zowe/zowe-cli/issues/1595)

--- a/packages/zosfiles/__tests__/__unit__/methods/create/Create.unit.test.ts
+++ b/packages/zosfiles/__tests__/__unit__/methods/create/Create.unit.test.ts
@@ -251,6 +251,38 @@ describe("Create data set", () => {
             );
         });
 
+        it("should be able to create a sequential data set using the a block size that is too small", async () => {
+            const custOptions = {
+                dsorg: "PS",
+                alcunit: "CYL",
+                primary: 20,
+                secondary: 1,
+                recfm: "VB",
+                blksize: 100,
+                lrecl: 1000
+            };
+            const response = await Create.dataSet(dummySession, CreateDataSetTypeEnum.DATA_SET_SEQUENTIAL, dataSetName, custOptions);
+
+            expect(response.success).toBe(true);
+            expect(response.commandResponse).toContain("created successfully");
+            expect(mySpy).toHaveBeenCalledWith(
+                dummySession,
+                endpoint,
+                [ZosmfHeaders.ACCEPT_ENCODING],
+                JSON.stringify({
+                    ...{
+                        alcunit: "CYL",
+                        dsorg: "PS",
+                        primary: 20,
+                        recfm: "VB",
+                        blksize: 1004,
+                        lrecl: 1000,
+                        secondary: 1
+                    }
+                })
+            );
+        });
+
         it("should be able to create a sequential data set using the primary allocation and default the secondary allocation", async () => {
             const custOptions = {
                 dsorg: "PS",

--- a/packages/zosfiles/__tests__/__unit__/methods/create/Create.unit.test.ts
+++ b/packages/zosfiles/__tests__/__unit__/methods/create/Create.unit.test.ts
@@ -251,7 +251,7 @@ describe("Create data set", () => {
             );
         });
 
-        it("should be able to create a sequential data set using the a block size that is too small", async () => {
+        it("should be able to create a variable block sequential data set using a block size that is too small", async () => {
             const custOptions = {
                 dsorg: "PS",
                 alcunit: "CYL",
@@ -276,6 +276,101 @@ describe("Create data set", () => {
                         primary: 20,
                         recfm: "VB",
                         blksize: 1004,
+                        lrecl: 1000,
+                        secondary: 1
+                    }
+                })
+            );
+        });
+
+        it("should be able to create a fixed block sequential data set using a block size that is too small", async () => {
+            const custOptions = {
+                dsorg: "PS",
+                alcunit: "CYL",
+                primary: 20,
+                secondary: 1,
+                recfm: "FB",
+                blksize: 100,
+                lrecl: 1000
+            };
+            const response = await Create.dataSet(dummySession, CreateDataSetTypeEnum.DATA_SET_SEQUENTIAL, dataSetName, custOptions);
+
+            expect(response.success).toBe(true);
+            expect(response.commandResponse).toContain("created successfully");
+            expect(mySpy).toHaveBeenCalledWith(
+                dummySession,
+                endpoint,
+                [ZosmfHeaders.ACCEPT_ENCODING],
+                JSON.stringify({
+                    ...{
+                        alcunit: "CYL",
+                        dsorg: "PS",
+                        primary: 20,
+                        recfm: "FB",
+                        blksize: 1000,
+                        lrecl: 1000,
+                        secondary: 1
+                    }
+                })
+            );
+        });
+
+        it("should be able to create a variable sequential data set using a block size that is too small", async () => {
+            const custOptions = {
+                dsorg: "PS",
+                alcunit: "CYL",
+                primary: 20,
+                secondary: 1,
+                recfm: "V",
+                blksize: 100,
+                lrecl: 1000
+            };
+            const response = await Create.dataSet(dummySession, CreateDataSetTypeEnum.DATA_SET_SEQUENTIAL, dataSetName, custOptions);
+
+            expect(response.success).toBe(true);
+            expect(response.commandResponse).toContain("created successfully");
+            expect(mySpy).toHaveBeenCalledWith(
+                dummySession,
+                endpoint,
+                [ZosmfHeaders.ACCEPT_ENCODING],
+                JSON.stringify({
+                    ...{
+                        alcunit: "CYL",
+                        dsorg: "PS",
+                        primary: 20,
+                        recfm: "V",
+                        blksize: 1000,
+                        lrecl: 1004,
+                        secondary: 1
+                    }
+                })
+            );
+        });
+
+        it("should be able to create a fixed sequential data set using a block size that is too small without specifying the alcunit", async () => {
+            const custOptions = {
+                dsorg: "PS",
+                alcunit: "CYL",
+                primary: 20,
+                secondary: 1,
+                blksize: 100,
+                lrecl: 1000
+            };
+            const response = await Create.dataSet(dummySession, CreateDataSetTypeEnum.DATA_SET_SEQUENTIAL, dataSetName, custOptions);
+
+            expect(response.success).toBe(true);
+            expect(response.commandResponse).toContain("created successfully");
+            expect(mySpy).toHaveBeenCalledWith(
+                dummySession,
+                endpoint,
+                [ZosmfHeaders.ACCEPT_ENCODING],
+                JSON.stringify({
+                    ...{
+                        alcunit: "CYL",
+                        dsorg: "PS",
+                        primary: 20,
+                        recfm: "FB",
+                        blksize: 1000,
                         lrecl: 1000,
                         secondary: 1
                     }

--- a/packages/zosfiles/__tests__/__unit__/methods/create/Create.unit.test.ts
+++ b/packages/zosfiles/__tests__/__unit__/methods/create/Create.unit.test.ts
@@ -339,8 +339,8 @@ describe("Create data set", () => {
                         dsorg: "PS",
                         primary: 20,
                         recfm: "V",
-                        blksize: 1000,
-                        lrecl: 1004,
+                        blksize: 1004,
+                        lrecl: 1000,
                         secondary: 1
                     }
                 })

--- a/packages/zosfiles/__tests__/__unit__/methods/create/Create.unit.test.ts
+++ b/packages/zosfiles/__tests__/__unit__/methods/create/Create.unit.test.ts
@@ -307,7 +307,7 @@ describe("Create data set", () => {
                 size: "3TRK",
                 secondary: 2,
                 recfm: "VB",
-                blksize: 4096,
+                blksize: 4100,
                 lrecl: 4096,
                 dirblk: 5
             };
@@ -419,7 +419,7 @@ describe("Create data set", () => {
                 size: "TRK",
                 secondary: 2,
                 recfm: "VB",
-                blksize: 4096,
+                blksize: 4100,
                 lrecl: 4096,
                 dirblk: 5
             };

--- a/packages/zosfiles/src/methods/create/Create.ts
+++ b/packages/zosfiles/src/methods/create/Create.ts
@@ -197,8 +197,8 @@ export class Create {
                         break;
 
                     case "blksize":
-                    /* 
-                    *  This is a fix for issue https://github.com/zowe/zowe-cli/issues/1439. 
+                    /*
+                    *  This is a fix for issue https://github.com/zowe/zowe-cli/issues/1439.
                     *
                     */
                         if (isNullOrUndefined(tempOptions.blksize)) {
@@ -207,6 +207,9 @@ export class Create {
 
                         if(tempOptions.blksize  <= tempOptions.lrecl ){
                             tempOptions.blksize = tempOptions.lrecl;
+                            if(isNullOrUndefined(tempOptions.recfm)){
+                                tempOptions.recfm = "FB";
+                            }
                             switch (tempOptions.recfm.toUpperCase()) {
                                 case "V":
                                 case "VB":

--- a/packages/zosfiles/src/methods/create/Create.ts
+++ b/packages/zosfiles/src/methods/create/Create.ts
@@ -10,7 +10,6 @@
 */
 
 import { AbstractSession, Headers, IHeaderContent, ImperativeError, ImperativeExpect, Logger, TextUtils } from "@zowe/imperative";
-import { isNullOrUndefined } from "util";
 import { ZosmfHeaders, ZosmfRestClient } from "@zowe/core-for-zowe-sdk";
 import { ZosFilesConstants } from "../../constants/ZosFiles.constants";
 import { ZosFilesMessages } from "../../constants/ZosFiles.messages";
@@ -46,7 +45,7 @@ export class Create {
         let validCmdType = true;
 
         // Removes undefined properties
-        let tempOptions = !isNullOrUndefined(options) ? JSON.parse(JSON.stringify(options)) : {};
+        let tempOptions = !(options === null || options === undefined) ? JSON.parse(JSON.stringify(options)) : {};
 
         // Required
         ImperativeExpect.toNotBeNullOrUndefined(dataSetType, ZosFilesMessages.missingDatasetType.message);
@@ -82,23 +81,23 @@ export class Create {
             throw new ImperativeError({ msg: ZosFilesMessages.unsupportedDatasetType.message });
         } else {
             // Handle the size option
-            if (!isNullOrUndefined(tempOptions.size)) {
+            if (!(tempOptions.size === null || tempOptions.size === undefined)) {
                 const tAlcunit = tempOptions.size.toString().match(/[a-zA-Z]+/g);
-                if (!isNullOrUndefined(tAlcunit)) {
+                if (!(tAlcunit === null || tAlcunit === undefined)) {
                     tempOptions.alcunit = tAlcunit.join("").toUpperCase();
                 }
 
                 const tPrimary = tempOptions.size.toString().match(/[0-9]+/g);
-                if (!isNullOrUndefined(tPrimary)) {
+                if (!(tPrimary === null || tPrimary === undefined)) {
                     tempOptions.primary = +(tPrimary.join(""));
 
-                    if (isNullOrUndefined(tempOptions.secondary)) {
+                    if (tempOptions.secondary === null || tempOptions.secondary === undefined) {
                         const TEN_PERCENT = 0.10;
                         tempOptions.secondary = Math.round(tempOptions.primary * TEN_PERCENT);
                     }
                 }
             } else {
-                if (isNullOrUndefined(tempOptions.secondary)) {
+                if (tempOptions.secondary === null || tempOptions.secondary === undefined) {
                     if (dataSetType === CreateDataSetTypeEnum.DATA_SET_BLANK) {
                         // do nothing
                     } else if (dataSetType !== CreateDataSetTypeEnum.DATA_SET_BINARY) {
@@ -112,7 +111,7 @@ export class Create {
 
             let response = "";
             // Handle the print attributes option
-            if (!isNullOrUndefined(tempOptions.showAttributes)) {
+            if (!(tempOptions.showAttributes === null || tempOptions.showAttributes === undefined)) {
                 if (tempOptions.showAttributes) {
                     delete tempOptions.showAttributes;
                     response = TextUtils.prettyJson(tempOptions);
@@ -177,7 +176,7 @@ export class Create {
 
                     case "alcunit":
                     // zOSMF defaults to TRK if missing so mimic it's behavior
-                        if (isNullOrUndefined(tempOptions.alcunit)) {
+                        if (tempOptions.alcunit === null || tempOptions.alcunit === undefined) {
                             tempOptions.alcunit = "TRK";
                         }
 
@@ -201,13 +200,13 @@ export class Create {
                     *  This is a fix for issue https://github.com/zowe/zowe-cli/issues/1439.
                     *
                     */
-                        if (isNullOrUndefined(tempOptions.blksize)) {
+                        if (tempOptions.blksize === null || tempOptions.blksize === undefined) {
                             tempOptions.blksize = tempOptions.lrecl;
                         }
 
                         if(tempOptions.blksize  <= tempOptions.lrecl ){
                             tempOptions.blksize = tempOptions.lrecl;
-                            if(isNullOrUndefined(tempOptions.recfm)){
+                            if(tempOptions.recfm === null || tempOptions.recfm === undefined){
                                 tempOptions.recfm = "FB";
                             }
                             switch (tempOptions.recfm.toUpperCase()) {
@@ -275,7 +274,7 @@ export class Create {
 
                     case "secondary":
                     // zOSMF defaults to 0 if missing so mimic it's behavior
-                        if (isNullOrUndefined(tempOptions.secondary)) {
+                        if (tempOptions.secondary === null || tempOptions.secondary === undefined) {
                             tempOptions.secondary = 0;
                         }
 
@@ -287,7 +286,7 @@ export class Create {
 
                     case "recfm":
                     // zOSMF defaults to F if missing so mimic it's behavior
-                        if (isNullOrUndefined(tempOptions.recfm)) {
+                        if (tempOptions.recfm === null || tempOptions.recfm === undefined) {
                             tempOptions.recfm = "F";
                         }
 
@@ -387,7 +386,7 @@ export class Create {
 
         // format the attributes to show, and remove the option
         let attribText = "";
-        if (!isNullOrUndefined(idcamsOptions.showAttributes)) {
+        if (!(idcamsOptions.showAttributes === null || idcamsOptions.showAttributes === undefined)) {
             if (idcamsOptions.showAttributes) {
                 delete idcamsOptions.showAttributes;
                 attribText = ZosFilesMessages.attributeTitle.message + TextUtils.prettyJson(idcamsOptions);
@@ -471,7 +470,8 @@ export class Create {
         ImperativeExpect.toNotBeNullOrUndefined(fileSystemName, ZosFilesMessages.missingFileSystemName.message);
 
         // Removes undefined properties
-        const tempOptions = !isNullOrUndefined(options) ? JSON.parse(JSON.stringify(options)) : {};
+        const tempOptions = !(options === null || options === undefined) ? JSON.parse(JSON.stringify(options)) : {};
+
 
         let endpoint: string = ZosFilesConstants.RESOURCE + ZosFilesConstants.RES_ZFS_FILES + "/" + encodeURIComponent(fileSystemName);
 
@@ -479,7 +479,7 @@ export class Create {
         tempOptions.JSONversion = 1;
         const headers = [];
 
-        if (!isNullOrUndefined(tempOptions.timeout)) {
+        if (!(tempOptions.timeout === null || tempOptions.timeout === undefined)) {
             endpoint += `?timeout=${encodeURIComponent(tempOptions.timeout)}`;
             delete tempOptions.timeout;
         }
@@ -507,7 +507,7 @@ export class Create {
      */
     private static vsamConvertToIdcamsOptions(cliOptions: ICreateVsamOptions): ICreateVsamOptions {
         // Removes undefined properties
-        let idcamsOptions = isNullOrUndefined(cliOptions) ? {} : JSON.parse(JSON.stringify(cliOptions));
+        let idcamsOptions = !(cliOptions === null || cliOptions === undefined) ? JSON.parse(JSON.stringify(cliOptions)) : {};
 
         // convert the zowe size into IDCAMS allocationUnit and primarySpace
         let matchArray;
@@ -532,7 +532,7 @@ export class Create {
         idcamsOptions = { ...CreateDefaults.VSAM, ...idcamsOptions };
 
         // when secondary is not specified, use 10% of primary
-        if (isNullOrUndefined(idcamsOptions.secondary)) {
+        if (idcamsOptions.secondary  === null || idcamsOptions.secondary  === undefined) {
             const tenPercent = 0.10;
             idcamsOptions.secondary = Math.round(idcamsOptions.primary * tenPercent);
         }

--- a/packages/zosfiles/src/methods/create/Create.ts
+++ b/packages/zosfiles/src/methods/create/Create.ts
@@ -197,9 +197,26 @@ export class Create {
                         break;
 
                     case "blksize":
-                    // zOSMF defaults to TRK if missing so mimic it's behavior
+                    /* 
+                    *  This is a fix for issue https://github.com/zowe/zowe-cli/issues/1439. 
+                    *
+                    */
                         if (isNullOrUndefined(tempOptions.blksize)) {
                             tempOptions.blksize = tempOptions.lrecl;
+                        }
+
+                        if(tempOptions.blksize  <= tempOptions.lrecl ){
+                            tempOptions.blksize = tempOptions.lrecl;
+                            switch (tempOptions.recfm.toUpperCase()) {
+                                case "V":
+                                case "VB":
+                                case "VBS":
+                                case "VS":
+                                    tempOptions.blksize += 4;
+                                    break;
+                                default:
+                                    break;
+                            }
                         }
                         break;
 


### PR DESCRIPTION
**What It Does**
This is a fix for issue https://github.com/zowe/zowe-cli/issues/1439. It checks the block size specified by the user, or the default, against the logical record length. If the block size is too small then it is changed to a valid size. 

**How to Test**
Attempt create a dataset with a lrec size greater than 6160 and no block size specific, or specify a lrec that is larger than the specified block size. If the dataset format is a variable block, it will add an extra four bytes on to the calculated block size. 

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [x] added/updated automated tests
- [x] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)



