### PR TITLE
Remove progress bar with env variables

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Zowe CLI package will be documented in this file.
 
+## Recent Changes
+
+- Enhancement: Hid the progress bar if `CI` environment variable is set, or if `FORCE_COLOR` environment variable is set to `0`. [#1845](https://github.com/zowe/zowe-cli/issues/1845)
+
 ## `7.21.2`
 
 - BugFix: Correct extra character being displayed at the end of lines when issuing `zowe files compare` on Windows. [#1992](https://github.com/zowe/zowe-cli/issues/1992)

--- a/packages/imperative/CHANGELOG.md
+++ b/packages/imperative/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Imperative package will be documented in this file.
 
+## Recent Changes
+
+- Enhancement: Hid the progress bar if `CI` environment variable is set, or if `FORCE_COLOR` environment variable is set to `0`. [#1845](https://github.com/zowe/zowe-cli/issues/1845)
+
 ## `5.20.2`
 
 - BugFix: Fixed issue when a property is not found in `ProfileInfo.updateProperty({forceUpdate: true})`. [zowe-explorer#2493](https://github.com/zowe/vscode-extension-for-zowe/issues/2493)

--- a/packages/imperative/src/cmd/__tests__/response/CommandResponse.unit.test.ts
+++ b/packages/imperative/src/cmd/__tests__/response/CommandResponse.unit.test.ts
@@ -126,6 +126,7 @@ describe("Command Response", () => {
     afterEach(() => {
         delete process.env.FORCE_COLOR;
         delete process.env.CI;
+        jest.restoreAllMocks();
     });
 
     it("If we create a progress bar, an interval should be set to update the bar. " +

--- a/packages/imperative/src/cmd/__tests__/response/CommandResponse.unit.test.ts
+++ b/packages/imperative/src/cmd/__tests__/response/CommandResponse.unit.test.ts
@@ -289,7 +289,7 @@ describe("Command Response", () => {
         expect(response.buildJsonResponse().stderr.toString()).toEqual(beforeMessage + "\n" + duringMessage + "\n" + afterMessage + "\n");
     });
 
-    it("should not show a progress bar if FORCE_COLOR is set to 0", () => {  // eslint-disable-line jest/no-done-callback
+    it("should not show a progress bar if FORCE_COLOR is set to 0", () => {
         process.env.FORCE_COLOR = "0";
         const response = new CommandResponse({ silent: false, responseFormat: "default", stream });
         const status: ITaskWithStatus = {
@@ -306,7 +306,7 @@ describe("Command Response", () => {
         expect((response.progress as any).mProgressBarInterval).not.toBeDefined();
     });
 
-    it("should not show a progress bar if CI is set", () => {  // eslint-disable-line jest/no-done-callback
+    it("should not show a progress bar if CI is set", () => {
         process.env.CI = "true";
         jest.spyOn(TextUtils, "chalk").mockImplementation(() => {
             return {level: 1, enabled: true};

--- a/packages/imperative/src/cmd/__tests__/response/CommandResponse.unit.test.ts
+++ b/packages/imperative/src/cmd/__tests__/response/CommandResponse.unit.test.ts
@@ -114,10 +114,14 @@ describe("Command Response", () => {
         }
         require("rimraf").sync(testFile);
     });
+    afterEach(() => {
+        delete process.env.FORCE_COLOR;
+    });
 
     it("If we create a progress bar, an interval should be set to update the bar. " +
         "If we finish the bar, the interval should be stopped and no longer stored" +
         "in the command response. ", (done) => {  // eslint-disable-line jest/no-done-callback
+        process.env.FORCE_COLOR = "1";
         const response = new CommandResponse({ silent: false, responseFormat: "default" });
         const status: ITaskWithStatus = {
             statusMessage: "Making a bar",
@@ -147,6 +151,7 @@ describe("Command Response", () => {
     });
 
     it("should allow the progress bar to write directly to a socket stream", (done) => {  // eslint-disable-line jest/no-done-callback
+        process.env.FORCE_COLOR = "1";
         const response = new CommandResponse({ silent: false, responseFormat: "default", stream });
         const status: ITaskWithStatus = {
             statusMessage: "Making a bar",
@@ -180,6 +185,7 @@ describe("Command Response", () => {
 
     it("If we create a progress bar, then set the bar to be complete, " +
         "the progress bar should automatically end ", (done) => {  // eslint-disable-line jest/no-done-callback
+        process.env.FORCE_COLOR = "1";
         const response = new CommandResponse({ silent: false, responseFormat: "default" });
         const status: ITaskWithStatus = {
             statusMessage: "Making a bar",
@@ -215,6 +221,7 @@ describe("Command Response", () => {
     it("If our response object is in silent mode, which is caused for example by " +
         "the user specifying that they want a JSON response, a progress bar should" +
         " not be created", () => {
+        process.env.FORCE_COLOR = "1";
         const response = new CommandResponse({ silent: true, responseFormat: "json" });
         const status: ITaskWithStatus = {
             statusMessage: "No bar should be made",
@@ -233,6 +240,7 @@ describe("Command Response", () => {
 
 
     it("should not duplicate output when calling endBar", () => {
+        process.env.FORCE_COLOR = "1";
         let stdoutMsg: string = "";
         let stderrMsg: string = "";
         const response = new CommandResponse({responseFormat: "default"});

--- a/packages/imperative/src/cmd/src/response/CommandResponse.ts
+++ b/packages/imperative/src/cmd/src/response/CommandResponse.ts
@@ -724,7 +724,8 @@ export class CommandResponse implements ICommandResponseApi {
                                 `Please call progress.endBar() before starting a new one.`
                         });
                     }
-                    if (!outer.silent && outer.mResponseFormat !== "json" && TextUtils.chalk.level > 0) {
+                    if (!outer.silent && outer.mResponseFormat !== "json" &&
+                        !(TextUtils.chalk.level === 0 || !TextUtils.chalk.enabled || process.env.CI != null)) {
 
                         // Persist the task specifications and determine the stream to use for the progress bar
                         this.mProgressBarStdoutStartIndex = outer.mStdout.length;

--- a/packages/imperative/src/cmd/src/response/CommandResponse.ts
+++ b/packages/imperative/src/cmd/src/response/CommandResponse.ts
@@ -724,7 +724,7 @@ export class CommandResponse implements ICommandResponseApi {
                                 `Please call progress.endBar() before starting a new one.`
                         });
                     }
-                    if (!outer.silent && outer.mResponseFormat !== "json") {
+                    if (!outer.silent && outer.mResponseFormat !== "json" && TextUtils.chalk.level > 0) {
 
                         // Persist the task specifications and determine the stream to use for the progress bar
                         this.mProgressBarStdoutStartIndex = outer.mStdout.length;

--- a/packages/imperative/src/utilities/src/TextUtils.ts
+++ b/packages/imperative/src/utilities/src/TextUtils.ts
@@ -300,7 +300,7 @@ export class TextUtils {
         const mChalk = require("chalk");
         // chalk is supposed to handle this, but I think it only does so the first time it is loaded
         // so we need to check ourselves in case we've changed the environmental variables
-        if (process.env.FORCE_COLOR in ["1", "2", "3", "true"]) { mChalk.enabled = true; }
+        if (process.env.FORCE_COLOR != null && ["1", "2", "3", "true"].includes(process.env.FORCE_COLOR)) { mChalk.enabled = true; }
         if (process.env.MARKDOWN_GEN != null || process.env.FORCE_COLOR == "0") { mChalk.enabled = false; }
         if (!mChalk.enabled) { mChalk.level = 0; }
         else if (process.env.FORCE_COLOR != null) {

--- a/packages/imperative/src/utilities/src/TextUtils.ts
+++ b/packages/imperative/src/utilities/src/TextUtils.ts
@@ -300,7 +300,8 @@ export class TextUtils {
         const mChalk = require("chalk");
         // chalk is supposed to handle this, but I think it only does so the first time it is loaded
         // so we need to check ourselves in case we've changed the environmental variables
-        mChalk.enabled = process.env.FORCE_COLOR !== "0" && process.env.MARKDOWN_GEN == null;
+        if (process.env.FORCE_COLOR in ["1", "2", "3", "true"]) { mChalk.enabled = true; }
+        if (process.env.MARKDOWN_GEN != null || process.env.FORCE_COLOR == "0") { mChalk.enabled = false; }
         if (!mChalk.enabled) { mChalk.level = 0; }
         else if (process.env.FORCE_COLOR != null) {
             const parsedInt = parseInt(process.env.FORCE_COLOR);


### PR DESCRIPTION
**What It Does**
Removes the progress bar if FORCE_COLOR is 0 or CI is set.

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [x] added/updated automated tests
- [x] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
