### PR TITLE
Implement fix for #1722

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Zowe CLI package will be documented in this file.
 
+## Recent Changes
+
+- BugFix: Fix behavior where a specified directory was being lowercased on non-PDS datasets when downloading all datasets [#1722](https://github.com/zowe/zowe-cli/issues/1722)
+
 ## `7.18.8`
 
 - BugFix: Fix bug where encoding is not passed to the Download USS Directory API [#1825](https://github.com/zowe/zowe-cli/issues/1825)

--- a/packages/zosfiles/CHANGELOG.md
+++ b/packages/zosfiles/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Zowe z/OS files SDK package will be documented in this file.
 
+## Recent Changes
+
+- BugFix: Fix behavior where a specified directory was being lowercased on non-PDS datasets when downloading all datasets [#1722](https://github.com/zowe/zowe-cli/issues/1722)
+
 ## `7.18.8`
 - Enhancement: Patch that adds invalidFileName to ZosFilesMessages
 

--- a/packages/zosfiles/src/methods/download/Download.ts
+++ b/packages/zosfiles/src/methods/download/Download.ts
@@ -372,11 +372,11 @@ export class Download {
                 } else if (dataSetObj.dsorg === "PO" || dataSetObj.dsorg === "PO-E") {
                     mutableOptions.directory = `${mutableOptions.directory}/${ZosFilesUtils.getDirsFromDataSet(dataSetObj.dsname)}`;
                 } else {
-                    mutableOptions.file = `${mutableOptions.directory}/${dataSetObj.dsname}.` +
-                        `${mutableOptions.extension ?? ZosFilesUtils.DEFAULT_FILE_EXTENSION}`;
+                    mutableOptions.file = `${dataSetObj.dsname}.${mutableOptions.extension ?? ZosFilesUtils.DEFAULT_FILE_EXTENSION}`;
                     if (!options.preserveOriginalLetterCase) {
                         mutableOptions.file = mutableOptions.file.toLowerCase();
                     }
+                    mutableOptions.file = `${mutableOptions.directory}/${mutableOptions.file}`;
                     mutableOptions.directory = undefined;
                     mutableOptions.extension = undefined;
                 }


### PR DESCRIPTION
**What It Does**
Implements fix for #1722 by not lowercasing the specified directory

**How to Test**
Run `zowe files download dsm` specifying a mixed case directory with the latest version of Zowe CLI on NPM and a built version of this PR.

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [x] added/updated automated tests
- [x] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
