### PR TITLE
fix(profInfo): Fixed property not found issue in `forceUpdate` functionality

### DIFF
--- a/packages/imperative/CHANGELOG.md
+++ b/packages/imperative/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Imperative package will be documented in this file.
 
+## Recent Changes
+
+- BugFix: Fixed issue when a property is not found in `ProfileInfo.updateProperty({forceUpdate: true})`. [zowe-explorer#2493](https://github.com/zowe/vscode-extension-for-zowe/issues/2493)
+
 ## `5.20.1`
 
 - BugFix: Fixed error message shown for null option definition to include details about which command caused the error. [#2002](https://github.com/zowe/zowe-cli/issues/2002)

--- a/packages/imperative/src/config/__tests__/ProfileInfo.TeamConfig.unit.test.ts
+++ b/packages/imperative/src/config/__tests__/ProfileInfo.TeamConfig.unit.test.ts
@@ -1040,6 +1040,31 @@ describe("TeamConfig ProfileInfo tests", () => {
             expect(updateKnownPropertySpy).toHaveBeenCalledWith({ ...profileOptions, mergedArgs, osLocInfo });
         });
 
+        it("should succeed forceUpdating a property even if the property doesn't exist", async () => {
+            const profInfo = createNewProfInfo(teamProjDir);
+            await profInfo.readProfilesFromDisk();
+            const storeSpy = jest.spyOn(ConfigAutoStore, "_storeSessCfgProps").mockImplementation(jest.fn());
+            const profileOptions: IProfInfoUpdatePropOpts = {
+                profileName: "LPAR4",
+                profileType: "dummy",
+                property: "DOES_NOT_EXIST",
+                value: true,
+                forceUpdate: true
+            };
+            let caughtError;
+            try {
+                await profInfo.updateProperty(profileOptions);
+            } catch (error) {
+                caughtError = error;
+            }
+            expect(caughtError).toBeUndefined();
+            expect(storeSpy).toHaveBeenCalledWith({
+                config: profInfo.getTeamConfig(), profileName: "LPAR4", profileType: "dummy",
+                defaultBaseProfileName: "base_glob",
+                propsToStore: [ "DOES_NOT_EXIST" ], sessCfg: { "DOES_NOT_EXIST": true }, setSecure : undefined,
+            });
+        });
+
         it("should attempt to store session config properties without adding profile types to the loadedConfig", async () => {
             const profInfo = createNewProfInfo(teamProjDir);
             await profInfo.readProfilesFromDisk();

--- a/packages/imperative/src/config/src/ProfileInfo.ts
+++ b/packages/imperative/src/config/src/ProfileInfo.ts
@@ -203,9 +203,11 @@ export class ProfileInfo {
         const mergedArgs = this.mergeArgsForProfile(desiredProfile, { getSecureVals: false });
         if (options.forceUpdate && this.usingTeamConfig) {
             const knownProperty = mergedArgs.knownArgs.find((v => v.argName === options.property));
-            const profPath = this.getTeamConfig().api.profiles.getProfilePathFromName(options.profileName);
-            if (!knownProperty?.argLoc.jsonLoc.startsWith(profPath)) {
-                knownProperty.argLoc.jsonLoc = `${profPath}.properties.${options.property}`;
+            if (knownProperty != null) {
+                const profPath = this.getTeamConfig().api.profiles.getProfilePathFromName(options.profileName);
+                if (!knownProperty.argLoc.jsonLoc.startsWith(profPath)) {
+                    knownProperty.argLoc.jsonLoc = `${profPath}.properties.${options.property}`;
+                }
             }
         }
         if (!(await this.updateKnownProperty({ ...options, mergedArgs, osLocInfo: this.getOsLocInfo(desiredProfile)?.[0] }))) {


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->

- Fixes a small bug in `ProfileInfo.updateProperty({forceUpdate: true})`

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->

- Create a base profile without `tokenType` and try updating the `tokenType` using the `forceUpdate` option.

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [x] added/updated automated tests
- [x] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->

This resolved the following comment:
- https://github.com/zowe/vscode-extension-for-zowe/pull/2606#pullrequestreview-1784258346