### PR TITLE
chore: bump Secrets SDK from 7.18.0 -> 7.18.1

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -23099,7 +23099,7 @@
         "node": ">=14.0.0"
       },
       "optionalDependencies": {
-        "@zowe/secrets-for-zowe-sdk": "7.18.0"
+        "@zowe/secrets-for-zowe-sdk": "7.18.1"
       }
     },
     "packages/cli/node_modules/brace-expansion": {
@@ -23170,7 +23170,7 @@
     },
     "packages/secrets": {
       "name": "@zowe/secrets-for-zowe-sdk",
-      "version": "7.18.0",
+      "version": "7.18.1",
       "hasInstallScript": true,
       "license": "EPL-2.0",
       "devDependencies": {
@@ -29664,7 +29664,7 @@
         "@zowe/imperative": "5.18.0",
         "@zowe/perf-timing": "1.0.7",
         "@zowe/provisioning-for-zowe-sdk": "7.18.0",
-        "@zowe/secrets-for-zowe-sdk": "7.18.0",
+        "@zowe/secrets-for-zowe-sdk": "7.18.1",
         "@zowe/zos-console-for-zowe-sdk": "7.18.0",
         "@zowe/zos-files-for-zowe-sdk": "7.18.0",
         "@zowe/zos-jobs-for-zowe-sdk": "7.18.0",
@@ -29689,6 +29689,11 @@
         "which": "^2.0.2"
       },
       "dependencies": {
+        "@zowe/secrets-for-zowe-sdk": {
+          "version": "https://zowe.jfrog.io/zowe/api/npm/npm-local-release/@zowe/secrets-for-zowe-sdk/-/@zowe/secrets-for-zowe-sdk-7.18.0.tgz",
+          "integrity": "sha512-QyZQh45pZEj9PWkqaTfMFIFDiHpMI4aCaZSbsbhanz54h/kN1s6nT4ri43EjQ3J3aUsG2wEjKkotjBZdGg3cHw==",
+          "optional": true
+        },
         "brace-expansion": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -93,7 +93,7 @@
     "which": "^2.0.2"
   },
   "optionalDependencies": {
-    "@zowe/secrets-for-zowe-sdk": "7.18.0"
+    "@zowe/secrets-for-zowe-sdk": "7.18.1"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/packages/secrets/package.json
+++ b/packages/secrets/package.json
@@ -3,7 +3,7 @@
   "description": "Credential management facilities for Imperative, Zowe CLI, and extenders.",
   "repository": "https://github.com/zowe/zowe-cli.git",
   "author": "Zowe",
-  "version": "7.18.0",
+  "version": "7.18.1",
   "homepage": "https://github.com/zowe/zowe-cli/tree/master/packages/secrets#readme",
   "bugs": {
     "url": "https://github.com/zowe/zowe-cli/issues"


### PR DESCRIPTION
This PR bumps the Secrets SDK from 7.18.0 to 7.18.1. It only includes changes to documentation as well as the new EXTENDERS.md doc in the keyring folder.
