### PR TITLE
chore: Add Linux dev. pre-requisites to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,16 @@ Versioning conventions for Zowe CLI and Plug-ins| [Versioning Guidelines](./docs
 ## **Building Zowe CLI From Source**
 Zowe CLI requires NPM version 8 and Cargo version 1.72.0 (or newer) to build from source. Before proceeding, check your NPM version with `npm --version` and if it's older than 8.x, update with `npm install -g npm`. To check your version of Cargo, run `cargo --version`. Cargo can be installed using rustup: [https://rustup.rs/](https://rustup.rs/). To update Cargo, run the `rustup update` command.
 
+For developers using Linux, the following packages are required to build Zowe CLI from source:
+
+- Debian/Ubuntu: 
+  - `sudo apt install build-essential libsecret-1-dev`
+- Red Hat-based:
+  - `sudo dnf group install "Development Tools"`
+  - `sudo dnf install libsecret-devel`
+- Arch Linux: 
+  - `sudo pacman -S base-devel libsecret`
+
 The first time that you download Zowe CLI from the GitHub repository, issue the following command to install the required Zowe CLI dependencies and several development tools:
 
 ```


### PR DESCRIPTION
**What It Does**

This PR adds instructions to install the required development packages to build Zowe CLI from source, namely for developers running Linux.

These packages are needed to compile the Secrets SDK on Linux distributions.

**How to Test**

- On Linux, install the packages in the README section "Building Zowe CLI from source"
- Once those packages have been installed, try to build the repository: `npm install && npm run build`

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)
