### PR TITLE
Add freebsd as target for Library error

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -23099,7 +23099,7 @@
         "node": ">=14.0.0"
       },
       "optionalDependencies": {
-        "@zowe/secrets-for-zowe-sdk": "7.18.4"
+        "@zowe/secrets-for-zowe-sdk": "7.18.5"
       }
     },
     "packages/cli/node_modules/brace-expansion": {
@@ -23170,7 +23170,7 @@
     },
     "packages/secrets": {
       "name": "@zowe/secrets-for-zowe-sdk",
-      "version": "7.18.4",
+      "version": "7.18.5",
       "hasInstallScript": true,
       "license": "EPL-2.0",
       "devDependencies": {
@@ -29664,7 +29664,7 @@
         "@zowe/imperative": "5.18.1",
         "@zowe/perf-timing": "1.0.7",
         "@zowe/provisioning-for-zowe-sdk": "7.18.2",
-        "@zowe/secrets-for-zowe-sdk": "7.18.4",
+        "@zowe/secrets-for-zowe-sdk": "7.18.5",
         "@zowe/zos-console-for-zowe-sdk": "7.18.2",
         "@zowe/zos-files-for-zowe-sdk": "7.18.2",
         "@zowe/zos-jobs-for-zowe-sdk": "7.18.2",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Zowe CLI package will be documented in this file.
 
+## Recent Changes
+
+- BugFix: Bump Secrets SDK to `7.18.5` to resolve build failures for FreeBSD users.
+
 ## `7.18.4`
 
 - BugFix: Bump Secrets SDK to `7.18.4` - uses more reliable resolution logic for `prebuilds` folder; adds static CRT for Windows builds.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -93,7 +93,7 @@
     "which": "^2.0.2"
   },
   "optionalDependencies": {
-    "@zowe/secrets-for-zowe-sdk": "7.18.4"
+    "@zowe/secrets-for-zowe-sdk": "7.18.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/packages/secrets/CHANGELOG.md
+++ b/packages/secrets/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Zowe Secrets SDK package will be documented in this file.
 
+## `7.18.5`
+
+- BugFix: Enable `KeyringError::Library` enum variant to fix building on FreeBSD targets.
+
 ## `7.18.4`
 
 - BugFix: Separated module resolution logic during installation; added more error handling to provide a more graceful installation process.

--- a/packages/secrets/package.json
+++ b/packages/secrets/package.json
@@ -3,7 +3,7 @@
   "description": "Credential management facilities for Imperative, Zowe CLI, and extenders.",
   "repository": "https://github.com/zowe/zowe-cli.git",
   "author": "Zowe",
-  "version": "7.18.4",
+  "version": "7.18.5",
   "homepage": "https://github.com/zowe/zowe-cli/tree/master/packages/secrets#readme",
   "bugs": {
     "url": "https://github.com/zowe/zowe-cli/issues"

--- a/packages/secrets/src/keyring/Cargo.lock
+++ b/packages/secrets/src/keyring/Cargo.lock
@@ -271,7 +271,7 @@ dependencies = [
 
 [[package]]
 name = "keyring"
-version = "0.0.0"
+version = "1.0.0"
 dependencies = [
  "cfg-if",
  "gio",

--- a/packages/secrets/src/keyring/src/os/error.rs
+++ b/packages/secrets/src/keyring/src/os/error.rs
@@ -7,7 +7,7 @@ pub enum KeyringError {
     #[error("[keyring] Invalid parameter provided for '{argument:?}'. Details:\n\n{details:?}")]
     InvalidArg { argument: String, details: String },
 
-    #[cfg(any(target_os = "macos", target_os = "linux"))]
+    #[cfg(any(target_os = "macos", target_os = "linux", target_os = "freebsd"))]
     #[error("[keyring] {name:?} library returned an error:\n\n{details:?}")]
     Library { name: String, details: String },
 


### PR DESCRIPTION
**What It Does**
Resolves https://github.com/zowe/zowe-cli/issues/1806

**How to Test**
Attempt to build the Secrets SDK under FreeBSD.

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [ ] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
