### PR TITLE
[zosfiles] Handle control characters in ds member names

### DIFF
--- a/__tests__/test-tsconfig.json
+++ b/__tests__/test-tsconfig.json
@@ -4,6 +4,9 @@
       "node",
       "jest"
     ],
+    "lib": [
+      "esnext"
+    ],
     "target": "es2015",
     "module": "commonjs",
     "declaration": true,

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to the Zowe CLI package will be documented in this file.
 
 ## Recent Changes
 
-- BugFix: Add check for invalid block size when creating a sequential dataset. [#1439](https://github.com/zowe/zowe-cli/issues/1439)
+- BugFix: Added the ability to list all dataset members when some members have invalid names
+- BugFix: Added check for invalid block size when creating a sequential dataset. [#1439](https://github.com/zowe/zowe-cli/issues/1439)
 
 ## `7.16.4`
 

--- a/packages/zosfiles/CHANGELOG.md
+++ b/packages/zosfiles/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to the Zowe z/OS files SDK package will be documented in thi
 
 ## Recent Changes
 
-- BugFix: Add check for invalid block size when creating a sequential dataset using the `Create.dataset` SDK method. [#1439](https://github.com/zowe/zowe-cli/issues/1439)
+- BugFix: Added the ability to list all dataset members when some members have invalid names
+- BugFix: Added check for invalid block size when creating a sequential dataset using the `Create.dataset` SDK method. [#1439](https://github.com/zowe/zowe-cli/issues/1439)
 
 
 ## `7.16.4`

--- a/packages/zosfiles/__tests__/__unit__/methods/list/List.unit.test.ts
+++ b/packages/zosfiles/__tests__/__unit__/methods/list/List.unit.test.ts
@@ -175,8 +175,10 @@ describe("z/OS Files - List", () => {
     "items": [
         {"member": "m1"},
         {"member": "m2"},
-        {"member": "ÚÓ @Ý
-¢☻"}
+        {"member": "ÚÓ	@Ý
+¢☻"},
+        {"member": "☻¢
+Ý@	ÓÚ"}
     ]
 }`);
 
@@ -184,7 +186,8 @@ describe("z/OS Files - List", () => {
                 items: [
                     {member: "m1"},
                     {member: "m2"},
-                    {member: "ÚÓ @Ý�¢☻"}
+                    {member: "ÚÓ�@Ý�¢☻"},
+                    {member: "☻¢�Ý@�ÓÚ"}
                 ]
             };
             try {

--- a/packages/zosfiles/__tests__/__unit__/methods/list/List.unit.test.ts
+++ b/packages/zosfiles/__tests__/__unit__/methods/list/List.unit.test.ts
@@ -46,6 +46,10 @@ describe("z/OS Files - List", () => {
         type: "basic"
     });
 
+    afterAll(() => {
+        jest.restoreAllMocks();
+    });
+
     describe("allMembers", () => {
         beforeEach(() => {
             expectStringSpy.mockClear();

--- a/packages/zosfiles/__tests__/__unit__/methods/list/List.unit.test.ts
+++ b/packages/zosfiles/__tests__/__unit__/methods/list/List.unit.test.ts
@@ -175,10 +175,8 @@ describe("z/OS Files - List", () => {
     "items": [
         {"member": "m1"},
         {"member": "m2"},
-        {"member": "ÚÓ	@Ý
-¢☻"},
-        {"member": "☻¢
-Ý@	ÓÚ"}
+        {"member": "ÚÓ\t@Ý\n¢\x02"},
+        {"member": "Ú"¢\nÝ@\tÓ"}
     ]
 }`);
 
@@ -186,8 +184,8 @@ describe("z/OS Files - List", () => {
                 items: [
                     {member: "m1"},
                     {member: "m2"},
-                    {member: "ÚÓ�@Ý�¢☻"},
-                    {member: "☻¢�Ý@�ÓÚ"}
+                    {member: "ÚÓ�@Ý�¢�"},
+                    {member: "Ú\"¢�Ý@�Ó"}
                 ]
             };
             try {

--- a/packages/zosfiles/__tests__/__unit__/methods/list/List.unit.test.ts
+++ b/packages/zosfiles/__tests__/__unit__/methods/list/List.unit.test.ts
@@ -20,6 +20,7 @@ import * as util from "util";
 
 describe("z/OS Files - List", () => {
     const expectJsonSpy = jest.spyOn(ZosmfRestClient, "getExpectJSON");
+    const expectStringSpy = jest.spyOn(ZosmfRestClient, "getExpectString");
     const dsname = "USER.DATA.SET";
     const path = "/u/myuser";
     const listApiResponse = {
@@ -28,6 +29,12 @@ describe("z/OS Files - List", () => {
             {member: "m2"}
         ]
     };
+    const listApiResponseString = `{
+    "items": [
+        {"member": "m1"},
+        {"member": "m2"}
+    ]
+}`;
     const fsname = "USER.DATA.SET";
 
     const dummySession = new Session({
@@ -41,8 +48,8 @@ describe("z/OS Files - List", () => {
 
     describe("allMembers", () => {
         beforeEach(() => {
-            expectJsonSpy.mockClear();
-            expectJsonSpy.mockImplementation(async () => listApiResponse);
+            expectStringSpy.mockClear();
+            expectStringSpy.mockImplementation(async () => listApiResponseString);
         });
 
         it("should throw an error if the data set name is not specified", async () => {
@@ -89,7 +96,7 @@ describe("z/OS Files - List", () => {
             let response;
             let caughtError;
 
-            expectJsonSpy.mockResolvedValueOnce({items: []});
+            expectStringSpy.mockResolvedValueOnce(`{"items": []}`);
 
             try {
                 response = await List.allMembers(dummySession, dsname);
@@ -105,8 +112,8 @@ describe("z/OS Files - List", () => {
                 commandResponse: null,
                 apiResponse: {items: []}
             });
-            expect(expectJsonSpy).toHaveBeenCalledTimes(1);
-            expect(expectJsonSpy).toHaveBeenCalledWith(dummySession, endpoint, [ZosmfHeaders.ACCEPT_ENCODING, ZosmfHeaders.X_IBM_MAX_ITEMS]);
+            expect(expectStringSpy).toHaveBeenCalledTimes(1);
+            expect(expectStringSpy).toHaveBeenCalledWith(dummySession, endpoint, [ZosmfHeaders.ACCEPT_ENCODING, ZosmfHeaders.X_IBM_MAX_ITEMS]);
         });
 
         it("should list members from given data set", async () => {
@@ -127,8 +134,8 @@ describe("z/OS Files - List", () => {
                 commandResponse: null,
                 apiResponse: listApiResponse
             });
-            expect(expectJsonSpy).toHaveBeenCalledTimes(1);
-            expect(expectJsonSpy).toHaveBeenCalledWith(dummySession, endpoint, [ZosmfHeaders.ACCEPT_ENCODING, ZosmfHeaders.X_IBM_MAX_ITEMS]);
+            expect(expectStringSpy).toHaveBeenCalledTimes(1);
+            expect(expectStringSpy).toHaveBeenCalledWith(dummySession, endpoint, [ZosmfHeaders.ACCEPT_ENCODING, ZosmfHeaders.X_IBM_MAX_ITEMS]);
         });
 
         it("should list members from given data set with responseTimeout", async () => {
@@ -150,9 +157,48 @@ describe("z/OS Files - List", () => {
                 commandResponse: null,
                 apiResponse: listApiResponse
             });
-            expect(expectJsonSpy).toHaveBeenCalledTimes(1);
-            expect(expectJsonSpy).toHaveBeenCalledWith(dummySession, endpoint,
+            expect(expectStringSpy).toHaveBeenCalledTimes(1);
+            expect(expectStringSpy).toHaveBeenCalledWith(dummySession, endpoint,
                 [ZosmfHeaders.ACCEPT_ENCODING, ZosmfHeaders.X_IBM_MAX_ITEMS, {[ZosmfHeaders.X_IBM_RESPONSE_TIMEOUT]: "5"}]);
+        });
+
+        it("should list members from given data set that contains a member with an invalid name", async () => {
+            let response;
+            let caughtError;
+
+            // I hate the indentation too.
+            expectStringSpy.mockResolvedValueOnce(`{
+    "items": [
+        {"member": "m1"},
+        {"member": "m2"},
+        {"member": "ÚÓ @Ý
+¢☻"}
+    ]
+}`);
+
+            const expectedListApiResponse = {
+                items: [
+                    {member: "m1"},
+                    {member: "m2"},
+                    {member: "ÚÓ @Ý�¢☻"}
+                ]
+            };
+            try {
+                response = await List.allMembers(dummySession, dsname);
+            } catch (e) {
+                caughtError = e;
+            }
+
+            const endpoint = posix.join(ZosFilesConstants.RESOURCE, ZosFilesConstants.RES_DS_FILES, dsname, ZosFilesConstants.RES_DS_MEMBERS);
+
+            expect(caughtError).toBeUndefined();
+            expect(response).toEqual({
+                success: true,
+                commandResponse: null,
+                apiResponse: expectedListApiResponse
+            });
+            expect(expectStringSpy).toHaveBeenCalledTimes(1);
+            expect(expectStringSpy).toHaveBeenCalledWith(dummySession, endpoint, [ZosmfHeaders.ACCEPT_ENCODING, ZosmfHeaders.X_IBM_MAX_ITEMS]);
         });
 
         it("should list members from given data set with a matching pattern", async () => {
@@ -178,8 +224,8 @@ describe("z/OS Files - List", () => {
                 commandResponse: null,
                 apiResponse: listApiResponse
             });
-            expect(expectJsonSpy).toHaveBeenCalledTimes(1);
-            expect(expectJsonSpy).toHaveBeenCalledWith(dummySession, endpoint, [ZosmfHeaders.ACCEPT_ENCODING, ZosmfHeaders.X_IBM_MAX_ITEMS]);
+            expect(expectStringSpy).toHaveBeenCalledTimes(1);
+            expect(expectStringSpy).toHaveBeenCalledWith(dummySession, endpoint, [ZosmfHeaders.ACCEPT_ENCODING, ZosmfHeaders.X_IBM_MAX_ITEMS]);
         });
 
         it("should list members from given data set with additional attributes", async () => {
@@ -202,8 +248,8 @@ describe("z/OS Files - List", () => {
                 commandResponse: null,
                 apiResponse: listApiResponse
             });
-            expect(expectJsonSpy).toHaveBeenCalledTimes(1);
-            expect(expectJsonSpy).toHaveBeenCalledWith(dummySession, endpoint,
+            expect(expectStringSpy).toHaveBeenCalledTimes(1);
+            expect(expectStringSpy).toHaveBeenCalledWith(dummySession, endpoint,
                 [ZosmfHeaders.ACCEPT_ENCODING, ZosmfHeaders.X_IBM_ATTRIBUTES_BASE, ZosmfHeaders.X_IBM_MAX_ITEMS]);
         });
 
@@ -212,7 +258,7 @@ describe("z/OS Files - List", () => {
             let caughtError;
 
             const dummyError = new Error("test");
-            expectJsonSpy.mockImplementationOnce(() => {
+            expectStringSpy.mockImplementationOnce(() => {
                 throw dummyError;
             });
 

--- a/packages/zosfiles/__tests__/__unit__/methods/list/List.unit.test.ts
+++ b/packages/zosfiles/__tests__/__unit__/methods/list/List.unit.test.ts
@@ -176,7 +176,7 @@ describe("z/OS Files - List", () => {
         {"member": "m1"},
         {"member": "m2"},
         {"member": "ÚÓ\t@Ý\n¢\x02"},
-        {"member": "Ú"¢\nÝ@\tÓ"}
+        {"member": "Ú"¢\n"}
     ]
 }`);
 
@@ -185,7 +185,7 @@ describe("z/OS Files - List", () => {
                     {member: "m1"},
                     {member: "m2"},
                     {member: "ÚÓ�@Ý�¢�"},
-                    {member: "Ú\"¢�Ý@�Ó"}
+                    {member: "Ú\"¢�"}
                 ]
             };
             try {

--- a/packages/zosfiles/__tests__/__unit__/methods/list/List.unit.test.ts
+++ b/packages/zosfiles/__tests__/__unit__/methods/list/List.unit.test.ts
@@ -177,7 +177,7 @@ describe("z/OS Files - List", () => {
         {"member": "m2"},
         {"member": "ÚÓ\t@Ý\n¢\x02"},
         {"member": "Ú"¢\n"}
-    ]
+    ], "returnedRows": 4
 }`);
 
             const expectedListApiResponse = {
@@ -186,7 +186,8 @@ describe("z/OS Files - List", () => {
                     {member: "m2"},
                     {member: "ÚÓ�@Ý�¢�"},
                     {member: "Ú\"¢�"}
-                ]
+                ],
+                returnedRows: 4
             };
             try {
                 response = await List.allMembers(dummySession, dsname);

--- a/packages/zosfiles/src/methods/list/List.ts
+++ b/packages/zosfiles/src/methods/list/List.ts
@@ -77,19 +77,20 @@ export class List {
             let data = await ZosmfRestClient.getExpectString(session, endpoint, reqHeaders);
             // Match each member name returned by list members endpoint
             for (const match of data.matchAll(/"member":\s*"/g)) {
+                const unicodeCharacterLength = 5;
                 const memberMaxLength = 8;
+                const firstNonControlChcaracter = 32;
+                const quoteCharCode = 34;
+                const backslashCharCode = 92;
                 let memberStartIdx = match.index + match[0].length;
                 // Loop through up to 8 characters that follow the opening quote
-                // eslint-disable-next-line @typescript-eslint/no-magic-numbers
                 for (let i = 1; i <= memberMaxLength; i++) {
                     const memberChar = data.charCodeAt(memberStartIdx + i);
-                    // eslint-disable-next-line @typescript-eslint/no-magic-numbers
-                    if (memberChar < 32) {
+                    if (memberChar < firstNonControlChcaracter) {
                         // Replace control characters with Unicode <?> symbol
                         data = data.substring(0, memberStartIdx + i) + "\\ufffd" + data.substring(memberStartIdx + i + 1);
-                        memberStartIdx += 5;  // eslint-disable-line @typescript-eslint/no-magic-numbers
-                    // eslint-disable-next-line @typescript-eslint/no-magic-numbers
-                    } else if (memberChar === 34 && data.charCodeAt(memberStartIdx + i - 1) !== 92) {
+                        memberStartIdx += unicodeCharacterLength;
+                    } else if (memberChar === quoteCharCode && data.charCodeAt(memberStartIdx + i - 1) !== backslashCharCode) {
                         // Exit the loop if we find closing quote (quote not preceded by backslash)
                         break;
                     }

--- a/packages/zosfiles/src/methods/list/List.ts
+++ b/packages/zosfiles/src/methods/list/List.ts
@@ -82,7 +82,8 @@ export class List {
                 // Escape invalid JSON characters in encrypted member names
                 for (const match of Array.from(data.matchAll(/"member":\s*"(?![A-Za-z@#$][A-Za-z0-9@#$]{0,7}")/g)).reverse()) {
                     const memberStartIdx = match.index + match[0].length;
-                    const memberNameLength = 8;
+                    const memberNameLength = data.substring(memberStartIdx,
+                        memberStartIdx + data.substring(memberStartIdx).match(/"[A-Za-z]{6,}"\s*:/).index).lastIndexOf(`"`);
                     const memberName = data.substring(memberStartIdx, memberStartIdx + memberNameLength);
                     // eslint-disable-next-line no-control-regex
                     const escapedMemberName = memberName.replace(/[\x00-\x1f]/g, "\\ufffd").replace(/"/g, `\\"`);

--- a/packages/zosfiles/src/methods/list/List.ts
+++ b/packages/zosfiles/src/methods/list/List.ts
@@ -86,7 +86,7 @@ export class List {
                         memberStartIdx + data.substring(memberStartIdx).match(/"[A-Za-z]{6,}"\s*:/).index).lastIndexOf(`"`);
                     const memberName = data.substring(memberStartIdx, memberStartIdx + memberNameLength);
                     // eslint-disable-next-line no-control-regex
-                    const escapedMemberName = memberName.replace(/[\x00-\x1f]/g, "\\ufffd").replace(/"/g, `\\"`);
+                    const escapedMemberName = memberName.replace(/[\x00-\x1f\x7f\x80-\x9f]/g, "\\ufffd").replace(/"/g, `\\"`);
                     data = data.substring(0, memberStartIdx) + escapedMemberName + data.substring(memberStartIdx + memberNameLength);
                 }
                 response = JSONUtils.parse(data);

--- a/packages/zosfiles/src/methods/list/List.ts
+++ b/packages/zosfiles/src/methods/list/List.ts
@@ -79,14 +79,14 @@ export class List {
             for (const match of data.matchAll(/"member":\s*"/g)) {
                 const unicodeCharacterLength = 5;
                 const memberMaxLength = 8;
-                const firstNonControlChcaracter = 32;
+                const firstNonControlCharCode = 32;
                 const quoteCharCode = 34;
                 const backslashCharCode = 92;
                 let memberStartIdx = match.index + match[0].length;
                 // Loop through up to 8 characters that follow the opening quote
                 for (let i = 1; i <= memberMaxLength; i++) {
                     const memberChar = data.charCodeAt(memberStartIdx + i);
-                    if (memberChar < firstNonControlChcaracter) {
+                    if (memberChar < firstNonControlCharCode) {
                         // Replace control characters with Unicode <?> symbol
                         data = data.substring(0, memberStartIdx + i) + "\\ufffd" + data.substring(memberStartIdx + i + 1);
                         memberStartIdx += unicodeCharacterLength;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,9 @@
       "node",
       "jest"
     ],
+    "lib": [
+      "esnext"
+    ],
     "target": "es2015",
     "module": "commonjs",
     "declaration": true,


### PR DESCRIPTION
**What It Does**
Handles control characters in data set member names returned by the `List.allMembers` API.

The "esnext" lib in tsconfig.json is required to use the `matchAll` function.

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [x] added/updated automated tests
- [x] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
