### PR TITLE
Fix system test: Udpate V1 message

### DIFF
--- a/packages/cli/__tests__/auth/__system__/cli.auth.login.apiml.system.test.ts
+++ b/packages/cli/__tests__/auth/__system__/cli.auth.login.apiml.system.test.ts
@@ -163,7 +163,7 @@ describe("auth login/logout apiml create profile", () => {
         expect(response.stderr.toString()).toBe("");
         expect(response.status).toBe(0);
         expect(response.stdout.toString()).toContain("Logout successful. The authentication token has been revoked");
-        expect(response.stdout.toString()).toContain("Token was removed from your"); // ${name} base profile
+        expect(response.stdout.toString()).toContain("and removed from your 'default' base profile"); // V1 message
     });
 });
 


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->
Fixes a logout system test that should go against V1 profiles

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->
- Make sure you don't have any V2 config files active, and 
- Run the `packages/cli/__tests__/auth/__system__/cli.auth.login.apiml.system.test.ts` system test

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [x] added/updated automated tests
- [x] updated the changelog: **N/A**
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
The logout test is specific to V1 and that message did not change.
I happened to have tested this with a V2 configuration which gave me the V2 message format. 😅 
