### PR TITLE
Fix for `zowe files create data-set` not working, console system test failures

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to the Zowe CLI package will be documented in this file.
 
 ## Recent Changes
 
+- BugFix: Fixed `zowe files create data-set` failing when no additional options are specified.
 - BugFix: Add check for invalid block size when creating a sequential dataset. [#1439](https://github.com/zowe/zowe-cli/issues/1439)
 
 ## `7.16.4`

--- a/packages/cli/__tests__/zosconsole/__system__/issue/__regex__/d_iplinfo.regex
+++ b/packages/cli/__tests__/zosconsole/__system__/issue/__regex__/d_iplinfo.regex
@@ -1,1 +1,1 @@
-[\s]*IEE254I.*IPLINFO DISPLAY .*[\s]*SYSTEM IPLED AT .* ON .*[\s]*RELEASE z\/OS .*LICENSE = z\/OS.*[\s]*USED .*[\s]*ARCHLVL = .* MTLSHARE = .*[\s]*IEASYM LIST = .*[\s]*IEASYS LIST = .*[\s]*IODF DEVICE: .*[\s]*IPL DEVICE: .*
+[\s]*IEE254I.*IPLINFO DISPLAY .*[\s]*SYSTEM IPLED AT .* ON .*[\s]*RELEASE z\/OS .*LICENSE = z\/OS.*[\s]*USED .*[\s]*ARCHLVL = .* MTLSHARE = .*[\s]*VALIDATED BOOT: .*[\s]*IEASYM LIST = .*[\s]*IEASYS LIST = .*[\s]*IODF DEVICE: .*[\s]*IPL DEVICE: .*

--- a/packages/zosconsole/__tests__/__regex__/d_iplinfo_regex.regex
+++ b/packages/zosconsole/__tests__/__regex__/d_iplinfo_regex.regex
@@ -1,1 +1,1 @@
-[\s]*IEE254I.*IPLINFO DISPLAY .*[\s]*SYSTEM IPLED AT .* ON .*[\s]*RELEASE z\/OS .*LICENSE = z\/OS.*[\s]*USED .*[\s]*ARCHLVL = .* MTLSHARE = .*[\s]*IEASYM LIST = .*[\s]*IEASYS LIST = .*[\s]*IODF DEVICE: .*[\s]*IPL DEVICE: .*
+[\s]*IEE254I.*IPLINFO DISPLAY .*[\s]*SYSTEM IPLED AT .* ON .*[\s]*RELEASE z\/OS .*LICENSE = z\/OS.*[\s]*USED .*[\s]*ARCHLVL = .* MTLSHARE = .*[\s]*VALIDATED BOOT: .*[\s]*IEASYM LIST = .*[\s]*IEASYS LIST = .*[\s]*IODF DEVICE: .*[\s]*IPL DEVICE: .*

--- a/packages/zosfiles/CHANGELOG.md
+++ b/packages/zosfiles/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to the Zowe z/OS files SDK package will be documented in thi
 
 ## Recent Changes
 
+- BugFix: Fixed `Create.dataset` failing when `CreateDataSetTypeEnum.DATA_SET_BLANK` is passed but no other options are specified. 
 - BugFix: Add check for invalid block size when creating a sequential dataset using the `Create.dataset` SDK method. [#1439](https://github.com/zowe/zowe-cli/issues/1439)
 
 

--- a/packages/zosfiles/src/methods/create/Create.defaults.ts
+++ b/packages/zosfiles/src/methods/create/Create.defaults.ts
@@ -90,7 +90,9 @@ export const CreateDefaults = {
          * Specifies the defaults used by the Zos Files API to create a blank data set
          * @type {ICreateDataSetOptions}
          */
-        BLANK: {}
+        BLANK: {
+            primary: 1
+        }
     },
     /**
      * Specifies the defaults used by the Zos Files API to create a VSAM cluster


### PR DESCRIPTION
- Fixes `zowe files create data-set` failing if no other dataset parameters are passed or the `--like` option is not passed. 
- Fixed failing Console system tests that issued the 'D IPLINFO' command and parsed the output. This was caused by changes in the command output in z/OS 2.5. 

The `zowe files create data-set` fix can be tested by issuing the command with no options. It should succeed without errors. 

I certify that I have:
- [x] tested my changes
- [x] added/updated automated tests
- [x] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


