### PR TITLE
Fixed Incorrect Section Links for README Navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,12 @@ This repository also contains the Zowe Node Client SDK. The SDK lets you leverag
 ## **Contents**  <!-- omit in toc -->
  - [Documentation](#documentation)
  - [Contribution Guidelines](#contribution-guidelines)
- - [Building Zowe CLI From Source](#build-zowe-cli-from-source)
- - [Installing Zowe CLI From Source](#install-zowe-cli-from-source)
- - [Uninstalling Zowe CLI](#uninstall-zowe-cli)
- - [Configuring Zowe CLI](#configure-zowe-cli)
+ - [Building Zowe CLI From Source](#building-zowe-cli-from-source)
+ - [Installing Zowe CLI From Source](#installing-zowe-cli-from-source)
+ - [Uninstalling Zowe CLI](#uninstalling-zowe-cli)
+ - [Configuring Zowe CLI](#configuring-zowe-cli)
  - [Zowe Node Client SDK](#zowe-node-client-sdk)
- - [Running System Tests](#run-system-tests)
+ - [Running System Tests](#running-system-tests)
  - [FAQs](#frequently-asked-questions)
 
 <br/>


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->
Issue #1784 
The non-functional section links were reviewed and corrected. As a result of these corrections, users can now click on the links and be accurately directed to the intended sections within the README

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
Signed off - Sidharth Bhardwaj
sidharthbh8@gmail.com