### PR TITLE
Fix error when uploading daemon binaries to GitHub release

### DIFF
--- a/.github/workflows/rust-cli-publish.yml
+++ b/.github/workflows/rust-cli-publish.yml
@@ -77,7 +77,7 @@ jobs:
       id: upload-release-asset
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: gh release upload native-v${{ needs.release.outputs.ZOWEX_VERSION }} target/x86_64-unknown-linux-gnu/release/zowe-linux.tgz
+      run: gh release upload native-v${{ needs.release.outputs.ZOWEX_VERSION }} target/x86_64-unknown-linux-gnu/release/zowe-linux.tgz --repo ${{ github.repository }}
 
 
   build-macos:
@@ -116,7 +116,7 @@ jobs:
       id: upload-release-asset
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: gh release upload native-v${{ needs.release.outputs.ZOWEX_VERSION }} target/release/zowe-macos.tgz
+      run: gh release upload native-v${{ needs.release.outputs.ZOWEX_VERSION }} target/release/zowe-macos.tgz --repo ${{ github.repository }}
 
 
   build-windows:
@@ -150,4 +150,4 @@ jobs:
       id: upload-release-asset
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: gh release upload native-v${{ needs.release.outputs.ZOWEX_VERSION }} target/release/zowe-windows.tgz
+      run: gh release upload native-v${{ needs.release.outputs.ZOWEX_VERSION }} target/release/zowe-windows.tgz --repo ${{ github.repository }}


### PR DESCRIPTION
Fixes the error in the last workflow run: https://github.com/zowe/zowe-cli/actions/runs/8161704190

> failed to run git: fatal: not a git repository (or any of the parent directories): .git