### PR TITLE
doc: Add README to Secrets SDK w/ how-to, examples

### DIFF
--- a/packages/secrets/CHANGELOG.md
+++ b/packages/secrets/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Zowe Secrets SDK package will be documented in this file.
 
+## `7.18.1`
+
+- Added README to package w/ description, instructions and examples of using the `keyring` module. 
+
 ## `7.18.0`
 
 - Initial release.

--- a/packages/secrets/README.md
+++ b/packages/secrets/README.md
@@ -1,0 +1,47 @@
+# Secrets Package
+
+Contains APIs for secure credential management.
+
+## `keyring` API Examples
+
+Developers that reference the dependency `keytar` directly in their code need to use the new `keyring` module from this package.
+
+Use the `keyring` module in the same fashion as `keytar`.
+
+### Storing and loading credentials
+
+```js
+const { keyring } = require("@zowe/secrets-for-zowe-sdk");
+await keyring.setPassword("ServiceName", "AccountName", "SomePassword");
+
+const password = await keyring.getPassword("ServiceName", "AccountName");
+// password should equal "SomePassword"
+```
+
+### Finding a credential
+
+```js
+const { keyring } = require("@zowe/secrets-for-zowe-sdk");
+const password = keyring.findPassword("ServiceName", "AccountName");
+// password should equal "SomePassword"
+```
+
+### Finding all credentials matching attribute
+
+```js
+const { keyring } = require("@zowe/secrets-for-zowe-sdk");
+const matchingCredentials = keyring.findCredentials("ServiceName");
+// returns: 
+// [
+//    { account: "AccountName", password: "SomePassword" },
+//    ...
+// ]
+```
+
+### Deleting a credential
+
+```js
+const { keyring } = require("@zowe/secrets-for-zowe-sdk");
+const wasDeleted = keyring.deletePassword("ServiceName", "AccountName");
+// wasDeleted should be true; ServiceName/AccountName removed from credential vault
+```

--- a/packages/secrets/README.md
+++ b/packages/secrets/README.md
@@ -22,7 +22,7 @@ const password = await keyring.getPassword("ServiceName", "AccountName");
 
 ```js
 const { keyring } = require("@zowe/secrets-for-zowe-sdk");
-const password = await keyring.findPassword("ServiceName", "AccountName");
+const password = await keyring.findPassword("ServiceName/AccountName");
 // password should equal "SomePassword"
 ```
 
@@ -45,3 +45,5 @@ const { keyring } = require("@zowe/secrets-for-zowe-sdk");
 const wasDeleted = await keyring.deletePassword("ServiceName", "AccountName");
 // wasDeleted should be true; ServiceName/AccountName removed from credential vault
 ```
+
+For more detailed information, see [src/keyring/EXTENDERS.md](src/keyring/EXTENDERS.md).

--- a/packages/secrets/src/keyring/EXTENDERS.md
+++ b/packages/secrets/src/keyring/EXTENDERS.md
@@ -1,0 +1,62 @@
+# Usage (Extenders)
+
+## What is `keyring`?
+
+`keyring` is a cross-platform module meant to interact with OS (operating system) credential storage. `keyring` is written in Rust, and uses other Rust libraries to interface with credential storage APIs (application programming interfaces). It was designed to be a drop-in replacement for `node-keytar`, a Microsoft (formerly GitHub under "Atom") project that was archived on December 15th, 2022. For context, `node-keytar` has widespread use in multiple projects with over 500k weekly downloads - this library was created to avoid long-term conflicts/vulnerabilities that may arise with `node-keytar` now that it is no longer maintained.
+
+## Why switch to `keyring`?
+
+By continuing to use `node-keytar`, it opens up the user to future problems with the library itself or its dependencies. Until Microsoft provides an update to the status of `keytar` on NPM, it is unknown whether the package will continue to be supported. As a result, there was a demand for a replacement that can function identically to the original module.
+
+As `keyring` was modeled after `node-keytar`, the same operations can be performed in credential storage:
+
+- Storing credentials
+- Retrieving credentials
+- Searching for passwords based on a matching label
+- Searching for matching credentials based on a prefix/query
+- Deleting credentials
+
+**Currently, there are no breaking changes** between the use of `node-keytar` and `keyring`. This is intended by design, and the library will be maintained with that principle in mind. As a result, `keyring` is a substitute for the original `node-keytar` module.
+
+From a developer's perspective, one can simply update existing extenders or plug-ins to import the keyring module from `@zowe/secrets-for-zowe-sdk` instead of `node-keytar`, allowing for a straightforward transition. All functions previously exported in `node-keytar` will be available in `keyring`. Simply add `@zowe/secrets-for-zowe-sdk` to your project using `npm` or `yarn`.
+
+Importing a function from `keyring` is identical to the `node-keytar` import process:
+
+```ts
+// Import all functions under a namespace...
+import { keyring } from "@zowe/secrets-for-zowe-sdk";
+// Or, use require to import the keyring module.
+const { keyring } = require("@zowe/secrets-for-zowe-sdk");
+```
+
+After the desired functions are imported, feel free to use them in the same fashion as the `node-keytar` functions. For the examples below, `async/await` keywords are used, but the functions can also be used with `.then/.catch` promise blocks:
+
+```ts
+getPassword("TestService", "AccountA")
+.then((pw) => {
+    console.log("The password for TestService/AccountA is:", pw);
+})
+.catch((err) => {
+    console.error("An error occurred!", err.message);
+});
+```
+
+**Examples:**
+
+```ts
+// Set a password with a given service and account name
+// Password will be stored under <service>/<account>
+await keyring.setPassword("TestService", "AccountA", "Apassword");
+
+// Get a password, given a service and account name
+await keyring.getPassword("TestService", "AccountA");
+
+// Find credentials based on a matching label
+await keyring.findCredentials("TestService");
+
+// Find password that matches a service and account
+await keyring.findPassword("TestService/AccountA");
+
+// Delete a credential w/ the provided service and account name
+await keyring.deletePassword("TestService", "AccountA");
+```

--- a/packages/secrets/src/keyring/EXTENDERS.md
+++ b/packages/secrets/src/keyring/EXTENDERS.md
@@ -2,11 +2,11 @@
 
 ## What is `keyring`?
 
-`keyring` is a cross-platform module meant to interact with OS (operating system) credential storage. `keyring` is written in Rust, and uses other Rust libraries to interface with credential storage APIs (application programming interfaces). It was designed to be a drop-in replacement for `node-keytar`, a Microsoft (formerly GitHub under "Atom") project that was archived on December 15th, 2022. For context, `node-keytar` has widespread use in multiple projects with over 500k weekly downloads - this library was created to avoid long-term conflicts/vulnerabilities that may arise with `node-keytar` now that it is no longer maintained.
+`keyring` is a cross-platform module meant to interact with OS (operating system) credential storage. `keyring` is written in Rust, and uses other Rust libraries to interface with credential storage APIs (application programming interfaces).
 
 ## Why switch to `keyring`?
 
-By continuing to use `node-keytar`, it opens up the user to future problems with the library itself or its dependencies. Until Microsoft provides an update to the status of `keytar` on NPM, it is unknown whether the package will continue to be supported. As a result, there was a demand for a replacement that can function identically to the original module.
+As `node-keytar` is now unmaintained, there was a demand for a replacement that can function identically to the original module.
 
 As `keyring` was modeled after `node-keytar`, the same operations can be performed in credential storage:
 
@@ -16,7 +16,7 @@ As `keyring` was modeled after `node-keytar`, the same operations can be perform
 - Searching for matching credentials based on a prefix/query
 - Deleting credentials
 
-**Currently, there are no breaking changes** between the use of `node-keytar` and `keyring`. This is intended by design, and the library will be maintained with that principle in mind. As a result, `keyring` is a substitute for the original `node-keytar` module.
+**Currently, there are no breaking changes** between the use of `node-keytar` and `keyring`. This is intended by design.
 
 From a developer's perspective, one can simply update existing extenders or plug-ins to import the keyring module from `@zowe/secrets-for-zowe-sdk` instead of `node-keytar`, allowing for a straightforward transition. All functions previously exported in `node-keytar` will be available in `keyring`. Simply add `@zowe/secrets-for-zowe-sdk` to your project using `npm` or `yarn`.
 


### PR DESCRIPTION
**What It Does**

This PR adds a README to the Secrets SDK explaining its purpose and examples of using the `keyring` module.
It also clarifies what developers need to do to switch from `node-keytar`.

**Review Checklist**
I certify that I have:
- [x] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)
