### PR TITLE
ci(secrets): Fix CI workflow to use prebuilds from current branch

### DIFF
--- a/.github/workflows/secrets-sdk-publish.yml
+++ b/.github/workflows/secrets-sdk-publish.yml
@@ -36,3 +36,4 @@ jobs:
         NPM_EMAIL: ${{ secrets.ZOWE_ROBOT_EMAIL }}
         NPM_REGISTRY: "https://zowe.jfrog.io/zowe/api/npm/npm-local-release"
         NPM_SCOPE: "@zowe"
+        SECRETS_BRANCH: ${{ github.ref_name }}

--- a/lerna.json
+++ b/lerna.json
@@ -6,6 +6,9 @@
         "packages/**/__tests__/**"
       ],
       "registry": "https://zowe.jfrog.io/zowe/api/npm/npm-local-release/"
+    },
+    "version": {
+      "private": false
     }
   },
   "useWorkspaces": true

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -23099,17 +23099,7 @@
         "node": ">=14.0.0"
       },
       "optionalDependencies": {
-        "@zowe/secrets-for-zowe-sdk": "7.18.3"
-      }
-    },
-    "packages/cli/node_modules/@zowe/secrets-for-zowe-sdk": {
-      "version": "7.18.3",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-local-release/@zowe/secrets-for-zowe-sdk/-/@zowe/secrets-for-zowe-sdk-7.18.3.tgz",
-      "integrity": "sha512-3/TyFgpZimOUreDLQSlRfZK+GAgRr4zl31YvPD1wOB95wIgcX7dDONmsMuf/Z721eJOkVMuae7W4Ke92oyJECQ==",
-      "hasInstallScript": true,
-      "optional": true,
-      "engines": {
-        "node": ">= 14"
+        "@zowe/secrets-for-zowe-sdk": "7.18.4"
       }
     },
     "packages/cli/node_modules/brace-expansion": {
@@ -23180,7 +23170,7 @@
     },
     "packages/secrets": {
       "name": "@zowe/secrets-for-zowe-sdk",
-      "version": "7.18.3",
+      "version": "7.18.4",
       "hasInstallScript": true,
       "license": "EPL-2.0",
       "devDependencies": {
@@ -29674,7 +29664,7 @@
         "@zowe/imperative": "5.18.1",
         "@zowe/perf-timing": "1.0.7",
         "@zowe/provisioning-for-zowe-sdk": "7.18.2",
-        "@zowe/secrets-for-zowe-sdk": "7.18.3",
+        "@zowe/secrets-for-zowe-sdk": "7.18.4",
         "@zowe/zos-console-for-zowe-sdk": "7.18.2",
         "@zowe/zos-files-for-zowe-sdk": "7.18.2",
         "@zowe/zos-jobs-for-zowe-sdk": "7.18.2",
@@ -29699,12 +29689,6 @@
         "which": "^2.0.2"
       },
       "dependencies": {
-        "@zowe/secrets-for-zowe-sdk": {
-          "version": "7.18.3",
-          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-local-release/@zowe/secrets-for-zowe-sdk/-/@zowe/secrets-for-zowe-sdk-7.18.3.tgz",
-          "integrity": "sha512-3/TyFgpZimOUreDLQSlRfZK+GAgRr4zl31YvPD1wOB95wIgcX7dDONmsMuf/Z721eJOkVMuae7W4Ke92oyJECQ==",
-          "optional": true
-        },
         "brace-expansion": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -93,7 +93,7 @@
     "which": "^2.0.2"
   },
   "optionalDependencies": {
-    "@zowe/secrets-for-zowe-sdk": "7.18.3"
+    "@zowe/secrets-for-zowe-sdk": "7.18.4"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/packages/secrets/package.json
+++ b/packages/secrets/package.json
@@ -15,6 +15,7 @@
     "lib",
     "prebuilds/*.node",
     "src/keyring",
+    "src/keyring/.cargo",
     "index.d.ts",
     "index.js",
     "scripts/*.js"

--- a/packages/secrets/package.json
+++ b/packages/secrets/package.json
@@ -3,7 +3,7 @@
   "description": "Credential management facilities for Imperative, Zowe CLI, and extenders.",
   "repository": "https://github.com/zowe/zowe-cli.git",
   "author": "Zowe",
-  "version": "7.18.4-next.1",
+  "version": "7.18.4",
   "homepage": "https://github.com/zowe/zowe-cli/tree/master/packages/secrets#readme",
   "bugs": {
     "url": "https://github.com/zowe/zowe-cli/issues"

--- a/packages/secrets/package.json
+++ b/packages/secrets/package.json
@@ -3,7 +3,7 @@
   "description": "Credential management facilities for Imperative, Zowe CLI, and extenders.",
   "repository": "https://github.com/zowe/zowe-cli.git",
   "author": "Zowe",
-  "version": "7.18.3",
+  "version": "7.18.4",
   "homepage": "https://github.com/zowe/zowe-cli/tree/master/packages/secrets#readme",
   "bugs": {
     "url": "https://github.com/zowe/zowe-cli/issues"

--- a/packages/secrets/package.json
+++ b/packages/secrets/package.json
@@ -3,7 +3,7 @@
   "description": "Credential management facilities for Imperative, Zowe CLI, and extenders.",
   "repository": "https://github.com/zowe/zowe-cli.git",
   "author": "Zowe",
-  "version": "7.18.4",
+  "version": "7.18.4-next.1",
   "homepage": "https://github.com/zowe/zowe-cli/tree/master/packages/secrets#readme",
   "bugs": {
     "url": "https://github.com/zowe/zowe-cli/issues"

--- a/packages/secrets/scripts/prebuildify.sh
+++ b/packages/secrets/scripts/prebuildify.sh
@@ -2,7 +2,7 @@
 set -ex
 rm -rf prebuilds && mkdir -p prebuilds
 SECRETS_BRANCH="${SECRETS_BRANCH:-master}"
-SECRETS_WORKFLOW_ID=$("gh run list -b $SECRETS_BRANCH --limit 1 --status success --workflow 'Secrets SDK Publish' --json databaseId --jq "".[0].databaseId""")
+SECRETS_WORKFLOW_ID=$(gh run list -b $SECRETS_BRANCH --limit 1 --status success --workflow "Secrets SDK Publish" --json databaseId --jq ".[0].databaseId")
 echo "Downloading Secrets SDK prebuilds from $SECRETS_BRANCH branch..."
 gh run download $SECRETS_WORKFLOW_ID --dir prebuilds --pattern "bindings-*"
 mv prebuilds/*/* prebuilds && rm -r prebuilds/*/

--- a/packages/secrets/scripts/prebuildify.sh
+++ b/packages/secrets/scripts/prebuildify.sh
@@ -2,7 +2,7 @@
 set -ex
 rm -rf prebuilds && mkdir -p prebuilds
 SECRETS_BRANCH="${SECRETS_BRANCH:-master}"
-SECRETS_WORKFLOW_ID=$(gh run list -b $SECRETS_BRANCH --limit 1 --status success --workflow "Secrets SDK Publish" --json databaseId --jq ".[0].databaseId")
+SECRETS_WORKFLOW_ID=$(gh run list -b $SECRETS_BRANCH --limit 1 --status success --workflow "Secrets SDK CI" --json databaseId --jq ".[0].databaseId")
 echo "Downloading Secrets SDK prebuilds from $SECRETS_BRANCH branch..."
 gh run download $SECRETS_WORKFLOW_ID --dir prebuilds --pattern "bindings-*"
 mv prebuilds/*/* prebuilds && rm -r prebuilds/*/

--- a/packages/secrets/scripts/prebuildify.sh
+++ b/packages/secrets/scripts/prebuildify.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 set -ex
 rm -rf prebuilds && mkdir -p prebuilds
-gh run download --dir prebuilds --pattern "bindings-*"
+SECRETS_BRANCH="${SECRETS_BRANCH:-master}"
+SECRETS_WORKFLOW_ID=$("gh run list -b $SECRETS_BRANCH --limit 1 --status success --workflow 'Secrets SDK Publish' --json databaseId --jq "".[0].databaseId""")
+echo "Downloading Secrets SDK prebuilds from $SECRETS_BRANCH branch..."
+gh run download $SECRETS_WORKFLOW_ID --dir prebuilds --pattern "bindings-*"
 mv prebuilds/*/* prebuilds && rm -r prebuilds/*/


### PR DESCRIPTION
**What It Does**

The CI workflow was previously grabbing the latest prebuilds from the master branch. This PR changes this behavior so it will use the current branch that the publish workflow is running on.

This PR also prevents lerna from auto-versioning the Secrets SDK, as it is versioned and published separately.
