### PR TITLE
Deprecate old getDataSet in v2 LTS, move to zosfiles SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,4 +208,4 @@ Don't see what you're looking for? Browse questions from the community or ask yo
 
 Zowe CLI is a component of the Zowe Open Mainframe Project, part of the Linux Foundation.
 
-To learn more about how Zowe is structured and governed, see the [Technical Steering Committee Strucutre and Governance documentation](https://github.com/zowe/community/blob/master/Technical-Steering-Committee/tsc-governance.md).
+To learn more about how Zowe is structured and governed, see the [Technical Steering Committee Structure and Governance documentation](https://github.com/zowe/community/blob/master/Technical-Steering-Committee/tsc-governance.md).

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Zowe CLI package will be documented in this file.
 
+## Recent Changes
+
+- Deprecated: `getDataSet` in the `zosfiles` command group utility functions, use `zosfiles` SDK's `ZosFilesUtils.getDataSetFromName` instead. [#1696](https://github.com/zowe/zowe-cli/issues/1696)
+
 ## `7.18.10`
 
 - BugFix: Added missing z/OSMF connection options to the z/OS Logs command group.

--- a/packages/cli/src/zosfiles/ZosFiles.utils.ts
+++ b/packages/cli/src/zosfiles/ZosFiles.utils.ts
@@ -14,6 +14,7 @@
 import { IDataSet } from "@zowe/zos-files-for-zowe-sdk";
 
 /**
+ * @deprecated - use @zowe/zos-files-for-zowe-sdk's ZosFilesUtils.getDataSetFromName instead
  * Converts the name of a data set to an IDataSet
  * @param {string} name  - the name in the form USER.DATA.SET | USER.DATA.SET(mem1)
  */

--- a/packages/cli/src/zosfiles/ZosFiles.utils.ts
+++ b/packages/cli/src/zosfiles/ZosFiles.utils.ts
@@ -11,7 +11,7 @@
 
 // We are using arguments as an expected input to the function. Thus there is no generated code
 // so we can ignore this linting error.
-import { IDataSet } from "@zowe/zos-files-for-zowe-sdk";
+import { IDataSet, ZosFilesUtils } from "@zowe/zos-files-for-zowe-sdk";
 
 /**
  * @deprecated - use @zowe/zos-files-for-zowe-sdk's ZosFilesUtils.getDataSetFromName instead
@@ -19,15 +19,5 @@ import { IDataSet } from "@zowe/zos-files-for-zowe-sdk";
  * @param {string} name  - the name in the form USER.DATA.SET | USER.DATA.SET(mem1)
  */
 export function getDataSet(name: string): IDataSet {
-    const parts = name.replace(')', '').split('(');
-    if (parts.length > 1) {
-        return {
-            dsn: parts[0],
-            member: parts[1]
-        };
-    } else {
-        return {
-            dsn: name
-        };
-    }
+    return ZosFilesUtils.getDataSetFromName(name);
 }

--- a/packages/cli/src/zosfiles/copy/ds/Ds.handler.ts
+++ b/packages/cli/src/zosfiles/copy/ds/Ds.handler.ts
@@ -10,17 +10,16 @@
 */
 
 import { AbstractSession, IHandlerParameters } from "@zowe/imperative";
-import { Copy, IZosFilesResponse, IDataSet, ICopyDatasetOptions } from "@zowe/zos-files-for-zowe-sdk";
+import { Copy, IZosFilesResponse, IDataSet, ICopyDatasetOptions, ZosFilesUtils } from "@zowe/zos-files-for-zowe-sdk";
 import { ZosFilesBaseHandler } from "../../ZosFilesBase.handler";
-import { getDataSet } from "../../ZosFiles.utils";
 
 /**
  * Handler to copy a data set.
  */
 export default class DsHandler extends ZosFilesBaseHandler {
     public async processWithSession(commandParameters: IHandlerParameters, session: AbstractSession): Promise<IZosFilesResponse> {
-        const fromDataSet: IDataSet = getDataSet(commandParameters.arguments.fromDataSetName);
-        const toDataSet: IDataSet = getDataSet(commandParameters.arguments.toDataSetName);
+        const fromDataSet: IDataSet = ZosFilesUtils.getDataSetFromName(commandParameters.arguments.fromDataSetName);
+        const toDataSet: IDataSet = ZosFilesUtils.getDataSetFromName(commandParameters.arguments.toDataSetName);
         const options: ICopyDatasetOptions = {
             "from-dataset": fromDataSet,
             enq: commandParameters.arguments.enq,

--- a/packages/cli/src/zosfiles/copy/dsclp/Dsclp.handler.ts
+++ b/packages/cli/src/zosfiles/copy/dsclp/Dsclp.handler.ts
@@ -10,9 +10,8 @@
 */
 
 import { AbstractSession, IHandlerParameters, IHandlerResponseConsoleApi, Session } from "@zowe/imperative";
-import { Copy, ICrossLparCopyDatasetOptions, IDataSet, IGetOptions, IZosFilesResponse } from "@zowe/zos-files-for-zowe-sdk";
+import { Copy, ICrossLparCopyDatasetOptions, IDataSet, IGetOptions, IZosFilesResponse, ZosFilesUtils } from "@zowe/zos-files-for-zowe-sdk";
 import { ZosFilesBaseHandler } from "../../ZosFilesBase.handler";
-import { getDataSet } from "../../ZosFiles.utils";
 
 /**
  * Handler to copy a data set.
@@ -20,8 +19,8 @@ import { getDataSet } from "../../ZosFiles.utils";
 
 export default class DsclpHandler extends ZosFilesBaseHandler {
     public async processWithSession(commandParameters: IHandlerParameters, session: AbstractSession): Promise<IZosFilesResponse> {
-        const sourceDataset: IDataSet = getDataSet(commandParameters.arguments.fromDataSetName);
-        const targetDataset: IDataSet = getDataSet(commandParameters.arguments.toDataSetName);
+        const sourceDataset: IDataSet = ZosFilesUtils.getDataSetFromName(commandParameters.arguments.fromDataSetName);
+        const targetDataset: IDataSet = ZosFilesUtils.getDataSetFromName(commandParameters.arguments.toDataSetName);
 
         const options: ICrossLparCopyDatasetOptions = {
             "from-dataset": sourceDataset,

--- a/packages/zosfiles/CHANGELOG.md
+++ b/packages/zosfiles/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the Zowe z/OS files SDK package will be documented in thi
 
 ## Recent Changes
 
-- Deprecated: Deprecated `getDataSet` from the `zosfiles` command group. Use the `zosfiles` SDK's `ZosFilesUtils.getDataSetFromName` instead [#1696](https://github.com/zowe/zowe-cli/issues/1696)
+- Enhancement: Adds `ZosFilesUtils.getDataSetFromName` to create an IDataSet from a dataset name [#1696](https://github.com/zowe/zowe-cli/issues/1696)
 
 ## `7.18.9`
 

--- a/packages/zosfiles/CHANGELOG.md
+++ b/packages/zosfiles/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Zowe z/OS files SDK package will be documented in this file.
 
+## Recent Changes
+
+- Deprecated: Deprecated `getDataSet` from the `zosfiles` command group. Use the `zosfiles` SDK's `ZosFilesUtils.getDataSetFromName` instead [#1696](https://github.com/zowe/zowe-cli/issues/1696)
+
 ## `7.18.9`
 
 - BugFix: Fix behavior where a specified directory was being lowercased on non-PDS datasets when downloading all datasets [#1722](https://github.com/zowe/zowe-cli/issues/1722)

--- a/packages/zosfiles/__tests__/__unit__/utils/ZosFilesUtils.unit.test.ts
+++ b/packages/zosfiles/__tests__/__unit__/utils/ZosFilesUtils.unit.test.ts
@@ -15,6 +15,7 @@ import { IO } from "@zowe/imperative";
 import { ZosFilesUtils } from "../../../src/utils/ZosFilesUtils";
 import { ZosFilesConstants } from "../../../src/constants/ZosFiles.constants";
 import { ZosFilesMessages } from "../../../src/constants/ZosFiles.messages";
+import { IDataSet } from "../../../src/doc/IDataSet";
 
 jest.mock("fs");
 
@@ -207,6 +208,28 @@ describe("ZosFilesUtils", () => {
             const expectResult = Buffer.from("testing\ndummy\n");
 
             expect(ZosFilesUtils.normalizeNewline(input).toString()).toBe(expectResult.toString());
+        });
+    });
+
+    describe("getDataSetFromName", () => {
+        it("should generate an IDataSet for a dataset", () => {
+            const dataSetName = "SYS1.PARMLIB";
+            const expectedResult: IDataSet = {
+                dsn: "SYS1.PARMLIB",
+                member: undefined
+            };
+
+            expect(ZosFilesUtils.getDataSetFromName(dataSetName)).toEqual(expectedResult);
+        });
+
+        it("should generate an IDataSet for a partitioned dataset", () => {
+            const dataSetName = "SYS1.PARMLIB(SOMEMEM)";
+            const expectedResult: IDataSet = {
+                dsn: "SYS1.PARMLIB",
+                member: "SOMEMEM"
+            };
+
+            expect(ZosFilesUtils.getDataSetFromName(dataSetName)).toEqual(expectedResult);
         });
     });
 

--- a/packages/zosfiles/src/utils/ZosFilesUtils.ts
+++ b/packages/zosfiles/src/utils/ZosFilesUtils.ts
@@ -18,6 +18,7 @@ import { IZosFilesResponse } from "../doc/IZosFilesResponse";
 import { ZosmfRestClient, ZosmfHeaders } from "@zowe/core-for-zowe-sdk";
 import { IDeleteOptions } from "../methods/hDelete";
 import { IOptions } from "../doc/IOptions";
+import { IDataSet } from "../doc/IDataSet";
 
 /**
  * Common IO utilities
@@ -273,6 +274,24 @@ export class ZosFilesUtils {
         } catch (error) {
             Logger.getAppLogger().error(error);
             throw error;
+        }
+    }
+
+    /**
+     * Converts the name of a data set to an IDataSet
+     * @param {string} name  - the name in the form USER.DATA.SET | USER.DATA.SET(mem1)
+     */
+    public static getDataSetFromName(name: string): IDataSet {
+        const parts = name.replace(')', '').split('(');
+        if (parts.length > 1) {
+            return {
+                dsn: parts[0],
+                member: parts[1]
+            };
+        } else {
+            return {
+                dsn: name
+            };
         }
     }
 }


### PR DESCRIPTION
**What It Does**
Copies getDataSet to the zosFiles SDK under the new name, and deprecates the original function

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [x] added/updated automated tests
- [x] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
