### PR TITLE
Fix minor code smell

### DIFF
--- a/packages/cli/__tests__/config/auto-init/__unit__/ApimlAutoInitHandler.unit.test.ts
+++ b/packages/cli/__tests__/config/auto-init/__unit__/ApimlAutoInitHandler.unit.test.ts
@@ -10,13 +10,14 @@
 */
 
 import ApimlAutoInitHandler from "../../../../src/config/auto-init/ApimlAutoInitHandler";
-import { SessConstants, RestClientError, IRestClientError, ImperativeConfig, IConfig, ConfigUtils } from "@zowe/imperative";
+import { SessConstants, RestClientError, IRestClientError, ImperativeConfig, IConfig, ConfigUtils, Config } from "@zowe/imperative";
 import { ZosmfSession } from "@zowe/zosmf-for-zowe-sdk";
 import { IApimlProfileInfo, IProfileRpt, Login, Services } from "@zowe/core-for-zowe-sdk";
 import * as lodash from "lodash";
 import stripAnsi = require("strip-ansi");
 
 function mockConfigApi(properties: IConfig | undefined): any {
+    properties = properties || Config.empty();
     return {
         api: {
             layers: {

--- a/packages/cli/src/config/auto-init/ApimlAutoInitHandler.ts
+++ b/packages/cli/src/config/auto-init/ApimlAutoInitHandler.ts
@@ -105,7 +105,7 @@ export default class ApimlAutoInitHandler extends BaseAutoInitHandler {
 
         const config = ImperativeConfig.instance.config;
         // Check to see if there is an active base profile to avoid creating a new one named "base"
-        let activeBaseProfile = params.arguments[`${this.mProfileType}-profile`] || config?.properties?.defaults?.[this.mProfileType];
+        let activeBaseProfile = params.arguments[`${this.mProfileType}-profile`] || config.properties.defaults[this.mProfileType];
         let baseProfileCreated = false;
         // Populate the config with base profile information
         if (activeBaseProfile == null) {


### PR DESCRIPTION
Fixes an issue flagged by Coverity - "accessing a property of null-like value `config`" on `ApimlAutoInitHandler.ts` line 138.