### PR TITLE
feat(imperative): Enhanced `ProfileInfo.updateProperty`

### DIFF
--- a/packages/imperative/CHANGELOG.md
+++ b/packages/imperative/CHANGELOG.md
@@ -335,6 +335,10 @@ that would be used if a command were executed.
 - BugFix: Fixed incorrect description for untyped profiles in team config files. [zowe/zowe-cli#1303](https://github.com/zowe/zowe-cli/issues/1303)
 - **Next Breaking**: Schema files created or updated with the above changes are not backward compatible with older versions of Imperative.
 
+## Recent Changes
+
+- Enhancement: Added the ability to `forceUpdate` a property using the `ProfileInfo.updateProperty` method. [zowe-explorer#2493](https://github.com/zowe/vscode-extension-for-zowe/issues/2493)
+
 ## `5.0.0-next.202203222132`
 
 - BugFix: Reverted unintentional breaking change that prevented `DefaultCredentialManager` from finding Keytar outside of calling CLI's node_modules folder.

--- a/packages/imperative/src/config/src/ProfileInfo.ts
+++ b/packages/imperative/src/config/src/ProfileInfo.ts
@@ -204,7 +204,7 @@ export class ProfileInfo {
         if (options.forceUpdate && this.usingTeamConfig) {
             const knownProperty = mergedArgs.knownArgs.find((v => v.argName === options.property));
             const profPath = this.getTeamConfig().api.profiles.getProfilePathFromName(options.profileName);
-            if (!knownProperty.argLoc.jsonLoc.startsWith(profPath)) {
+            if (!knownProperty?.argLoc.jsonLoc.startsWith(profPath)) {
                 knownProperty.argLoc.jsonLoc = `${profPath}.properties.${options.property}`;
             }
         }

--- a/packages/imperative/src/config/src/ProfileInfo.ts
+++ b/packages/imperative/src/config/src/ProfileInfo.ts
@@ -201,6 +201,13 @@ export class ProfileInfo {
         }
 
         const mergedArgs = this.mergeArgsForProfile(desiredProfile, { getSecureVals: false });
+        if (options.forceUpdate && this.usingTeamConfig) {
+            const knownProperty = mergedArgs.knownArgs.find((v => v.argName === options.property));
+            const profPath = this.getTeamConfig().api.profiles.getProfilePathFromName(options.profileName);
+            if (!knownProperty.argLoc.jsonLoc.startsWith(profPath)) {
+                knownProperty.argLoc.jsonLoc = `${profPath}.properties.${options.property}`;
+            }
+        }
         if (!(await this.updateKnownProperty({ ...options, mergedArgs, osLocInfo: this.getOsLocInfo(desiredProfile)?.[0] }))) {
             if (this.usingTeamConfig) {
                 // Check to see if loadedConfig already contains the schema for the specified profile type

--- a/packages/imperative/src/config/src/doc/IProfInfoUpdatePropOpts.ts
+++ b/packages/imperative/src/config/src/doc/IProfInfoUpdatePropOpts.ts
@@ -29,8 +29,11 @@ export interface IProfInfoUpdatePropOpts extends IProfInfoUpdatePropCommonOpts {
 
     /**
      * Force the update to the profile specified even if the property comes from somehwere else
-     * Example: Token Value could be in the base profile and not in the service profile specified
-     *             and the programmer has the intention of storing the token in the service profile
+     * @example Token Value could be in the base profile (not in the service profile specified)
+     *          and the programmer has the intention of storing the token in the service profile
+     * @default false When the property is not specified, the updateProperty method follows current
+     *          procedure of updating the property in the known jsonLoc (e.g. base profile). Otherwise,
+     *          the updateProperty method updates the specified profile name-type combination.
      */
     forceUpdate?: boolean
 }

--- a/packages/imperative/src/config/src/doc/IProfInfoUpdatePropOpts.ts
+++ b/packages/imperative/src/config/src/doc/IProfInfoUpdatePropOpts.ts
@@ -26,6 +26,13 @@ export interface IProfInfoUpdatePropOpts extends IProfInfoUpdatePropCommonOpts {
      * Name of the active profile
      */
     profileName: string;
+
+    /**
+     * Force the update to the profile specified even if the property comes from somehwere else
+     * Example: Token Value could be in the base profile and not in the service profile specified
+     *             and the programmer has the intention of storing the token in the service profile
+     */
+    forceUpdate?: boolean
 }
 
 /**


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->

- Add a `forceUpdate` optional property to the `ProfileInfo.updateProperty` method.
  - This property only works on V2 config files

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->

Check out the GIF at the bottom 😋 
OR
- Modify a property in a service profile that originally comes from a base profile (e.g. tokenType, tokenValue)
  - With `forceUpdate: false`: the `base` profile is updated
  - With `forceUpdate: true`: the `apiml` profile is updated

Use this config file for testing purposes
```json
{
    "$schema": "./zowe.schema.json",
    "profiles": {
        "apiml": {
            "type": "zosmf",
            "properties": {
                "basePath": "/ibmzosmf/api/v1/"
            }
        },
        "base": {
            "type": "base",
            "properties": {
                "tokenType": "apimlAuthenticationToken"
            }
        }
    },
    "defaults": {
        "zosmf": "apiml",
        "base": "base"
    },
    "autoStore": true
}
```

Use this little `test.mjs` script for testing purposes
```typescript
import { ProfileInfo } from "@zowe/imperative";
(async () => {
    const profInfo = new ProfileInfo("zowe");
    await profInfo.readProfilesFromDisk();
    await profInfo.updateProperty({
      profileName: "apiml", 
      profileType: "zosmf",
      property: "tokenType", 
      value: "test",
      forceUpdate: false
    })
})().catch((err) => {
    console.error(err);
    process.exit(1);
});
```

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [x] added/updated automated tests
- [x] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)

**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->

This is intended to help with the implementation of:
- https://github.com/zowe/vscode-extension-for-zowe/issues/2493

![temp](https://github.com/zowe/zowe-cli/assets/37381190/344adda8-d316-4975-a591-758a91a81bff)

