### PR TITLE
Fix prebuilds missing from secrets SDK package

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -23367,7 +23367,7 @@
     },
     "packages/secrets": {
       "name": "@zowe/secrets-for-zowe-sdk",
-      "version": "7.18.0-next.2",
+      "version": "7.18.0-next.4",
       "hasInstallScript": true,
       "license": "EPL-2.0",
       "devDependencies": {

--- a/packages/secrets/package.json
+++ b/packages/secrets/package.json
@@ -3,7 +3,7 @@
   "description": "Credential management facilities for Imperative, Zowe CLI, and extenders.",
   "repository": "https://github.com/zowe/zowe-cli.git",
   "author": "Zowe",
-  "version": "7.18.0-next.2",
+  "version": "7.18.0-next.4",
   "homepage": "https://github.com/zowe/zowe-cli/tree/master/packages/secrets#readme",
   "bugs": {
     "url": "https://github.com/zowe/zowe-cli/issues"
@@ -13,7 +13,7 @@
   "types": "lib/index.d.ts",
   "files": [
     "lib",
-    "prebuilds",
+    "prebuilds/*.node",
     "src/keyring",
     "index.d.ts",
     "index.js"


### PR DESCRIPTION
**What It Does**
Allow `.node` files to be published in the "prebuilds" folder

**How to Test**
Already published a `next` release from this branch - see the prebuilds here:
https://zowe.jfrog.io/artifactory/npm-local-release/%40zowe/secrets-for-zowe-sdk/-/%40zowe/secrets-for-zowe-sdk-7.18.0-next.4.tgz

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)

**Additional Comments**

Other possible fixes:
* This seems like a bug specific to npm@8 because it was working locally with npm@9., so we could upgrade to Node 18/npm 9 in the pipeline. However it seems likely that npm@9 could break sometime in the future since enhancements are actively being made to it.
* I tried adding the following line to `packages/secrets/src/keyring/.npmignore` thinking that would fix the problem but it didn't (which is why there's a skip from `next.2` to `next.4`):
  ```
  !prebuilds/*.node
  ```