### PR TITLE
only showing command output in stdout for `zowe uss issue cmd`

### DIFF
--- a/packages/zosuss/CHANGELOG.md
+++ b/packages/zosuss/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to the Zowe z/OS USS SDK package will be documented in this file.
 
+## Recent Changes
+- BugFix: Updated `zowe zos-ssh issue cmd` to return just the command output in `stdout` instead of both the command and its output. [#1724](https://github.com/zowe/zowe-cli/issues/1724)
+
 ## `7.6.1`
 
 - BugFix: Updated `ssh2` dependency to fix "Received unexpected packet type" error. [#1516](https://github.com/zowe/zowe-cli/issues/1516)

--- a/packages/zosuss/__tests__/__unit__/Shell.unit.test.ts
+++ b/packages/zosuss/__tests__/__unit__/Shell.unit.test.ts
@@ -61,11 +61,12 @@ function checkMockFunctionsWithCommand(command: string) {
     expect(mockConnect).toBeCalled();
     expect(mockShell).toBeCalled();
 
-    // Check the stream.end() fucntion is called with an argument containing the SSH command
+    // Check the stream.end() function is called with an argument containing the SSH command
     expect(mockStreamWrite.mock.calls[0][0]).toMatch(command);
     expect(mockStreamEnd).toHaveBeenCalled();
     expect(stdoutHandler).toHaveBeenCalledWith("stdout data\n");
     expect(stdoutHandler).toHaveBeenCalledWith("\rerror");
+    expect(stdoutHandler).not.toContain("$")
 }
 
 describe("Shell", () => {

--- a/packages/zosuss/__tests__/__unit__/Shell.unit.test.ts
+++ b/packages/zosuss/__tests__/__unit__/Shell.unit.test.ts
@@ -66,7 +66,7 @@ function checkMockFunctionsWithCommand(command: string) {
     expect(mockStreamEnd).toHaveBeenCalled();
     expect(stdoutHandler).toHaveBeenCalledWith("stdout data\n");
     expect(stdoutHandler).toHaveBeenCalledWith("\rerror");
-    expect(stdoutHandler).not.toContain("$")
+    expect(stdoutHandler).not.toContain("$");
 }
 
 describe("Shell", () => {

--- a/packages/zosuss/src/Shell.ts
+++ b/packages/zosuss/src/Shell.ts
@@ -94,8 +94,10 @@ export class Shell {
                                 dataToPrint = "";
                                 isUserCommand = false;
                             } else if (isUserCommand) {
-                                // print out the user command result
-                                stdoutHandler(dataToPrint);
+                                // don't print out command, just print result
+                                if (!dataToPrint.match(new RegExp("\\$"))){
+                                    stdoutHandler(dataToPrint);
+                                }
                                 dataToPrint = "";
                             }
                         }

--- a/packages/zosuss/src/Shell.ts
+++ b/packages/zosuss/src/Shell.ts
@@ -96,7 +96,11 @@ export class Shell {
                             } else if (isUserCommand) {
                                 // don't print out command, just print result
                                 if (!dataToPrint.match(new RegExp("\\$"))){
-                                    stdoutHandler(dataToPrint);
+                                    if (dataToPrint.startsWith("\r\n")){
+                                        stdoutHandler(dataToPrint.split("\r\n")[1]);
+                                    }else{
+                                        stdoutHandler(dataToPrint);
+                                    }
                                 }
                                 dataToPrint = "";
                             }


### PR DESCRIPTION
**What It Does**
Fixes Issue (#1724 

**How to Test**
Run any command with `zowe uss issue cmd "chosenCommand" --rfj` and verify that `$chosenCommand` isn't present in the stdout of the json response. 

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [x] added/updated automated tests
- [x] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
Newline padding has been removed from the front of command output but not the end. This is because line endings appear to vary across systems and rather than attempt to remove these endings and cause some unintended break, it seems easier to have the end user remove this information if they choose. 

