### PR TITLE
chore: Update CHANGELOG versions for CLI and Secrets SDK

### DIFF
--- a/.github/workflows/zowe-cli.yml
+++ b/.github/workflows/zowe-cli.yml
@@ -78,7 +78,7 @@ jobs:
 
     - name: Use Original NPM Version
       id: original-npm-version
-      run: npm install -g npm@${{ steps.npm-version.outputs.number }}
+      run: npm install -g npm@${{ steps.npm-version.outputs.number || '9' }}
 
     - name: Install Rust toolchain
       id: install-rust

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the Zowe CLI package will be documented in this file.
 
 ## `7.18.4`
 
-- Enhancement: Bump Secrets SDK to `7.18.4` - uses more reliable resolution logic for `prebuilds` folder; adds static CRT for Windows builds.
+- BugFix: Bump Secrets SDK to `7.18.4` - uses more reliable resolution logic for `prebuilds` folder; adds static CRT for Windows builds.
 
 ## `7.18.0`
 

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 All notable changes to the Zowe CLI package will be documented in this file.
 
-## `7.18.3`
+## `7.18.4`
 
-- Enhancement: Bump Secrets SDK to `7.18.3` - uses more reliable resolution logic for `prebuilds` folder; adds static CRT for Windows builds.
+- Enhancement: Bump Secrets SDK to `7.18.4` - uses more reliable resolution logic for `prebuilds` folder; adds static CRT for Windows builds.
 
 ## `7.18.0`
 

--- a/packages/secrets/CHANGELOG.md
+++ b/packages/secrets/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to the Zowe Secrets SDK package will be documented in this file.
 
-## `7.18.3`
+## `7.18.4`
 
 - Enhancement: Separated module resolution logic during installation; added more error handling to provide a more graceful installation process.
 - Enhancement: Add static CRT when compiling Windows builds.

--- a/packages/secrets/CHANGELOG.md
+++ b/packages/secrets/CHANGELOG.md
@@ -4,8 +4,8 @@ All notable changes to the Zowe Secrets SDK package will be documented in this f
 
 ## `7.18.4`
 
-- Enhancement: Separated module resolution logic during installation; added more error handling to provide a more graceful installation process.
-- Enhancement: Add static CRT when compiling Windows builds.
+- BugFix: Separated module resolution logic during installation; added more error handling to provide a more graceful installation process.
+- BugFix: Add static CRT when compiling Windows builds.
 - Added OVERVIEW document to package: provides context on the Secrets SDK transition and how it affects Zowe CLI and Zowe Explorer.
 
 ## `7.18.2`

--- a/packages/secrets/src/keyring/Cargo.toml
+++ b/packages/secrets/src/keyring/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 edition = "2021"
 name = "keyring"
-version = "0.0.0"
+version = "1.0.0"
+authors = ["Zowe Project"]
+license = "EPL-2.0"
+repository = "https://github.com/zowe/zowe-cli"
 
 [lib]
 crate-type = ["cdylib"]


### PR DESCRIPTION
**What It Does**

This PR fixes the versions for the changelog in both Zowe CLI and the Secrets SDK.
It also:

- adds a version number (1.0.0) and license to `keyring/Cargo.toml`.
- adds a fallback to `npm@9` in case it cannot find a version and tries to use `npm@10`, which is suffering from a `EBADENGINE` error on Windows.