### PR TITLE
ci: add `NPM_REGISTRY` to secrets publish workflow

### DIFF
--- a/.github/workflows/secrets-sdk-publish.yml
+++ b/.github/workflows/secrets-sdk-publish.yml
@@ -30,5 +30,5 @@ jobs:
         NPM_USER: ${{ secrets.ARTIFACTORY_USERNAME }}
         NPM_PASS: ${{ secrets.ARTIFACTORY_PASSWORD }}
         NPM_EMAIL: ${{ secrets.ZOWE_ROBOT_EMAIL }}
-        NPM_RC_PATH: "../../.npmrc"
+        NPM_REGISTRY: "https://zowe.jfrog.io/zowe/api/npm/npm-local-release"
         NPM_SCOPE: "@zowe"


### PR DESCRIPTION
**What It Does**

This PR fixes a quick issue with the Secrets SDK publish workflow, due to an issue with `npm-cli-login` failing to read the `.npmrc` file.
