### PR TITLE
[zosfiles] Add stream support to Download API and refactor Get API

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -23197,6 +23197,7 @@
       "version": "7.16.4",
       "license": "EPL-2.0",
       "dependencies": {
+        "get-stream": "6.0.1",
         "minimatch": "5.0.1"
       },
       "devDependencies": {
@@ -30203,6 +30204,7 @@
         "@zowe/imperative": "5.14.1",
         "@zowe/zos-uss-for-zowe-sdk": "7.16.3",
         "eslint": "^8.22.0",
+        "get-stream": "6.0.1",
         "madge": "^4.0.1",
         "minimatch": "5.0.1",
         "rimraf": "^2.6.3",

--- a/packages/cli/__tests__/zosfiles/__unit__/compare/CompareBaseHelper.unit.test.ts
+++ b/packages/cli/__tests__/zosfiles/__unit__/compare/CompareBaseHelper.unit.test.ts
@@ -10,7 +10,7 @@
 */
 
 import { CompareBaseHelper } from "../../../../src/zosfiles/compare/CompareBaseHelper";
-import { DiffUtils, IO, ImperativeError } from "@zowe/imperative";
+import { DiffUtils, ImperativeError } from "@zowe/imperative";
 import * as fs from "fs";
 
 describe("Compare Base Helper", () => {
@@ -66,7 +66,7 @@ describe("Compare Base Helper", () => {
         it("should get the buffer of a local file", () => {
             jest.spyOn(fs, "openSync").mockReturnValue(0);
             jest.spyOn(fs, "fstatSync").mockReturnValue({isFile: () => true} as any);
-            jest.spyOn(IO, "readFileSync").mockReturnValue(Buffer.from("test"));
+            jest.spyOn(fs, "readFileSync").mockReturnValue("test");
             jest.spyOn(fs, "closeSync").mockImplementation();
 
             const response = helper.prepareLocalFile("/absolute/path/to/real/file");

--- a/packages/cli/__tests__/zosfiles/__unit__/edit/Edit.handler.unit.test.ts
+++ b/packages/cli/__tests__/zosfiles/__unit__/edit/Edit.handler.unit.test.ts
@@ -16,7 +16,7 @@ import { mockHandlerParameters } from "@zowe/cli-test-utils";
 import { EditDefinition } from "../../../../src/zosfiles/edit/Edit.definition";
 import EditHandler from "../../../../src/zosfiles/edit/Edit.handler";
 import { UNIT_TEST_PROFILES_ZOSMF, UNIT_TEST_ZOSMF_PROF_OPTS } from "../../../../../../__tests__/__src__/mocks/ZosmfProfileMock";
-import * as path from 'path';
+import stripAnsi = require("strip-ansi");
 
 describe("Files Edit Group Handler", () => {
     describe("process method", () => {
@@ -73,6 +73,9 @@ describe("Files Edit Group Handler", () => {
         commandParameters.arguments.dataSetName = dataSetName;
         const params = Object.assign({}, ...[commandParameters]);
         params.arguments = Object.assign({}, ...[commandParameters.arguments]);
+        params.response.console.log = jest.fn((logs) => {
+            expect(stripAnsi(logs.toString())).toMatchSnapshot();
+        }) as any;
 
         it("should make and upload edits successfully", async () => {
             jest.spyOn(EditUtilities, "makeEdits").mockImplementation(async () => {

--- a/packages/cli/__tests__/zosfiles/__unit__/edit/Edit.handler.unit.test.ts
+++ b/packages/cli/__tests__/zosfiles/__unit__/edit/Edit.handler.unit.test.ts
@@ -17,13 +17,12 @@ import { EditDefinition } from "../../../../src/zosfiles/edit/Edit.definition";
 import EditHandler from "../../../../src/zosfiles/edit/Edit.handler";
 import { UNIT_TEST_PROFILES_ZOSMF, UNIT_TEST_ZOSMF_PROF_OPTS } from "../../../../../../__tests__/__src__/mocks/ZosmfProfileMock";
 import * as path from 'path';
-import * as os from 'os';
 
 describe("Files Edit Group Handler", () => {
     describe("process method", () => {
         //Variable instantiation
         const dataSetName = "dataset";
-        const dataSetPath = path.join(process.cwd(), "packages\\cli\\src\\zosfiles\\edit\\Edit.handler.ts");
+        const dataSetPath = "/tmp/dataset.txt";
 
         const commandParameters: IHandlerParameters = mockHandlerParameters({
             arguments: UNIT_TEST_ZOSMF_PROF_OPTS,
@@ -52,7 +51,6 @@ describe("Files Edit Group Handler", () => {
         const guiAvailSpy = jest.spyOn(ProcessUtils, "isGuiAvailable");
         jest.spyOn(EditUtilities, "fileComparison").mockImplementation(jest.fn());
         jest.spyOn(EditUtilities, "makeEdits").mockImplementation(jest.fn());
-        jest.spyOn(os,"tmpdir").mockReturnValue("/tmp");
 
         guiAvailSpy.mockImplementation(jest.fn(() => {
             return GuiResult.GUI_AVAILABLE;

--- a/packages/cli/__tests__/zosfiles/__unit__/edit/__snapshots__/Edit.handler.unit.test.ts.snap
+++ b/packages/cli/__tests__/zosfiles/__unit__/edit/__snapshots__/Edit.handler.unit.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Files Edit Group Handler process method should make and upload edits successfully 1`] = `"[32mRemote downloaded to temp for editing: [39m[34mC:\\\\Users\\\\at895452\\\\Desktop\\\\zowe-cli\\\\packages\\\\cli\\\\src\\\\zosfiles\\\\edit\\\\Edit.handler.ts[39m"`;
+exports[`Files Edit Group Handler process method should make and upload edits successfully 1`] = `"[32mRemote downloaded to temp for editing: [39m[94m/tmp/dataset.txt[39m"`;
 
 exports[`Files Edit Group Handler process method should make and upload edits successfully 2`] = `"[32mSuccessfully uploaded edits to mainframe.[39m"`;
 

--- a/packages/cli/__tests__/zosfiles/__unit__/edit/__snapshots__/Edit.handler.unit.test.ts.snap
+++ b/packages/cli/__tests__/zosfiles/__unit__/edit/__snapshots__/Edit.handler.unit.test.ts.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Files Edit Group Handler process method should make and upload edits successfully 1`] = `"[32mRemote downloaded to temp for editing: [39m[94m/tmp/dataset.txt[39m"`;
+exports[`Files Edit Group Handler process method should make and upload edits successfully 1`] = `"Remote downloaded to temp for editing: /tmp/dataset.txt"`;
 
-exports[`Files Edit Group Handler process method should make and upload edits successfully 2`] = `"[32mSuccessfully uploaded edits to mainframe.[39m"`;
+exports[`Files Edit Group Handler process method should make and upload edits successfully 2`] = `"Successfully uploaded edits to mainframe."`;
 
 exports[`Files Edit Group Handler process method should make and upload edits successfully 3`] = `
 Object {

--- a/packages/zosfiles/CHANGELOG.md
+++ b/packages/zosfiles/CHANGELOG.md
@@ -3,7 +3,9 @@
 All notable changes to the Zowe z/OS files SDK package will be documented in this file.
 
 ## Recent Changes
-- Enhancement: Created zos-files edit commands to edit a dataset or uss file locally [PR #1672](https://github.com/zowe/zowe-cli/pull/1672)
+
+- Enhancement: Added streaming capabilities to the `Download.dataSet` and `Download.ussFile` methods.
+- BugFix: Fixed `Get.USSFile` API not respecting USS file tags.
 
 ## `7.16.4`
 

--- a/packages/zosfiles/__tests__/__unit__/methods/download/Download.unit.test.ts
+++ b/packages/zosfiles/__tests__/__unit__/methods/download/Download.unit.test.ts
@@ -128,7 +128,7 @@ describe("z/OS Files - Download", () => {
             expect(caughtError).toBeUndefined();
             expect(response).toEqual({
                 success: true,
-                commandResponse: util.format(ZosFilesMessages.datasetDownloadedSuccessfully.message, destination),
+                commandResponse: util.format(ZosFilesMessages.datasetDownloadedWithDestination.message, destination),
                 apiResponse: {}
             });
 
@@ -165,7 +165,7 @@ describe("z/OS Files - Download", () => {
             expect(caughtError).toBeUndefined();
             expect(response).toEqual({
                 success: true,
-                commandResponse: util.format(ZosFilesMessages.datasetDownloadedSuccessfully.message, destination),
+                commandResponse: util.format(ZosFilesMessages.datasetDownloadedWithDestination.message, destination),
                 apiResponse: {}
             });
 
@@ -199,7 +199,7 @@ describe("z/OS Files - Download", () => {
             expect(caughtError).toBeUndefined();
             expect(response).toEqual({
                 success: true,
-                commandResponse: util.format(ZosFilesMessages.datasetDownloadedSuccessfully.message, destination),
+                commandResponse: util.format(ZosFilesMessages.datasetDownloadedWithDestination.message, destination),
                 apiResponse: {}
             });
 
@@ -235,7 +235,7 @@ describe("z/OS Files - Download", () => {
             expect(caughtError).toBeUndefined();
             expect(response).toEqual({
                 success: true,
-                commandResponse: util.format(ZosFilesMessages.datasetDownloadedSuccessfully.message, file),
+                commandResponse: util.format(ZosFilesMessages.datasetDownloadedWithDestination.message, file),
                 apiResponse: {}
             });
 
@@ -273,7 +273,7 @@ describe("z/OS Files - Download", () => {
             expect(caughtError).toBeUndefined();
             expect(response).toEqual({
                 success: true,
-                commandResponse: util.format(ZosFilesMessages.datasetDownloadedSuccessfully.message, file),
+                commandResponse: util.format(ZosFilesMessages.datasetDownloadedWithDestination.message, file),
                 apiResponse: {}
             });
 
@@ -310,7 +310,7 @@ describe("z/OS Files - Download", () => {
             expect(caughtError).toBeUndefined();
             expect(response).toEqual({
                 success: true,
-                commandResponse: util.format(ZosFilesMessages.datasetDownloadedSuccessfully.message, destination),
+                commandResponse: util.format(ZosFilesMessages.datasetDownloadedWithDestination.message, destination),
                 apiResponse: {}
             });
 
@@ -346,7 +346,7 @@ describe("z/OS Files - Download", () => {
             expect(caughtError).toBeUndefined();
             expect(response).toEqual({
                 success: true,
-                commandResponse: util.format(ZosFilesMessages.datasetDownloadedSuccessfully.message, file),
+                commandResponse: util.format(ZosFilesMessages.datasetDownloadedWithDestination.message, file),
                 apiResponse: {}
             });
 
@@ -383,7 +383,7 @@ describe("z/OS Files - Download", () => {
             expect(caughtError).toBeUndefined();
             expect(response).toEqual({
                 success: true,
-                commandResponse: util.format(ZosFilesMessages.datasetDownloadedSuccessfully.message, destination),
+                commandResponse: util.format(ZosFilesMessages.datasetDownloadedWithDestination.message, destination),
                 apiResponse: {}
             });
 
@@ -417,7 +417,7 @@ describe("z/OS Files - Download", () => {
             expect(caughtError).toBeUndefined();
             expect(response).toEqual({
                 success: true,
-                commandResponse: util.format(ZosFilesMessages.datasetDownloadedSuccessfully.message, file),
+                commandResponse: util.format(ZosFilesMessages.datasetDownloadedWithDestination.message, file),
                 apiResponse: {}
             });
 
@@ -454,7 +454,7 @@ describe("z/OS Files - Download", () => {
             expect(caughtError).toBeUndefined();
             expect(response).toEqual({
                 success: true,
-                commandResponse: util.format(ZosFilesMessages.datasetDownloadedSuccessfully.message, destination),
+                commandResponse: util.format(ZosFilesMessages.datasetDownloadedWithDestination.message, destination),
                 apiResponse: {}
             });
 
@@ -491,7 +491,7 @@ describe("z/OS Files - Download", () => {
             expect(caughtError).toBeUndefined();
             expect(response).toEqual({
                 success: true,
-                commandResponse: util.format(ZosFilesMessages.datasetDownloadedSuccessfully.message, destination),
+                commandResponse: util.format(ZosFilesMessages.datasetDownloadedWithDestination.message, destination),
                 apiResponse: {etag: etagValue}
             });
 
@@ -642,7 +642,7 @@ describe("z/OS Files - Download", () => {
             expect(caughtError).toBeUndefined();
             expect(response).toEqual({
                 success: true,
-                commandResponse: util.format(ZosFilesMessages.datasetDownloadedSuccessfully.message, dsFolder),
+                commandResponse: util.format(ZosFilesMessages.datasetDownloadedWithDestination.message, dsFolder),
                 apiResponse: listApiResponse
             });
 
@@ -675,7 +675,7 @@ describe("z/OS Files - Download", () => {
             expect(caughtError).toBeUndefined();
             expect(response).toEqual({
                 success: true,
-                commandResponse: util.format(ZosFilesMessages.datasetDownloadedSuccessfully.message, directory),
+                commandResponse: util.format(ZosFilesMessages.datasetDownloadedWithDestination.message, directory),
                 apiResponse: listApiResponse
             });
 
@@ -710,7 +710,7 @@ describe("z/OS Files - Download", () => {
             expect(caughtError).toBeUndefined();
             expect(response).toEqual({
                 success: true,
-                commandResponse: util.format(ZosFilesMessages.datasetDownloadedSuccessfully.message, directory),
+                commandResponse: util.format(ZosFilesMessages.datasetDownloadedWithDestination.message, directory),
                 apiResponse: listApiResponse
             });
 
@@ -746,7 +746,7 @@ describe("z/OS Files - Download", () => {
             expect(caughtError).toBeUndefined();
             expect(response).toEqual({
                 success: true,
-                commandResponse: util.format(ZosFilesMessages.datasetDownloadedSuccessfully.message, directory),
+                commandResponse: util.format(ZosFilesMessages.datasetDownloadedWithDestination.message, directory),
                 apiResponse: listApiResponse
             });
 
@@ -784,7 +784,7 @@ describe("z/OS Files - Download", () => {
             expect(caughtError).toBeUndefined();
             expect(response).toEqual({
                 success: true,
-                commandResponse: util.format(ZosFilesMessages.datasetDownloadedSuccessfully.message, directory),
+                commandResponse: util.format(ZosFilesMessages.datasetDownloadedWithDestination.message, directory),
                 apiResponse: listApiResponse
             });
 
@@ -821,7 +821,7 @@ describe("z/OS Files - Download", () => {
             expect(caughtError).toBeUndefined();
             expect(response).toEqual({
                 success: true,
-                commandResponse: util.format(ZosFilesMessages.datasetDownloadedSuccessfully.message, directory),
+                commandResponse: util.format(ZosFilesMessages.datasetDownloadedWithDestination.message, directory),
                 apiResponse: listApiResponse
             });
 
@@ -856,7 +856,7 @@ describe("z/OS Files - Download", () => {
             expect(caughtError).toBeUndefined();
             expect(response).toEqual({
                 success: true,
-                commandResponse: util.format(ZosFilesMessages.datasetDownloadedSuccessfully.message, directory),
+                commandResponse: util.format(ZosFilesMessages.datasetDownloadedWithDestination.message, directory),
                 apiResponse: listApiResponse
             });
 
@@ -886,7 +886,7 @@ describe("z/OS Files - Download", () => {
             expect(caughtError).toBeUndefined();
             expect(response).toEqual({
                 success: true,
-                commandResponse: util.format(ZosFilesMessages.datasetDownloadedSuccessfully.message, dsFolder.toUpperCase()),
+                commandResponse: util.format(ZosFilesMessages.datasetDownloadedWithDestination.message, dsFolder.toUpperCase()),
                 apiResponse: listApiResponse
             });
 
@@ -1514,7 +1514,7 @@ describe("z/OS Files - Download", () => {
                             { member: "TESTDS" }
                         ]
                     },
-                    commandResponse: util.format(ZosFilesMessages.datasetDownloadedSuccessfully.message, "./")
+                    commandResponse: util.format(ZosFilesMessages.datasetDownloadedWithDestination.message, "./")
                 };
             });
 
@@ -1545,7 +1545,7 @@ describe("z/OS Files - Download", () => {
                 }, {}),
                 apiResponse: [{
                     ...dataSetPO,
-                    status: util.format(ZosFilesMessages.datasetDownloadedSuccessfully.message, "./") + "\nMembers:  TESTDS;"
+                    status: util.format(ZosFilesMessages.datasetDownloadedWithDestination.message, "./") + "\nMembers:  TESTDS;"
                 }]
             });
         });
@@ -1608,7 +1608,7 @@ describe("z/OS Files - Download", () => {
                             { member: "TESTDS" }
                         ]
                     },
-                    commandResponse: util.format(ZosFilesMessages.datasetDownloadedSuccessfully.message, directory)
+                    commandResponse: util.format(ZosFilesMessages.datasetDownloadedWithDestination.message, directory)
                 };
             });
 
@@ -1639,7 +1639,7 @@ describe("z/OS Files - Download", () => {
                 }, {directory}),
                 apiResponse: [{
                     ...dataSetPO,
-                    status: util.format(ZosFilesMessages.datasetDownloadedSuccessfully.message, directory) + "\nMembers:  TESTDS;"
+                    status: util.format(ZosFilesMessages.datasetDownloadedWithDestination.message, directory) + "\nMembers:  TESTDS;"
                 }]
             });
         });
@@ -1748,7 +1748,7 @@ describe("z/OS Files - Download", () => {
             expect(caughtError).toBeUndefined();
             expect(response).toEqual({
                 success: true,
-                commandResponse: util.format(ZosFilesMessages.ussFileDownloadedSuccessfully.message, destination),
+                commandResponse: util.format(ZosFilesMessages.ussFileDownloadedWithDestination.message, destination),
                 apiResponse: {}
             });
 
@@ -1782,7 +1782,7 @@ describe("z/OS Files - Download", () => {
             expect(caughtError).toBeUndefined();
             expect(response).toEqual({
                 success: true,
-                commandResponse: util.format(ZosFilesMessages.ussFileDownloadedSuccessfully.message, destination),
+                commandResponse: util.format(ZosFilesMessages.ussFileDownloadedWithDestination.message, destination),
                 apiResponse: {}
             });
 
@@ -1820,7 +1820,7 @@ describe("z/OS Files - Download", () => {
             expect(caughtError).toBeUndefined();
             expect(response).toEqual({
                 success: true,
-                commandResponse: util.format(ZosFilesMessages.ussFileDownloadedSuccessfully.message, destination),
+                commandResponse: util.format(ZosFilesMessages.ussFileDownloadedWithDestination.message, destination),
                 apiResponse: {}
             });
 
@@ -1858,7 +1858,7 @@ describe("z/OS Files - Download", () => {
             expect(caughtError).toBeUndefined();
             expect(response).toEqual({
                 success: true,
-                commandResponse: util.format(ZosFilesMessages.ussFileDownloadedSuccessfully.message, destination),
+                commandResponse: util.format(ZosFilesMessages.ussFileDownloadedWithDestination.message, destination),
                 apiResponse: {}
             });
 
@@ -1899,7 +1899,7 @@ describe("z/OS Files - Download", () => {
             expect(caughtError).toBeUndefined();
             expect(response).toEqual({
                 success: true,
-                commandResponse: util.format(ZosFilesMessages.ussFileDownloadedSuccessfully.message, destination),
+                commandResponse: util.format(ZosFilesMessages.ussFileDownloadedWithDestination.message, destination),
                 apiResponse: {}
             });
 
@@ -1935,7 +1935,7 @@ describe("z/OS Files - Download", () => {
             expect(caughtError).toBeUndefined();
             expect(response).toEqual({
                 success: true,
-                commandResponse: util.format(ZosFilesMessages.ussFileDownloadedSuccessfully.message, destination),
+                commandResponse: util.format(ZosFilesMessages.ussFileDownloadedWithDestination.message, destination),
                 apiResponse: {}
             });
 
@@ -1968,7 +1968,7 @@ describe("z/OS Files - Download", () => {
             expect(caughtError).toBeUndefined();
             expect(response).toEqual({
                 success: true,
-                commandResponse: util.format(ZosFilesMessages.ussFileDownloadedSuccessfully.message, file),
+                commandResponse: util.format(ZosFilesMessages.ussFileDownloadedWithDestination.message, file),
                 apiResponse: {}
             });
 
@@ -2004,7 +2004,7 @@ describe("z/OS Files - Download", () => {
             expect(caughtError).toBeUndefined();
             expect(response).toEqual({
                 success: true,
-                commandResponse: util.format(ZosFilesMessages.ussFileDownloadedSuccessfully.message, destination),
+                commandResponse: util.format(ZosFilesMessages.ussFileDownloadedWithDestination.message, destination),
                 apiResponse: {etag: etagValue}
             });
 

--- a/packages/zosfiles/package.json
+++ b/packages/zosfiles/package.json
@@ -46,6 +46,7 @@
     "prepack": "node ../../scripts/prepareLicenses.js"
   },
   "dependencies": {
+    "get-stream": "6.0.1",
     "minimatch": "5.0.1"
   },
   "devDependencies": {

--- a/packages/zosfiles/src/constants/ZosFiles.messages.ts
+++ b/packages/zosfiles/src/constants/ZosFiles.messages.ts
@@ -156,6 +156,14 @@ export const ZosFilesMessages: { [key: string]: IMessageDefinition } = {
      * @type {IMessageDefinition}
      */
     datasetDownloadedSuccessfully: {
+        message: "Data set downloaded successfully."
+    },
+
+    /**
+     * Message indicating that the data set was downloaded successfully
+     * @type {IMessageDefinition}
+     */
+    datasetDownloadedWithDestination: {
         message: "Data set downloaded successfully.\nDestination: %s"
     },
 
@@ -164,6 +172,14 @@ export const ZosFilesMessages: { [key: string]: IMessageDefinition } = {
      * @type {IMessageDefinition}
      */
     ussFileDownloadedSuccessfully: {
+        message: "USS file downloaded successfully."
+    },
+
+    /**
+     * Message indicating that the uss file was downloaded successfully
+     * @type {IMessageDefinition}
+     */
+    ussFileDownloadedWithDestination: {
         message: "USS file downloaded successfully.\nDestination: %s"
     },
 

--- a/packages/zosfiles/src/doc/IOptions.ts
+++ b/packages/zosfiles/src/doc/IOptions.ts
@@ -41,6 +41,11 @@ export interface IOptions extends IZosFilesOptions {
     encoding?: string;
 
     /**
+     * The local file encoding to pass as a "Content-Type" header
+     */
+    localEncoding?: string;
+
+    /**
      * The volume on which the data set is stored
      * @type {string}
      */

--- a/packages/zosfiles/src/methods/download/Download.ts
+++ b/packages/zosfiles/src/methods/download/Download.ts
@@ -21,7 +21,7 @@ import { ZosFilesMessages } from "../../constants/ZosFiles.messages";
 import { IZosFilesResponse } from "../../doc/IZosFilesResponse";
 import { ZosFilesUtils } from "../../utils/ZosFilesUtils";
 import { List } from "../list/List";
-import { IDownloadOptions } from "./doc/IDownloadOptions";
+import { IDownloadOptions, IDownloadSingleOptions } from "./doc/IDownloadOptions";
 import { IRestClientResponse } from "../../doc/IRestClientResponse";
 import { CLIENT_PROPERTY } from "../../doc/types/ZosmfRestClientProperties";
 import { IOptionsFullResponse } from "../../doc/IOptionsFullResponse";
@@ -35,16 +35,16 @@ import { TransferMode } from "../../utils/ZosFilesAttributes";
 type IZosmfListResponseWithStatus = IZosmfListResponse & { error?: Error; status?: string };
 
 interface IDownloadDsmTask {
-    handler: (session: AbstractSession, dsname: string, options: IDownloadOptions) => Promise<IZosFilesResponse>;
+    handler: (session: AbstractSession, dsname: string, options: IDownloadSingleOptions) => Promise<IZosFilesResponse>;
     dsname: string;
-    options: IDownloadOptions;
-    onSuccess: (response: IZosFilesResponse, options: IDownloadOptions) => void;
+    options: IDownloadSingleOptions;
+    onSuccess: (response: IZosFilesResponse, options: IDownloadSingleOptions) => void;
 }
 
 interface IDownloadUssTask {
     dirName?: string;
     file?: string;
-    options?: IDownloadOptions;
+    options?: IDownloadSingleOptions;
 }
 
 /**
@@ -56,7 +56,7 @@ export class Download {
      *
      * @param {AbstractSession}  session      - z/OS MF connection info
      * @param {string}           dataSetName  - contains the data set name
-     * @param {IDownloadOptions} [options={}] - contains the options to be sent
+     * @param {IDownloadSingleOptions} [options={}] - contains the options to be sent
      *
      * @returns {Promise<IZosFilesResponse>} A response indicating the outcome of the API
      *
@@ -78,7 +78,7 @@ export class Download {
      *
      * @see https://www.ibm.com/support/knowledgecenter/en/SSLTBW_2.3.0/com.ibm.zos.v2r3.izua700/IZUHPINFO_API_GetReadDataSet.htm
      */
-    public static async dataSet(session: AbstractSession, dataSetName: string, options: IDownloadOptions = {}): Promise<IZosFilesResponse> {
+    public static async dataSet(session: AbstractSession, dataSetName: string, options: IDownloadSingleOptions = {}): Promise<IZosFilesResponse> {
         // required
         ImperativeExpect.toNotBeNullOrUndefined(dataSetName, ZosFilesMessages.missingDatasetName.message);
         ImperativeExpect.toNotBeEqual(dataSetName, "", ZosFilesMessages.missingDatasetName.message);
@@ -497,14 +497,14 @@ export class Download {
      *
      * @param {AbstractSession}  session      - z/OS MF connection info
      * @param {string}           ussFileName  - contains the USS file name
-     * @param {IDownloadOptions} [options={}] - contains the options to be sent
+     * @param {IDownloadSingleOptions} [options={}] - contains the options to be sent
      *
      * @returns {Promise<IZosFilesResponse>} A response indicating the outcome of the API
      *
      * @throws {ImperativeError} USS file name must be set
      * @throws {Error} When the {@link ZosmfRestClient} throws an error
      */
-    public static async ussFile(session: AbstractSession, ussFileName: string, options: IDownloadOptions = {}): Promise<IZosFilesResponse> {
+    public static async ussFile(session: AbstractSession, ussFileName: string, options: IDownloadSingleOptions = {}): Promise<IZosFilesResponse> {
         // required
         ImperativeExpect.toNotBeNullOrUndefined(ussFileName, ZosFilesMessages.missingUSSFileName.message);
         ImperativeExpect.toNotBeEqual(ussFileName, "", ZosFilesMessages.missingUSSFileName.message);

--- a/packages/zosfiles/src/methods/download/doc/IDownloadOptions.ts
+++ b/packages/zosfiles/src/methods/download/doc/IDownloadOptions.ts
@@ -14,10 +14,9 @@ import { IGetOptions } from "../../get/doc/IGetOptions";
 import { ZosFilesAttributes } from "../../../utils/ZosFilesAttributes";
 
 /**
- * This interface defines the options that can be sent into the download data set function
+ * This interface defines options for downloading a single data set or USS file
  */
-export interface IDownloadOptions extends IGetOptions {
-
+export interface IDownloadSingleOptions extends IGetOptions {
     /**
      * The local file to download the data set to
      * @example "./path/to/file.txt"
@@ -37,6 +36,37 @@ export interface IDownloadOptions extends IGetOptions {
      */
     directory?: string;
 
+    /**
+     * The indicator to force return of ETag.
+     * If set to 'true' it forces the response to include an "ETag" header, regardless of the size of the response data.
+     * If it is not present, the the default is to only send an Etag for data sets smaller than a system determined length,
+     * which is at least 8MB.
+     */
+    returnEtag?: boolean;
+
+    /**
+     * Indicates if the created directories and files use the original letter case, which is for data sets always uppercase.
+     * The default value is false for backward compability.
+     * If the option "directory" or "file" is provided, this option doesn't have any effect.
+     * This option has only effect on automatically generated directories and files.
+     */
+    preserveOriginalLetterCase?: boolean;
+
+    /**
+     * Specifies whether local files should be overwritten when downloaded.
+     */
+    overwrite?: boolean;
+
+    /**
+     * Optional stream to read the file contents
+     */
+    stream?: Writable;
+}
+
+/**
+ * This interface defines options for downloading multiple data sets or USS files
+ */
+export interface IDownloadOptions extends Omit<IDownloadSingleOptions, "stream"> {
     /**
      * Exclude data sets that match these DSLEVEL patterns. Any data sets that match
      * this pattern will not be downloaded
@@ -61,22 +91,6 @@ export interface IDownloadOptions extends IGetOptions {
     maxConcurrentRequests?: number;
 
     /**
-     * The indicator to force return of ETag.
-     * If set to 'true' it forces the response to include an "ETag" header, regardless of the size of the response data.
-     * If it is not present, the the default is to only send an Etag for data sets smaller than a system determined length,
-     * which is at least 8MB.
-     */
-    returnEtag?: boolean;
-
-    /**
-     * Indicates if the created directories and files use the original letter case, which is for data sets always uppercase.
-     * The default value is false for backward compability.
-     * If the option "directory" or "file" is provided, this option doesn't have any effect.
-     * This option has only effect on automatically generated directories and files.
-     */
-    preserveOriginalLetterCase?: boolean;
-
-    /**
      * Indicates if a download operation for multiple files/data sets should fail as soon as the first failure happens.
      * If set to true, the first failure will throw an error and abort the download operation.
      * If set to false, individual download failures will be reported after all other downloads have completed.
@@ -93,14 +107,4 @@ export interface IDownloadOptions extends IGetOptions {
      * Specifies whether hidden files whose names begin with a dot should be downloaded.
      */
     includeHidden?: boolean;
-
-    /**
-     * Specifies whether local files should be overwritten when downloaded.
-     */
-    overwrite?: boolean;
-
-    /**
-     * Optional stream to read the file contents
-     */
-    stream?: Writable;
 }

--- a/packages/zosfiles/src/methods/download/doc/IDownloadOptions.ts
+++ b/packages/zosfiles/src/methods/download/doc/IDownloadOptions.ts
@@ -10,13 +10,13 @@
 */
 
 import { Writable } from "stream";
-import { IOptions } from "../../../doc/IOptions";
+import { IGetOptions } from "../../get/doc/IGetOptions";
 import { ZosFilesAttributes } from "../../../utils/ZosFilesAttributes";
 
 /**
  * This interface defines the options that can be sent into the download data set function
  */
-export interface IDownloadOptions extends IOptions {
+export interface IDownloadOptions extends IGetOptions {
 
     /**
      * The local file to download the data set to
@@ -83,11 +83,6 @@ export interface IDownloadOptions extends IOptions {
      * The default value is true for backward compatibility.
      */
     failFast?: boolean;
-
-    /**
-     * The local file encoding to pass as a "Content-Type" header
-     */
-    localEncoding?: string;
 
     /**
      * The path to a .zosattributes file used to control file conversion and tagging.

--- a/packages/zosfiles/src/methods/download/doc/IDownloadOptions.ts
+++ b/packages/zosfiles/src/methods/download/doc/IDownloadOptions.ts
@@ -9,6 +9,7 @@
 *
 */
 
+import { Writable } from "stream";
 import { IOptions } from "../../../doc/IOptions";
 import { ZosFilesAttributes } from "../../../utils/ZosFilesAttributes";
 
@@ -102,4 +103,9 @@ export interface IDownloadOptions extends IOptions {
      * Specifies whether local files should be overwritten when downloaded.
      */
     overwrite?: boolean;
+
+    /**
+     * Optional stream to read the file contents
+     */
+    stream?: Writable;
 }

--- a/packages/zosfiles/src/methods/get/Get.ts
+++ b/packages/zosfiles/src/methods/get/Get.ts
@@ -9,13 +9,12 @@
 *
 */
 
-import { posix } from "path";
+import { PassThrough } from "stream";
+import getStream = require("get-stream");
 import { AbstractSession, ImperativeExpect } from "@zowe/imperative";
 import { ZosFilesMessages } from "../../constants/ZosFiles.messages";
-import { ZosFilesConstants } from "../../constants/ZosFiles.constants";
-import { ZosmfRestClient, IHeaderContent, ZosmfHeaders } from "@zowe/core-for-zowe-sdk";
+import { Download } from "../download/Download";
 import { IGetOptions } from "./doc/IGetOptions";
-import { ZosFilesUtils } from "../../utils/ZosFilesUtils";
 
 /**
  * This class holds helper functions that are used to get the content of data sets or USS files through the z/OSMF APIs
@@ -28,7 +27,7 @@ export class Get {
      *
      * @param {AbstractSession}  session      - z/OSMF connection info
      * @param {string}           dataSetName  - contains the data set name
-     * @param {IViewOptions} [options={}] - contains the options to be sent
+     * @param {IGetOptions} [options={}] - contains the options to be sent
      *
      * @returns {Promise<Buffer>} Promise that resolves to the content of the data set
      *
@@ -38,25 +37,12 @@ export class Get {
         ImperativeExpect.toNotBeNullOrUndefined(dataSetName, ZosFilesMessages.missingDatasetName.message);
         ImperativeExpect.toNotBeEqual(dataSetName, "", ZosFilesMessages.missingDatasetName.message);
 
-        let endpoint = posix.join(ZosFilesConstants.RESOURCE, ZosFilesConstants.RES_DS_FILES, encodeURIComponent(dataSetName));
-
-        const reqHeaders: IHeaderContent[] = ZosFilesUtils.generateHeadersBasedOnOptions(options);
-
-        if (options.range) {
-            reqHeaders.push({ [ZosmfHeaders.X_IBM_RECORD_RANGE]: options.range});
-        }
-
-        if (options.volume) {
-            endpoint = posix.join(ZosFilesConstants.RESOURCE,
-                ZosFilesConstants.RES_DS_FILES,
-                `-(${encodeURIComponent(options.volume)})`,
-                encodeURIComponent(dataSetName)
-            );
-        }
-
-        const content = await ZosmfRestClient.getExpectBuffer(session, endpoint, reqHeaders);
-
-        return content;
+        const responseStream = new PassThrough();
+        await Download.dataSet(session, dataSetName, {
+            ...options,
+            stream: responseStream
+        });
+        return getStream.buffer(responseStream);
     }
 
     /**
@@ -64,7 +50,7 @@ export class Get {
      *
      * @param {AbstractSession}  session      - z/OSMF connection info
      * @param {string}           USSFileName  - contains the data set name
-     * @param {IViewOptions} [options={}] - contains the options to be sent
+     * @param {IGetOptions} [options={}] - contains the options to be sent
      *
      * @returns {Promise<Buffer>} Promise that resolves to the content of the uss file
      *
@@ -74,19 +60,12 @@ export class Get {
         ImperativeExpect.toNotBeNullOrUndefined(USSFileName, ZosFilesMessages.missingUSSFileName.message);
         ImperativeExpect.toNotBeEqual(USSFileName, "", ZosFilesMessages.missingUSSFileName.message);
         ImperativeExpect.toNotBeEqual(options.record, true, ZosFilesMessages.unsupportedDataType.message); // This should never exist for USS files
-        USSFileName = posix.normalize(USSFileName);
-        // Get a proper destination for the file to be downloaded
-        // If the "file" is not provided, we create a folder structure similar to the uss file structure
-        const encodedFileName = ZosFilesUtils.sanitizeUssPathForRestCall(USSFileName);
-        const endpoint = posix.join(ZosFilesConstants.RESOURCE, ZosFilesConstants.RES_USS_FILES, encodedFileName);
 
-        const reqHeaders: IHeaderContent[] = ZosFilesUtils.generateHeadersBasedOnOptions(options);
-
-        if (options.range) {
-            reqHeaders.push({[ZosmfHeaders.X_IBM_RECORD_RANGE]: options.range});
-        }
-        const content = await ZosmfRestClient.getExpectBuffer(session, endpoint, reqHeaders);
-
-        return content;
+        const responseStream = new PassThrough();
+        await Download.ussFile(session, USSFileName, {
+            ...options,
+            stream: responseStream
+        });
+        return getStream.buffer(responseStream);
     }
 }

--- a/packages/zosfiles/src/methods/get/doc/IGetOptions.ts
+++ b/packages/zosfiles/src/methods/get/doc/IGetOptions.ts
@@ -17,6 +17,10 @@ import { IOptions } from "../../../doc/IOptions";
  * @interface IGetOptions
  */
 export interface IGetOptions extends IOptions {
+    /**
+     * The local file encoding to pass as a "Content-Type" header
+     */
+    localEncoding?: string;
 
     /**
      * Range of records to return
@@ -25,4 +29,3 @@ export interface IGetOptions extends IOptions {
      */
     range?: string;
 }
-

--- a/packages/zosfiles/src/methods/get/doc/IGetOptions.ts
+++ b/packages/zosfiles/src/methods/get/doc/IGetOptions.ts
@@ -18,11 +18,6 @@ import { IOptions } from "../../../doc/IOptions";
  */
 export interface IGetOptions extends IOptions {
     /**
-     * The local file encoding to pass as a "Content-Type" header
-     */
-    localEncoding?: string;
-
-    /**
      * Range of records to return
      * @type {string}
      * @memberof IGetOptions

--- a/packages/zosfiles/src/methods/upload/doc/IUploadOptions.ts
+++ b/packages/zosfiles/src/methods/upload/doc/IUploadOptions.ts
@@ -65,11 +65,6 @@ export interface IUploadOptions extends IOptions {
     etag?: string;
 
     /**
-     * The local file encoding to pass as a "Content-Type" header
-     */
-    localEncoding?: string;
-
-    /**
      * The indicator to force return of ETag.
      * If set to 'true' it forces the response to include an "ETag" header, regardless of the size of the response data.
      * If it is not present, the the default is to only send an Etag for data sets smaller than a system determined length,


### PR DESCRIPTION
**What It Does**
Add stream support to APIs for downloading data sets and USS files, similar to what was done for job spool files in https://github.com/zowe/zowe-cli/pull/1686.

Also refactor the Get APIs to call the Download API so they take advantage of all its features including USS file tag detection.

**How to Test**
Verify that the Get APIs work as expected with a test script like the following:
```javascript
const zowe = require("@zowe/cli");

(async () => {
    // Load connection info from default z/OSMF profile
    const profInfo = new zowe.imperative.ProfileInfo("zowe");
    await profInfo.readProfilesFromDisk();
    const zosmfProfAttrs = profInfo.getDefaultProfile("zosmf");
    const zosmfMergedArgs = profInfo.mergeArgsForProfile(zosmfProfAttrs, { getSecureVals: true });
    const session = zowe.imperative.ProfileInfo.createSession(zosmfMergedArgs.knownArgs);

    // Test Zowe SDKs
    const dsBuffer = await zowe.Get.dataSet(session, "<dsname>");
    console.log(dsBuffer.toString());
    const ussBuffer = await zowe.Get.USSFile(session, "<ussname>");
    console.log(ussBuffer.toString());
})();
```

You can also perform cross-LPAR copy using streams without downloading the file to disk as an intermediate step:
```javascript
const responseStream = new require("stream").PassThrough();
zowe.Download.ussFile(sourceSession, "<sourceFilePath>", { binary: true, stream: responseStream });
await zowe.Upload.streamToUssFile(targetSession, "<targetFilePath>", responseStream, { binary: true });
```

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [x] added/updated automated tests
- [x] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
