### PR TITLE
fix(ProfileInfo): update global schema even if project config is present

### DIFF
--- a/packages/imperative/CHANGELOG.md
+++ b/packages/imperative/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Imperative package will be documented in this file.
 
+## Recent Changes
+
+- BugFix: Fixed issue where `ProfileInfo.addProfileTypeToSchema` did not update the global schema if a project-level configuration was detected. [#2086](https://github.com/zowe/zowe-cli/issues/2086)
+
 ## `5.22.4`
 
 - BugFix: Fixed race condition in `config convert-profiles` command that may fail to delete secure values for old profiles

--- a/packages/imperative/CHANGELOG.md
+++ b/packages/imperative/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the Imperative package will be documented in this file.
 
 ## Recent Changes
 
-- BugFix: Fixed issue where `ProfileInfo.addProfileTypeToSchema` did not update the global schema if a project-level configuration was detected. [#2086](https://github.com/zowe/zowe-cli/issues/2086)
+- BugFix: Fixed issue where the `ProfileInfo.addProfileTypeToSchema` function did not update the global schema if a project-level configuration was detected. [#2086](https://github.com/zowe/zowe-cli/issues/2086)
 
 ## `5.22.4`
 

--- a/packages/imperative/src/config/src/ProfileInfo.ts
+++ b/packages/imperative/src/config/src/ProfileInfo.ts
@@ -1338,8 +1338,10 @@ export class ProfileInfo {
         const sameSchemaExists = this.mProfileSchemaCache.has(cacheKey) && lodash.isEqual(transformedSchemaProps, transformedCacheProps);
         // Update the cache with the newest schema for this profile type
         this.mProfileSchemaCache.set(cacheKey, schema);
+        const schemaUri = new url.URL(layer.properties.$schema, url.pathToFileURL(layer.path));
+        const schemaPath = url.fileURLToPath(schemaUri);
 
-        if (!fs.existsSync(layer.path)) {
+        if (!fs.existsSync(schemaPath)) {
             this.mImpLogger.trace(
                 "ProfileInfo.updateSchemaAtLayer returned false: the schema does not exist on disk for this layer."
             );
@@ -1348,7 +1350,7 @@ export class ProfileInfo {
 
         // if profile type schema has changed or if it doesn't exist on-disk, rebuild schema and write to disk
         if (versionChanged || !sameSchemaExists) {
-            jsonfile.writeFileSync(layer.path, this.buildSchema([], layer), { spaces: 4 });
+            jsonfile.writeFileSync(schemaPath, this.buildSchema([], layer), { spaces: 4 });
         }
 
         return true;
@@ -1499,7 +1501,7 @@ export class ProfileInfo {
         }
 
         // If we could not add to the schema, return early
-        if (!result.success) {
+        if (!result.success && !wasGlobalUpdated) {
             return result;
         }
 

--- a/packages/imperative/src/config/src/ProfileInfo.ts
+++ b/packages/imperative/src/config/src/ProfileInfo.ts
@@ -1500,11 +1500,6 @@ export class ProfileInfo {
             wasGlobalUpdated = result.success;
         }
 
-        // If we could not add to the schema, return early
-        if (!result.success && !wasGlobalUpdated) {
-            return result;
-        }
-
         // Update contents of extenders.json if it has changed
         if (wasGlobalUpdated && !lodash.isEqual(oldExtendersJson, this.mExtendersJson)) {
             if (!ProfileInfo.writeExtendersJson(this.mExtendersJson)) {

--- a/packages/imperative/src/config/src/ProfileInfo.ts
+++ b/packages/imperative/src/config/src/ProfileInfo.ts
@@ -1316,11 +1316,11 @@ export class ProfileInfo {
     }
 
     /**
-     * Updates the schema to contain the new profile type.
-     * If the type exists in the cache, it will use the matching layer; if not found, it will use the schema at the active layer.
+     * Updates the schema of the provided config layer to contain the new profile type.
      *
      * @param {string} profileType The profile type to add into the schema
      * @param {IProfileSchema} typeSchema The schema for the profile type
+     * @param {IConfigLayer} layer The config layer that matches the schema to update
      * @param [versionChanged] Whether the version has changed for the schema (optional)
      * @returns {boolean} `true` if added to the schema; `false` otherwise
      */

--- a/packages/imperative/src/config/src/ProfileInfo.ts
+++ b/packages/imperative/src/config/src/ProfileInfo.ts
@@ -1327,7 +1327,7 @@ export class ProfileInfo {
     private updateSchemaAtLayer(profileType: string, schema: IProfileSchema, versionChanged?: boolean): boolean {
         // Check if type already exists in schema cache; if so, update schema at the same layer.
         // Otherwise, update schema at the active layer.
-        const layerToUpdate = this.getTeamConfig().mLayers.find((l) => l.global);
+        const layerToUpdate = this.getTeamConfig().mLayers.find((l) => l.global && l.exists);
         if (layerToUpdate == null) {
             this.mImpLogger.trace("ProfileInfo.updateSchemaAtLayer returned false: global schema was not found.");
             return false;

--- a/packages/imperative/src/config/src/ProfileInfo.ts
+++ b/packages/imperative/src/config/src/ProfileInfo.ts
@@ -1404,16 +1404,15 @@ export class ProfileInfo {
                         if (semver.major(typeInfo.schema.version) != semver.major(prevTypeVersion)) {
                             // Warn user if new major schema version is specified
                             infoMsg =
-                            `Profile type ${profileType} was updated from schema version ${prevTypeVersion} to ${typeInfo.schema.version}.\n`.concat(
-                                `The following applications may be affected: ${typeMetadata.from.filter((src) => src !== typeInfo.sourceApp)}`
-                            );
+                            `Profile type ${profileType} was updated from schema version ${prevTypeVersion} to ${typeInfo.schema.version}.\n` +
+                                `The following applications may be affected: ${typeMetadata.from.filter((src) => src !== typeInfo.sourceApp)}`;
                         }
                     } else if (semver.major(prevTypeVersion) > semver.major(typeInfo.schema.version)) {
                         // Warn user if previous schema version is a newer major version
                         return {
                             success: false,
-                            info: `Profile type ${profileType} expects a newer schema version than provided by ${typeInfo.sourceApp}\n`.concat(
-                                `(expected: v${typeInfo.schema.version}, installed: v${prevTypeVersion})`)
+                            info: `Profile type ${profileType} expects a newer schema version than provided by ${typeInfo.sourceApp}\n` +
+                                `(expected: v${typeInfo.schema.version}, installed: v${prevTypeVersion})`
                         };
                     }
                 } else {
@@ -1442,8 +1441,8 @@ export class ProfileInfo {
                     !lodash.isEqual(schemaProps, cachedSchemaProps)) {
                     return {
                         success: false,
-                        info: `Both the old and new schemas are unversioned for ${profileType}, but the schemas are different. `.concat(
-                            "The new schema was not written to disk, but will still be accessible in-memory.")
+                        info: `Both the old and new schemas are unversioned for ${profileType}, but the schemas are different. ` +
+                            "The new schema was not written to disk, but will still be accessible in-memory."
                     };
                 }
             }
@@ -1457,10 +1456,7 @@ export class ProfileInfo {
             addedToSchema = this.updateSchemaAtLayer(profileType, typeInfo.schema, layer);
         }
 
-        return {
-            success: addedToSchema,
-            info: infoMsg
-        };
+        return { success: addedToSchema, info: infoMsg };
     }
 
     /**
@@ -1497,7 +1493,7 @@ export class ProfileInfo {
                 result.success = this.updateSchemaAtLayer(profileType, typeInfo.schema, activeLayer);
             }
             wasGlobalUpdated = this.addToGlobalSchema(profileType, typeInfo).success;
-        } else if (activeLayer.global && activeLayer.exists) {
+        } else {
             result = this.addToGlobalSchema(profileType, typeInfo);
             wasGlobalUpdated = result.success;
         }


### PR DESCRIPTION
**What It Does**

Resolves #2086 

**How to Test**

This one is a bit difficult to test on the CLI side because it relies on information from the source that initialized the ProfileInfo instance.

1. Create an instance of `ProfileInfo` and call `readProfilesFromDisk`, specifying both a global dir and project dir
2. While in a directory containing a project-level config and schema, call `ProfileInfo.addProfileTypeToSchema` to add a new profile type to the global schema
3. Notice that the global schema will still be updated even though you are in a directory with a project-level config.

You can also test this through Zowe Explorer, but it requires a bit more setup:
- Run `npm run build && npm pack` in the imperative folder
- Set a resolution in Zowe Explorer's root `package.json` to resolve the local tarball containing the fixed Imperative
- Run `yarn fresh-clone && yarn && yarn build`
- Start debugging Zowe Explorer once the build is complete
- In the extension host, open a workspace folder containing a project-level config file
- Install the FTP extension for Zowe Explorer
- Notice that the global schema is updated with the `zftp` profile type even though you have a workspace folder open (containing a proj. config)

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [x] added/updated automated tests
- [x] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)
