### PR TITLE
chore(cli): Bump Secrets SDK from 7.18.2 -> 7.18.3

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -23099,7 +23099,17 @@
         "node": ">=14.0.0"
       },
       "optionalDependencies": {
-        "@zowe/secrets-for-zowe-sdk": "7.18.2"
+        "@zowe/secrets-for-zowe-sdk": "7.18.3"
+      }
+    },
+    "packages/cli/node_modules/@zowe/secrets-for-zowe-sdk": {
+      "version": "7.18.3",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-local-release/@zowe/secrets-for-zowe-sdk/-/@zowe/secrets-for-zowe-sdk-7.18.3.tgz",
+      "integrity": "sha512-3/TyFgpZimOUreDLQSlRfZK+GAgRr4zl31YvPD1wOB95wIgcX7dDONmsMuf/Z721eJOkVMuae7W4Ke92oyJECQ==",
+      "hasInstallScript": true,
+      "optional": true,
+      "engines": {
+        "node": ">= 14"
       }
     },
     "packages/cli/node_modules/brace-expansion": {
@@ -29664,7 +29674,7 @@
         "@zowe/imperative": "5.18.1",
         "@zowe/perf-timing": "1.0.7",
         "@zowe/provisioning-for-zowe-sdk": "7.18.2",
-        "@zowe/secrets-for-zowe-sdk": "7.18.2",
+        "@zowe/secrets-for-zowe-sdk": "7.18.3",
         "@zowe/zos-console-for-zowe-sdk": "7.18.2",
         "@zowe/zos-files-for-zowe-sdk": "7.18.2",
         "@zowe/zos-jobs-for-zowe-sdk": "7.18.2",
@@ -29689,6 +29699,12 @@
         "which": "^2.0.2"
       },
       "dependencies": {
+        "@zowe/secrets-for-zowe-sdk": {
+          "version": "7.18.3",
+          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-local-release/@zowe/secrets-for-zowe-sdk/-/@zowe/secrets-for-zowe-sdk-7.18.3.tgz",
+          "integrity": "sha512-3/TyFgpZimOUreDLQSlRfZK+GAgRr4zl31YvPD1wOB95wIgcX7dDONmsMuf/Z721eJOkVMuae7W4Ke92oyJECQ==",
+          "optional": true
+        },
         "brace-expansion": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to the Zowe CLI package will be documented in this file.
 
-## `7.18.1`
+## Recent Changes
 
 - Enhancement: Bump Secrets SDK to `7.18.3` - uses more reliable resolution logic for `prebuilds` folder; adds static CRT for Windows builds.
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -93,7 +93,7 @@
     "which": "^2.0.2"
   },
   "optionalDependencies": {
-    "@zowe/secrets-for-zowe-sdk": "7.18.2"
+    "@zowe/secrets-for-zowe-sdk": "7.18.3"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/packages/secrets/CHANGELOG.md
+++ b/packages/secrets/CHANGELOG.md
@@ -2,14 +2,11 @@
 
 All notable changes to the Zowe Secrets SDK package will be documented in this file.
 
-## `7.18.2`
-
-- Added OVERVIEW document to package: provides context on the Secrets SDK transition and how it affects Zowe CLI and Zowe Explorer.
-
 ## `7.18.3`
 
 - Enhancement: Separated module resolution logic during installation; added more error handling to provide a more graceful installation process.
 - Enhancement: Add static CRT when compiling Windows builds.
+- Added OVERVIEW document to package: provides context on the Secrets SDK transition and how it affects Zowe CLI and Zowe Explorer.
 
 ## `7.18.2`
 


### PR DESCRIPTION
**What It Does**

This PR bumps the Secrets SDK from version 7.18.2 to 7.18.3 to address some bug fixes:

- Separated module resolution logic during installation; added more error handling to provide a more graceful installation process.
- Add static CRT when compiling Windows builds.

This was to be released with CLI 7.18.1, but an issue occurred in the publishing process that rolled back the Secrets SDK.

**Review Checklist**
I certify that I have:
- [x] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)
