### PR TITLE
Fix broken package.jsons from publish error - v1

### DIFF
--- a/package.json
+++ b/package.json
@@ -140,6 +140,7 @@
   },
   "jest-stare": {
     "coverageLink": "../unit/coverage/lcov-report/index.html",
+    "resultDir": "__tests__/__results__/jest-stare",
     "additionalResultsProcessors": [
       "jest-junit",
       "jest-sonar-reporter"

--- a/packages/zosjobs/package.json
+++ b/packages/zosjobs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zowe/zos-jobs-for-zowe-sdk",
-  "version": "6.40.22",
+  "version": "6.40.23",
   "description": "Zowe SDK to interact with jobs on z/OS",
   "author": "Zowe",
   "license": "EPL-2.0",

--- a/packages/zosmf/package.json
+++ b/packages/zosmf/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zowe/zosmf-for-zowe-sdk",
-  "version": "6.40.22",
+  "version": "6.40.23",
   "description": "Zowe SDK to interact with the z/OS Management Facility",
   "author": "Zowe",
   "license": "EPL-2.0",

--- a/packages/zostso/package.json
+++ b/packages/zostso/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zowe/zos-tso-for-zowe-sdk",
-  "version": "6.40.22",
+  "version": "6.40.23",
   "description": "Zowe SDK to interact with TSO on z/OS",
   "author": "Zowe",
   "license": "EPL-2.0",
@@ -45,7 +45,7 @@
     "prepack": "node ../../scripts/prepareLicenses.js"
   },
   "dependencies": {
-    "@zowe/zosmf-for-zowe-sdk": "6.40.22"
+    "@zowe/zosmf-for-zowe-sdk": "6.40.23"
   },
   "devDependencies": {
     "@types/node": "^16.11.7",


### PR DESCRIPTION
**What It Does**
An error occurred with logic in the octorelease scripts that caused versions to bump when only tests were updated. Corrects the mismatched versions in the affected package.json file

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
