### PR TITLE
pkg(secrets): Add bundler instructions to EXTENDERS.md; fix README link; resolve pkg root for `prebuilds`

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -23173,6 +23173,9 @@
       "version": "7.18.1",
       "hasInstallScript": true,
       "license": "EPL-2.0",
+      "dependencies": {
+        "pkg-dir": "^5.0.0"
+      },
       "devDependencies": {
         "@napi-rs/cli": "^2.16.2",
         "@types/node": "^14.18.28",
@@ -23181,6 +23184,17 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "packages/secrets/node_modules/pkg-dir": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-5.0.0.tgz",
+      "integrity": "sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA==",
+      "dependencies": {
+        "find-up": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "packages/workflows": {
@@ -29689,11 +29703,6 @@
         "which": "^2.0.2"
       },
       "dependencies": {
-        "@zowe/secrets-for-zowe-sdk": {
-          "version": "https://zowe.jfrog.io/zowe/api/npm/npm-local-release/@zowe/secrets-for-zowe-sdk/-/@zowe/secrets-for-zowe-sdk-7.18.0.tgz",
-          "integrity": "sha512-QyZQh45pZEj9PWkqaTfMFIFDiHpMI4aCaZSbsbhanz54h/kN1s6nT4ri43EjQ3J3aUsG2wEjKkotjBZdGg3cHw==",
-          "optional": true
-        },
         "brace-expansion": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
@@ -29986,7 +29995,18 @@
         "@napi-rs/cli": "^2.16.2",
         "@types/node": "^14.18.28",
         "ava": "^4.3.3",
+        "pkg-dir": "^5.0.0",
         "typescript": "^4.0.0"
+      },
+      "dependencies": {
+        "pkg-dir": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-5.0.0.tgz",
+          "integrity": "sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA==",
+          "requires": {
+            "find-up": "^5.0.0"
+          }
+        }
       }
     },
     "@zowe/zos-console-for-zowe-sdk": {

--- a/packages/secrets/README.md
+++ b/packages/secrets/README.md
@@ -46,4 +46,4 @@ const wasDeleted = await keyring.deletePassword("ServiceName", "AccountName");
 // wasDeleted should be true; ServiceName/AccountName removed from credential vault
 ```
 
-For more detailed information, see [src/keyring/EXTENDERS.md](src/keyring/EXTENDERS.md).
+For more detailed information, see [src/keyring/EXTENDERS.md](/packages/secrets/src/keyring/EXTENDERS.md).

--- a/packages/secrets/package.json
+++ b/packages/secrets/package.json
@@ -45,5 +45,8 @@
     "rebuild": "npx --yes --package=@napi-rs/cli@2.16.2 -- napi build --config src/keyring/napi.json --cargo-cwd src/keyring --platform --release --js=false src/keyring",
     "test": "ava",
     "version": "napi version"
+  },
+  "dependencies": {
+    "pkg-dir": "^5.0.0"
   }
 }

--- a/packages/secrets/src/keyring/EXTENDERS.md
+++ b/packages/secrets/src/keyring/EXTENDERS.md
@@ -64,8 +64,18 @@ await keyring.deletePassword("TestService", "AccountA");
 ## Webpacking/bundling alongside your project
 
 Some projects leverage a JavaScript bundler, such as Webpack or Vite, to minify and compress their Node.js packages.
-While the Secrets SDK does support Webpack, developers who want to bundle the Secrets SDK alongside their package should set up
-a `prebuilds` folder in the same directory as their extension's build output.
+While the Secrets SDK does support Webpack, developers who want to bundle the Secrets SDK alongside their package should set up a `prebuilds` folder alongside the same directory as their extension's build folder.
+
+For example, if your extension build output is placed in the "out" folder, your directory structure should look like this:
+
+```
+your-extension/
+├── src
+├── out
+│   └── bundledExtension.js
+└── prebuilds
+    └── (node binaries for Secrets SDK)
+```
 
 This can be accomplished by executing a Node.js script that creates a symbolic link between the Secrets SDK and the aforementioned `prebuilds` folder. Run this script in the same directory as your extension's build folder, or update the script according to your extension path:
 

--- a/packages/secrets/src/keyring/index.js
+++ b/packages/secrets/src/keyring/index.js
@@ -8,8 +8,8 @@
 * Copyright Contributors to the Zowe Project.
 *
 */
-
 const { join } = require("path");
+const { sync: pkgDirSync } = require("pkg-dir");
 
 function getTargetName() {
     switch (process.platform) {
@@ -33,7 +33,7 @@ function getTargetName() {
 
 const requireFn = typeof __webpack_require__ === "function" ? __non_webpack_require__ : require;
 const binaryPath = requireFn.resolve(`./keyring.${getTargetName()}.node`, {
-    paths: [__dirname, join(__dirname, "..", "..", "prebuilds")],
+    paths: [__dirname, join(pkgDirSync(), "prebuilds")],
 });
 const {
     deletePassword,


### PR DESCRIPTION
**What It Does**

This PR adds the following:
- feat: The Secrets SDK package now leverages `pkg-dir` v5 to resolve the `prebuilds/` folder
  - If compiling from source, `pkg-dir` will use the root of the Secrets SDK: `packages/secrets/prebuilds`
  - If a developer is bundling an extension or Node.js package, `pkg-dir` will resolve to the root of the extension folder: `/path/to/some/package_root/prebuilds`
- fix: link in `README.md` worked locally and in GitHub, but not from NPM's website
- doc: Enhanced `EXTENDERS.md` to include steps on how to bundle the Secrets SDK alongside a webpacked extension/package

Unfortunately, I have to use `pkg-dir` v5, as versions 6 and above are ESM-only, which could be a breaking change for others importing the Secrets SDK package.

**How to Test**

To test `pkg-dir`, run the `prepublishOnly` script after building the Secrets SDK, and then run the test stage:
- `npm install` (to fetch new dependency)
- `npm run prepublishOnly && npm run build && npm run test`  

The Secrets SDK will use the `prebuilds` folder in the root of the Secrets SDK package to load the Node-native binary.

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
