### PR TITLE
feat(secrets): Bundle static CRT for Windows builds

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the Zowe CLI package will be documented in this file.
 
 ## Recent Changes
 
-- BugFix: Bump Secrets SDK to `7.18.2` - uses more reliable resolution logic for `prebuilds` folder.
+- Enhancement: Bump Secrets SDK to `7.18.3` - uses more reliable resolution logic for `prebuilds` folder; adds static CRT for Windows builds.
 
 ## `7.18.0`
 

--- a/packages/secrets/CHANGELOG.md
+++ b/packages/secrets/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to the Zowe Secrets SDK package will be documented in this f
 
 ## `7.18.3`
 
-- BugFix: Separated module resolution logic during installation; added more error handling to provide a more graceful installation process.
+- Enhancement: Separated module resolution logic during installation; added more error handling to provide a more graceful installation process.
+- Enhancement: Add static CRT when compiling Windows builds.
 
 ## `7.18.2`
 

--- a/packages/secrets/src/keyring/.cargo/config.toml
+++ b/packages/secrets/src/keyring/.cargo/config.toml
@@ -1,0 +1,5 @@
+[target.i686-pc-windows-msvc]
+rustflags = ["-Ctarget-feature=+crt-static"]
+
+[target.x86_64-pc-windows-msvc]
+rustflags = ["-Ctarget-feature=+crt-static"]

--- a/packages/secrets/src/keyring/.cargo/config.toml
+++ b/packages/secrets/src/keyring/.cargo/config.toml
@@ -1,5 +1,2 @@
-[target.i686-pc-windows-msvc]
-rustflags = ["-Ctarget-feature=+crt-static"]
-
-[target.x86_64-pc-windows-msvc]
+[target.'cfg(all(windows, target_env = "msvc"))']
 rustflags = ["-Ctarget-feature=+crt-static"]


### PR DESCRIPTION
**What It Does**

This PR adds a Rust flag so that users can run the Secrets SDK on Windows without needing the MSVC redistributables.

**How to Test**

Try running Zowe CLI in Windows Sandbox or an environment without the MSVC redistributables. It should still be able to store/retrieve secure credentials.

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [ ] added/updated automated tests
- [x] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)
