### PR TITLE
fix(ProfileInfo): remove `@internal` from `layerActive`

### DIFF
--- a/packages/imperative/src/config/src/Config.ts
+++ b/packages/imperative/src/config/src/Config.ts
@@ -619,8 +619,6 @@ export class Config {
     /**
      * Obtain the layer object that is currently active.
      *
-     * @internal
-     *
      * @returns The active layer object
      */
     public layerActive(): IConfigLayer {


### PR DESCRIPTION
**What It Does**

We did not have `stripInternal` on the `tsconfig.json` in the past, so even though some functions and variables were marked with `@internal`, those comments were simply ignored during compilation. Since recent work in Zowe Explorer uses the `layerActive` function for converting v1 profiles, I've removed the `@internal` from this function's TSDoc.

No changelog was added as the behavior remains the same as previous v3 snapshots and v2 by removing `@internal`.

**How to Test**

No specific scenario to test - should be able to build and run tests.

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)