### PR TITLE
Fix error when listing ds members that include '"'

### DIFF
--- a/packages/cli/src/zosfiles/edit/Edit.utils.ts
+++ b/packages/cli/src/zosfiles/edit/Edit.utils.ts
@@ -135,7 +135,7 @@ export class EditUtilities {
             input = await CliUtils.readPrompt(TextUtils.chalk.green(promptText));
         }
         while (input != null && input.toLowerCase() != 'y' &&  input.toLowerCase() != 'n');
-        if (input === null) {
+        if (input == null) {
             throw new ImperativeError({
                 msg: TextUtils.chalk.red('No input provided. Command terminated. Temp file will persist.')
             });

--- a/packages/zosfiles/CHANGELOG.md
+++ b/packages/zosfiles/CHANGELOG.md
@@ -2,9 +2,14 @@
 
 All notable changes to the Zowe z/OS files SDK package will be documented in this file.
 
+## Recent Changes
+
+- BugFix: Fixed error when listing data set members that include double quote in the name.
+
 ## `7.17.0`
-- Enhancement: Added streaming capabilities to the Download.dataSet and Download.ussFile methods.
-- BugFix: Fixed Get.USSFile API not respecting USS file tags.
+
+- Enhancement: Added streaming capabilities to the `Download.dataSet` and `Download.ussFile` methods.
+- BugFix: Fixed `Get.USSFile` API not respecting USS file tags.
 
 ## `7.16.6`
 

--- a/packages/zosfiles/src/methods/list/List.ts
+++ b/packages/zosfiles/src/methods/list/List.ts
@@ -83,7 +83,7 @@ export class List {
                 response = JSONUtils.parse(data);
             } catch {
                 // Escape invalid JSON characters in encrypted member names
-                for (const match of Array.from(data.matchAll(/"member":\s*"(?![A-Za-z@#$][A-Za-z0-9@#$]{0,7}")/g)).reverse()) {
+                for (const match of Array.from(data.matchAll(/"member":\s*"/g)).reverse()) {
                     const memberStartIdx = match.index + match[0].length;
                     const memberNameLength = data.substring(memberStartIdx,
                         memberStartIdx + data.substring(memberStartIdx).match(/"[A-Za-z]{6,}"\s*:/).index).lastIndexOf(`"`);


### PR DESCRIPTION
**What It Does**
Fixes a bug in the implementation of https://github.com/zowe/zowe-cli/pull/1730 - error when listing data set members that include double quote in the name.

**How to Test**
There isn't really a way to test the changes manually. The error is only reproducible in the unit test ["should list members from given data set that contains a member with an invalid name"](https://github.com/zowe/zowe-cli/blob/master/packages/zosfiles/__tests__/__unit__/methods/list/List.unit.test.ts#L169) which generates random member names to test with. The member name that was previously failing the test is `XK"¶J9	^`, and I've verified that it now passes with this member name.

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [ ] added/updated automated tests
- [x] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)

**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
