### PR TITLE
Fix error when listing ds members that include "\"

### DIFF
--- a/packages/zosfiles/CHANGELOG.md
+++ b/packages/zosfiles/CHANGELOG.md
@@ -2,13 +2,16 @@
 
 All notable changes to the Zowe z/OS files SDK package will be documented in this file.
 
+## Recent Changes
+
+- BugFix: Fixed error when listing data set members that include backslash in the name.
+
 ## `7.16.5`
 
 - BugFix: Fixed `Create.dataset` failing when `CreateDataSetTypeEnum.DATA_SET_BLANK` is passed but no other options are specified.
 - BugFix: Added check for invalid block size when creating a sequential data set using the `Create.dataset` SDK method. [#1439](https://github.com/zowe/zowe-cli/issues/1439)
 - BugFix: Added the ability to list all data set members when some members have invalid names.
 - BugFix: Removed extra calls to list datasets matching patterns if authentication to z/OSMF fails.
-
 
 ## `7.16.4`
 

--- a/packages/zosfiles/src/methods/list/List.ts
+++ b/packages/zosfiles/src/methods/list/List.ts
@@ -88,7 +88,7 @@ export class List {
                     const memberNameLength = data.substring(memberStartIdx,
                         memberStartIdx + data.substring(memberStartIdx).match(/"[A-Za-z]{6,}"\s*:/).index).lastIndexOf(`"`);
                     const memberName = data.substring(memberStartIdx, memberStartIdx + memberNameLength);
-                    const escapedMemberName = memberName.replace(/("|\\)/g, `\\$1`).replace(this.CONTROL_CHAR_REGEX, "\\ufffd");
+                    const escapedMemberName = memberName.replace(/(["\\])/g, `\\$1`).replace(this.CONTROL_CHAR_REGEX, "\\ufffd");
                     data = data.substring(0, memberStartIdx) + escapedMemberName + data.substring(memberStartIdx + memberNameLength);
                 }
                 response = JSONUtils.parse(data);

--- a/packages/zosfiles/src/methods/list/List.ts
+++ b/packages/zosfiles/src/methods/list/List.ts
@@ -28,6 +28,9 @@ import { IDsmListOptions } from "./doc/IDsmListOptions";
  * This class holds helper functions that are used to list data sets and its members through the z/OS MF APIs
  */
 export class List {
+    // eslint-disable-next-line no-control-regex
+    private static CONTROL_CHAR_REGEX = new RegExp(/[\x00-\x1f\x7f\x80-\x9f]/g);
+
     /**
      * Retrieve all members from a PDS
      *
@@ -85,8 +88,7 @@ export class List {
                     const memberNameLength = data.substring(memberStartIdx,
                         memberStartIdx + data.substring(memberStartIdx).match(/"[A-Za-z]{6,}"\s*:/).index).lastIndexOf(`"`);
                     const memberName = data.substring(memberStartIdx, memberStartIdx + memberNameLength);
-                    // eslint-disable-next-line no-control-regex
-                    const escapedMemberName = memberName.replace(/[\x00-\x1f\x7f\x80-\x9f]/g, "\\ufffd").replace(/"/g, `\\"`);
+                    const escapedMemberName = memberName.replace(/("|\\)/g, `\\$1`).replace(this.CONTROL_CHAR_REGEX, "\\ufffd");
                     data = data.substring(0, memberStartIdx) + escapedMemberName + data.substring(memberStartIdx + memberNameLength);
                 }
                 response = JSONUtils.parse(data);


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->
Fixes a bug in the implementation of #1730 - error when listing data set members that include backslash in the name.

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->
Run against our mainframe test system: `zowe files ls am {Timothy's PMF key}.COPYBOOK.UNTERSED`
This data set contains thousands of members with special characters in the name 🙂 

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [x] added/updated automated tests
- [x] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
