### PR TITLE
Move Imperative and CLI log files into same folder

### DIFF
--- a/__tests__/__system__/cli/logging/LoggingCredentials.system.test.ts
+++ b/__tests__/__system__/cli/logging/LoggingCredentials.system.test.ts
@@ -45,8 +45,8 @@ describe("Zowe CLI Logging", () => {
         const encodedAuth = Buffer.from(zosmfUsername + ":" + zosmfPassword).toString("base64");
 
         // Grab both log files
-        const imperativeLogContents = fs.readFileSync(join(TEST_ENVIRONMENT.workingDir, "/logs/imperative.log"));
-        const zoweLogContents = fs.readFileSync(join(TEST_ENVIRONMENT.workingDir, "/" + Constants.LOG_LOCATION));
+        const imperativeLogContents = fs.readFileSync(join(TEST_ENVIRONMENT.workingDir, "logs", "imperative.log"));
+        const zoweLogContents = fs.readFileSync(join(TEST_ENVIRONMENT.workingDir, Constants.LOG_LOCATION));
         const tempTestLog = fs.readFileSync(join(TEST_ENVIRONMENT.workingDir, TempTestProfiles.LOG_FILE_NAME));
 
         // ensure that the password and encoded auth does not appear in the imperative log
@@ -75,8 +75,8 @@ describe("Zowe CLI Logging", () => {
         expect(response.status).toBe(0);
 
         // Grab both log files
-        const imperativeLogContents = fs.readFileSync(join(TEST_ENVIRONMENT.workingDir, "/logs/imperative.log"));
-        const zoweLogContents = fs.readFileSync(join(TEST_ENVIRONMENT.workingDir, "/" + Constants.LOG_LOCATION));
+        const imperativeLogContents = fs.readFileSync(join(TEST_ENVIRONMENT.workingDir, "logs", "imperative.log"));
+        const zoweLogContents = fs.readFileSync(join(TEST_ENVIRONMENT.workingDir, Constants.LOG_LOCATION));
         const tempTestLog = fs.readFileSync(join(TEST_ENVIRONMENT.workingDir, TempTestProfiles.LOG_FILE_NAME));
 
         // ensure that the password and encoded auth does not appear in the imperative log

--- a/__tests__/__system__/cli/logging/LoggingCredentials.system.test.ts
+++ b/__tests__/__system__/cli/logging/LoggingCredentials.system.test.ts
@@ -45,7 +45,7 @@ describe("Zowe CLI Logging", () => {
         const encodedAuth = Buffer.from(zosmfUsername + ":" + zosmfPassword).toString("base64");
 
         // Grab both log files
-        const imperativeLogContents = fs.readFileSync(join(TEST_ENVIRONMENT.workingDir, "/imperative/logs/imperative.log"));
+        const imperativeLogContents = fs.readFileSync(join(TEST_ENVIRONMENT.workingDir, "/logs/imperative.log"));
         const zoweLogContents = fs.readFileSync(join(TEST_ENVIRONMENT.workingDir, "/" + Constants.LOG_LOCATION));
         const tempTestLog = fs.readFileSync(join(TEST_ENVIRONMENT.workingDir, TempTestProfiles.LOG_FILE_NAME));
 
@@ -75,7 +75,7 @@ describe("Zowe CLI Logging", () => {
         expect(response.status).toBe(0);
 
         // Grab both log files
-        const imperativeLogContents = fs.readFileSync(join(TEST_ENVIRONMENT.workingDir, "/imperative/logs/imperative.log"));
+        const imperativeLogContents = fs.readFileSync(join(TEST_ENVIRONMENT.workingDir, "/logs/imperative.log"));
         const zoweLogContents = fs.readFileSync(join(TEST_ENVIRONMENT.workingDir, "/" + Constants.LOG_LOCATION));
         const tempTestLog = fs.readFileSync(join(TEST_ENVIRONMENT.workingDir, TempTestProfiles.LOG_FILE_NAME));
 

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Zowe CLI package will be documented in this file.
 
+## Recent Changes
+
+- Enhancement: Consolidated the Zowe client log files into the same directory. [#2116](https://github.com/zowe/zowe-cli/issues/2116)
+
 ## `8.0.0-next.202404032038`
 
 - BugFix: Fixed error in `zos-files list all-members` command that could occur when members contain control characters in the name. [#2104](https://github.com/zowe/zowe-cli/pull/2104)

--- a/packages/cli/src/Constants.ts
+++ b/packages/cli/src/Constants.ts
@@ -22,7 +22,7 @@ export class Constants {
      * @static
      * @memberof Constants
      */
-    public static readonly LOG_LOCATION = "zowe/logs/zowe.log";
+    public static readonly LOG_LOCATION = "logs/zowe.log";
 
     /**
      * Display name

--- a/packages/core/__tests__/apiml/__unit__/allPluginCfgPropsMock.json
+++ b/packages/core/__tests__/apiml/__unit__/allPluginCfgPropsMock.json
@@ -18,7 +18,7 @@
           }
         ],
         "appLogging": {
-          "logFile": "zowe/logs/zowe-endevor.log"
+          "logFile": "logs/zowe-endevor.log"
         }
       },
       "secondaryTextColor": "yellow",

--- a/packages/core/__tests__/apiml/__unit__/cliImpConfigMock.json
+++ b/packages/core/__tests__/apiml/__unit__/cliImpConfigMock.json
@@ -16,7 +16,7 @@
   "webHelpLogoImgPath": "C:\\ourstuff\\repos\\zowe-cli\\packages\\cli\\web-help-logo.png",
   "logging": {
     "appLogging": {
-      "logFile": "zowe/logs/zowe.log",
+      "logFile": "logs/zowe.log",
       "apiName": "app",
       "category": "app"
     },

--- a/packages/imperative/CHANGELOG.md
+++ b/packages/imperative/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to the Imperative package will be documented in this file.
 
+## Recent Changes
+
+- Enhancement: Consolidated the Zowe client log files into the same directory. [#2116](https://github.com/zowe/zowe-cli/issues/2116)
+- Deprecated: The `IO.FILE_DELIM` constant. Use `path.sep` or `path.posix.sep` instead.
+
 ## `8.0.0-next.202404191414`
 
 - Enhancement: Added a new class named ConvertV1Profiles to enable other apps to better convert V1 profiles into a current Zowe config file.

--- a/packages/imperative/CHANGELOG.md
+++ b/packages/imperative/CHANGELOG.md
@@ -5,7 +5,8 @@ All notable changes to the Imperative package will be documented in this file.
 ## Recent Changes
 
 - Enhancement: Consolidated the Zowe client log files into the same directory. [#2116](https://github.com/zowe/zowe-cli/issues/2116)
-- Deprecated: The `IO.FILE_DELIM` constant. Use `path.sep` or `path.posix.sep` instead.
+- Deprecated: The `IO.FILE_DELIM` constant. Use `path.posix.sep` instead or `path.sep` for better cross-platform support.
+- Deprecated: The `LoggerConfigBuilder.DEFAULT_LOG_DIR` and `LoggerConfigBuilder.DEFAULT_LOG_FILE_DIR` constants. Use `LoggerConfigBuilder.DEFAULT_LOGS_DIR` instead.
 
 ## `8.0.0-next.202404301428`
 

--- a/packages/imperative/__tests__/__integration__/imperative/__tests__/__integration__/cli/test/cli.imperative-test-cli.test.logging.integration.test.ts
+++ b/packages/imperative/__tests__/__integration__/imperative/__tests__/__integration__/cli/test/cli.imperative-test-cli.test.logging.integration.test.ts
@@ -20,9 +20,9 @@ import { LoggerConfigBuilder } from "../../../../../../../src";
 let TEST_ENVIRONMENT: ITestEnvironment;
 
 // Log directories
-const APP_LOGS_DIR = "/imperative-test-cli/logs/";
+const APP_LOGS_DIR = "/logs/";
 const APP_LOG = APP_LOGS_DIR + "imperative-test-cli.log";
-const IMP_LOGS_DIR = "/imperative/logs/";
+const IMP_LOGS_DIR = "/logs/";
 const IMP_LOG = IMP_LOGS_DIR + "imperative.log";
 
 describe("imperative-test-cli test logging command", () => {

--- a/packages/imperative/__tests__/__integration__/imperative/__tests__/__integration__/cli/test/cli.imperative-test-cli.test.logging.integration.test.ts
+++ b/packages/imperative/__tests__/__integration__/imperative/__tests__/__integration__/cli/test/cli.imperative-test-cli.test.logging.integration.test.ts
@@ -9,10 +9,11 @@
 *
 */
 
+import * as fs from "fs";
+import * as path from "path";
 import { runCliScript } from "../../../../../../src/TestUtil";
 import { SetupTestEnvironment } from "../../../../../../__src__/environment/SetupTestEnvironment";
 import { ITestEnvironment } from "../../../../../../__src__/environment/doc/response/ITestEnvironment";
-import * as fs from "fs";
 import { TestLogger } from "../../../../../../src/TestLogger";
 import { LoggerConfigBuilder } from "../../../../../../../src";
 
@@ -20,10 +21,8 @@ import { LoggerConfigBuilder } from "../../../../../../../src";
 let TEST_ENVIRONMENT: ITestEnvironment;
 
 // Log directories
-const APP_LOGS_DIR = "/logs/";
-const APP_LOG = APP_LOGS_DIR + "imperative-test-cli.log";
-const IMP_LOGS_DIR = "/logs/";
-const IMP_LOG = IMP_LOGS_DIR + "imperative.log";
+const APP_LOG = path.join("logs", "imperative-test-cli.log");
+const IMP_LOG = path.join("logs", "imperative.log");
 
 describe("imperative-test-cli test logging command", () => {
 
@@ -51,10 +50,10 @@ describe("imperative-test-cli test logging command", () => {
                 expect(response.stdout.toString()).toMatchSnapshot();
 
                 // Make sure the log files are present
-                expect(fs.existsSync(TEST_ENVIRONMENT.workingDir + APP_LOG)).toBe(true);
-                expect(fs.existsSync(TEST_ENVIRONMENT.workingDir + IMP_LOG)).toBe(true);
+                expect(fs.existsSync(path.join(TEST_ENVIRONMENT.workingDir, APP_LOG))).toBe(true);
+                expect(fs.existsSync(path.join(TEST_ENVIRONMENT.workingDir, IMP_LOG))).toBe(true);
 
-                const logContents = fs.readFileSync(TEST_ENVIRONMENT.workingDir + IMP_LOG).toString();
+                const logContents = fs.readFileSync(path.join(TEST_ENVIRONMENT.workingDir, IMP_LOG)).toString();
 
                 // Check for each tag
                 expect(logContents).not.toContain("[TRACE]");
@@ -89,10 +88,10 @@ describe("imperative-test-cli test logging command", () => {
                 expect(response.stdout.toString()).toMatchSnapshot();
 
                 // Make sure the log files are present
-                expect(fs.existsSync(TEST_ENVIRONMENT.workingDir + APP_LOG)).toBe(true);
-                expect(fs.existsSync(TEST_ENVIRONMENT.workingDir + IMP_LOG)).toBe(true);
+                expect(fs.existsSync(path.join(TEST_ENVIRONMENT.workingDir, APP_LOG))).toBe(true);
+                expect(fs.existsSync(path.join(TEST_ENVIRONMENT.workingDir, IMP_LOG))).toBe(true);
 
-                const logContents = fs.readFileSync(TEST_ENVIRONMENT.workingDir + APP_LOG).toString();
+                const logContents = fs.readFileSync(path.join(TEST_ENVIRONMENT.workingDir, APP_LOG)).toString();
 
                 // Check for each tag
                 expect(logContents).not.toContain("[TRACE]");
@@ -132,10 +131,10 @@ describe("imperative-test-cli test logging command", () => {
                 expect(response.stdout.toString()).toMatchSnapshot();
 
                 // Make sure the log files are present
-                expect(fs.existsSync(TEST_ENVIRONMENT.workingDir + APP_LOG)).toBe(true);
-                expect(fs.existsSync(TEST_ENVIRONMENT.workingDir + IMP_LOG)).toBe(true);
+                expect(fs.existsSync(path.join(TEST_ENVIRONMENT.workingDir, APP_LOG))).toBe(true);
+                expect(fs.existsSync(path.join(TEST_ENVIRONMENT.workingDir, IMP_LOG))).toBe(true);
 
-                const logContents = fs.readFileSync(TEST_ENVIRONMENT.workingDir + IMP_LOG).toString();
+                const logContents = fs.readFileSync(path.join(TEST_ENVIRONMENT.workingDir, IMP_LOG)).toString();
 
                 // Check for each tag
                 expect(logContents).not.toContain("[TRACE]");
@@ -161,10 +160,10 @@ describe("imperative-test-cli test logging command", () => {
                 expect(response.stdout.toString()).toMatchSnapshot();
 
                 // Make sure the log files are present
-                expect(fs.existsSync(TEST_ENVIRONMENT.workingDir + APP_LOG)).toBe(true);
-                expect(fs.existsSync(TEST_ENVIRONMENT.workingDir + IMP_LOG)).toBe(true);
+                expect(fs.existsSync(path.join(TEST_ENVIRONMENT.workingDir, APP_LOG))).toBe(true);
+                expect(fs.existsSync(path.join(TEST_ENVIRONMENT.workingDir, IMP_LOG))).toBe(true);
 
-                const logContents = fs.readFileSync(TEST_ENVIRONMENT.workingDir + IMP_LOG).toString();
+                const logContents = fs.readFileSync(path.join(TEST_ENVIRONMENT.workingDir, IMP_LOG)).toString();
 
                 // Check for each tag
                 expect(logContents).not.toContain("[TRACE]");
@@ -199,10 +198,10 @@ describe("imperative-test-cli test logging command", () => {
                 expect(response.stdout.toString()).toMatchSnapshot();
 
                 // Make sure the log files are present
-                expect(fs.existsSync(TEST_ENVIRONMENT.workingDir + APP_LOG)).toBe(true);
-                expect(fs.existsSync(TEST_ENVIRONMENT.workingDir + IMP_LOG)).toBe(true);
+                expect(fs.existsSync(path.join(TEST_ENVIRONMENT.workingDir, APP_LOG))).toBe(true);
+                expect(fs.existsSync(path.join(TEST_ENVIRONMENT.workingDir, IMP_LOG))).toBe(true);
 
-                const logContents = fs.readFileSync(TEST_ENVIRONMENT.workingDir + APP_LOG).toString();
+                const logContents = fs.readFileSync(path.join(TEST_ENVIRONMENT.workingDir, APP_LOG)).toString();
 
                 // Check for each tag
                 expect(logContents).not.toContain("[TRACE]");
@@ -228,10 +227,10 @@ describe("imperative-test-cli test logging command", () => {
                 expect(response.stdout.toString()).toMatchSnapshot();
 
                 // Make sure the log files are present
-                expect(fs.existsSync(TEST_ENVIRONMENT.workingDir + APP_LOG)).toBe(true);
-                expect(fs.existsSync(TEST_ENVIRONMENT.workingDir + IMP_LOG)).toBe(true);
+                expect(fs.existsSync(path.join(TEST_ENVIRONMENT.workingDir, APP_LOG))).toBe(true);
+                expect(fs.existsSync(path.join(TEST_ENVIRONMENT.workingDir, IMP_LOG))).toBe(true);
 
-                const logContents = fs.readFileSync(TEST_ENVIRONMENT.workingDir + APP_LOG).toString();
+                const logContents = fs.readFileSync(path.join(TEST_ENVIRONMENT.workingDir, APP_LOG)).toString();
 
                 // Check for each tag
                 expect(logContents).not.toContain("[TRACE]");
@@ -271,10 +270,10 @@ describe("imperative-test-cli test logging command", () => {
                 expect(response.stdout.toString()).toMatchSnapshot();
 
                 // Make sure the log files are present
-                expect(fs.existsSync(TEST_ENVIRONMENT.workingDir + APP_LOG)).toBe(true);
-                expect(fs.existsSync(TEST_ENVIRONMENT.workingDir + IMP_LOG)).toBe(true);
+                expect(fs.existsSync(path.join(TEST_ENVIRONMENT.workingDir, APP_LOG))).toBe(true);
+                expect(fs.existsSync(path.join(TEST_ENVIRONMENT.workingDir, IMP_LOG))).toBe(true);
 
-                const logStats = fs.statSync(TEST_ENVIRONMENT.workingDir + IMP_LOG);
+                const logStats = fs.statSync(path.join(TEST_ENVIRONMENT.workingDir, IMP_LOG));
                 expect(logStats.size).toBe(0);
             });
 
@@ -290,10 +289,10 @@ describe("imperative-test-cli test logging command", () => {
                 expect(response.stdout.toString()).toMatchSnapshot();
 
                 // Make sure the log files are present
-                expect(fs.existsSync(TEST_ENVIRONMENT.workingDir + APP_LOG)).toBe(true);
-                expect(fs.existsSync(TEST_ENVIRONMENT.workingDir + IMP_LOG)).toBe(true);
+                expect(fs.existsSync(path.join(TEST_ENVIRONMENT.workingDir, APP_LOG))).toBe(true);
+                expect(fs.existsSync(path.join(TEST_ENVIRONMENT.workingDir, IMP_LOG))).toBe(true);
 
-                const logContents = fs.readFileSync(TEST_ENVIRONMENT.workingDir + IMP_LOG).toString();
+                const logContents = fs.readFileSync(path.join(TEST_ENVIRONMENT.workingDir, IMP_LOG)).toString();
 
                 // Check for each tag
                 expect(logContents).toContain("[TRACE]");
@@ -336,10 +335,10 @@ describe("imperative-test-cli test logging command", () => {
                 expect(response.stdout.toString()).toMatchSnapshot();
 
                 // Make sure the log files are present
-                expect(fs.existsSync(TEST_ENVIRONMENT.workingDir + APP_LOG)).toBe(true);
-                expect(fs.existsSync(TEST_ENVIRONMENT.workingDir + IMP_LOG)).toBe(true);
+                expect(fs.existsSync(path.join(TEST_ENVIRONMENT.workingDir, APP_LOG))).toBe(true);
+                expect(fs.existsSync(path.join(TEST_ENVIRONMENT.workingDir, IMP_LOG))).toBe(true);
 
-                const logStats = fs.statSync(TEST_ENVIRONMENT.workingDir + APP_LOG);
+                const logStats = fs.statSync(path.join(TEST_ENVIRONMENT.workingDir, APP_LOG));
                 expect(logStats.size).toBe(0);
             });
 
@@ -355,10 +354,10 @@ describe("imperative-test-cli test logging command", () => {
                 expect(response.stdout.toString()).toMatchSnapshot();
 
                 // Make sure the log files are present
-                expect(fs.existsSync(TEST_ENVIRONMENT.workingDir + APP_LOG)).toBe(true);
-                expect(fs.existsSync(TEST_ENVIRONMENT.workingDir + IMP_LOG)).toBe(true);
+                expect(fs.existsSync(path.join(TEST_ENVIRONMENT.workingDir, APP_LOG))).toBe(true);
+                expect(fs.existsSync(path.join(TEST_ENVIRONMENT.workingDir, IMP_LOG))).toBe(true);
 
-                const logContents = fs.readFileSync(TEST_ENVIRONMENT.workingDir + APP_LOG).toString();
+                const logContents = fs.readFileSync(path.join(TEST_ENVIRONMENT.workingDir, APP_LOG)).toString();
 
                 // Check for each tag
                 expect(logContents).toContain("[TRACE]");
@@ -402,13 +401,13 @@ describe("imperative-test-cli test logging command", () => {
                 expect(response.stdout.toString()).toMatchSnapshot();
 
                 // Make sure the log files are present
-                expect(fs.existsSync(TEST_ENVIRONMENT.workingDir + APP_LOG)).toBe(true);
-                expect(fs.existsSync(TEST_ENVIRONMENT.workingDir + IMP_LOG)).toBe(true);
+                expect(fs.existsSync(path.join(TEST_ENVIRONMENT.workingDir, APP_LOG))).toBe(true);
+                expect(fs.existsSync(path.join(TEST_ENVIRONMENT.workingDir, IMP_LOG))).toBe(true);
 
-                const appLogStats = fs.statSync(TEST_ENVIRONMENT.workingDir + APP_LOG);
+                const appLogStats = fs.statSync(path.join(TEST_ENVIRONMENT.workingDir, APP_LOG));
                 expect(appLogStats.size).toBe(0);
 
-                const impLogStats = fs.statSync(TEST_ENVIRONMENT.workingDir + IMP_LOG);
+                const impLogStats = fs.statSync(path.join(TEST_ENVIRONMENT.workingDir, IMP_LOG));
                 expect(impLogStats.size).toBe(0);
             });
 
@@ -427,10 +426,10 @@ describe("imperative-test-cli test logging command", () => {
                 expect(response.stdout.toString()).toMatchSnapshot();
 
                 // Make sure the log files are present
-                expect(fs.existsSync(TEST_ENVIRONMENT.workingDir + APP_LOG)).toBe(true);
-                expect(fs.existsSync(TEST_ENVIRONMENT.workingDir + IMP_LOG)).toBe(true);
+                expect(fs.existsSync(path.join(TEST_ENVIRONMENT.workingDir, APP_LOG))).toBe(true);
+                expect(fs.existsSync(path.join(TEST_ENVIRONMENT.workingDir, IMP_LOG))).toBe(true);
 
-                const appLogContents = fs.readFileSync(TEST_ENVIRONMENT.workingDir + APP_LOG).toString();
+                const appLogContents = fs.readFileSync(path.join(TEST_ENVIRONMENT.workingDir, APP_LOG)).toString();
 
                 // Check for each tag
                 expect(appLogContents).toContain("[TRACE]");
@@ -448,7 +447,7 @@ describe("imperative-test-cli test logging command", () => {
                 expect(appLogContents).toContain("This is an app logger error message from the test logging handler!");
                 expect(appLogContents).toContain("This is an app logger fatal message from the test logging handler!");
 
-                const impLogContents = fs.readFileSync(TEST_ENVIRONMENT.workingDir + IMP_LOG).toString();
+                const impLogContents = fs.readFileSync(path.join(TEST_ENVIRONMENT.workingDir, IMP_LOG)).toString();
 
                 // Check for each tag
                 expect(impLogContents).toContain("[TRACE]");
@@ -482,10 +481,10 @@ describe("imperative-test-cli test logging command", () => {
                 expect(response.stdout.toString()).toMatchSnapshot();
 
                 // Make sure the log files are present
-                expect(fs.existsSync(TEST_ENVIRONMENT.workingDir + APP_LOG)).toBe(true);
-                expect(fs.existsSync(TEST_ENVIRONMENT.workingDir + IMP_LOG)).toBe(true);
+                expect(fs.existsSync(path.join(TEST_ENVIRONMENT.workingDir, APP_LOG))).toBe(true);
+                expect(fs.existsSync(path.join(TEST_ENVIRONMENT.workingDir, IMP_LOG))).toBe(true);
 
-                const appLogContents = fs.readFileSync(TEST_ENVIRONMENT.workingDir + APP_LOG).toString();
+                const appLogContents = fs.readFileSync(path.join(TEST_ENVIRONMENT.workingDir, APP_LOG)).toString();
 
                 // Check for each tag
                 expect(appLogContents).not.toContain("[TRACE]");
@@ -503,7 +502,7 @@ describe("imperative-test-cli test logging command", () => {
                 expect(appLogContents).toContain("This is an app logger error message from the test logging handler!");
                 expect(appLogContents).toContain("This is an app logger fatal message from the test logging handler!");
 
-                const impLogContents = fs.readFileSync(TEST_ENVIRONMENT.workingDir + IMP_LOG).toString();
+                const impLogContents = fs.readFileSync(path.join(TEST_ENVIRONMENT.workingDir, IMP_LOG)).toString();
 
                 // Check for each tag
                 expect(impLogContents).not.toContain("[TRACE]");
@@ -537,10 +536,10 @@ describe("imperative-test-cli test logging command", () => {
                 expect(response.stdout.toString()).toMatchSnapshot();
 
                 // Make sure the log files are present
-                expect(fs.existsSync(TEST_ENVIRONMENT.workingDir + APP_LOG)).toBe(true);
-                expect(fs.existsSync(TEST_ENVIRONMENT.workingDir + IMP_LOG)).toBe(true);
+                expect(fs.existsSync(path.join(TEST_ENVIRONMENT.workingDir, APP_LOG))).toBe(true);
+                expect(fs.existsSync(path.join(TEST_ENVIRONMENT.workingDir, IMP_LOG))).toBe(true);
 
-                const appLogContents = fs.readFileSync(TEST_ENVIRONMENT.workingDir + APP_LOG).toString();
+                const appLogContents = fs.readFileSync(path.join(TEST_ENVIRONMENT.workingDir, APP_LOG)).toString();
 
                 // Check for each tag
                 expect(appLogContents).not.toContain("[TRACE]");
@@ -559,7 +558,7 @@ describe("imperative-test-cli test logging command", () => {
                 expect(appLogContents).toContain("This is an app logger fatal message from the test logging handler!");
 
                 // Read the imperative log contents
-                const impLogContents = fs.readFileSync(TEST_ENVIRONMENT.workingDir + IMP_LOG).toString();
+                const impLogContents = fs.readFileSync(path.join(TEST_ENVIRONMENT.workingDir, IMP_LOG)).toString();
 
                 // Check for each tag
                 expect(impLogContents).not.toContain("[TRACE]");
@@ -593,15 +592,15 @@ describe("imperative-test-cli test logging command", () => {
                 expect(response.stdout.toString()).toMatchSnapshot();
 
                 // Make sure the log files are present
-                expect(fs.existsSync(TEST_ENVIRONMENT.workingDir + APP_LOG)).toBe(true);
-                expect(fs.existsSync(TEST_ENVIRONMENT.workingDir + IMP_LOG)).toBe(true);
+                expect(fs.existsSync(path.join(TEST_ENVIRONMENT.workingDir, APP_LOG))).toBe(true);
+                expect(fs.existsSync(path.join(TEST_ENVIRONMENT.workingDir, IMP_LOG))).toBe(true);
 
                 // Ensure that the app log is empty
-                const appLogStats = fs.statSync(TEST_ENVIRONMENT.workingDir + APP_LOG);
+                const appLogStats = fs.statSync(path.join(TEST_ENVIRONMENT.workingDir, APP_LOG));
                 expect(appLogStats.size).toBe(0);
 
                 // Ensure that the imp log has all levels
-                const impLogContents = fs.readFileSync(TEST_ENVIRONMENT.workingDir + IMP_LOG).toString();
+                const impLogContents = fs.readFileSync(path.join(TEST_ENVIRONMENT.workingDir, IMP_LOG)).toString();
 
                 // Check for each tag
                 expect(impLogContents).toContain("[TRACE]");
@@ -635,15 +634,15 @@ describe("imperative-test-cli test logging command", () => {
                 expect(response.stdout.toString()).toMatchSnapshot();
 
                 // Make sure the log files are present
-                expect(fs.existsSync(TEST_ENVIRONMENT.workingDir + APP_LOG)).toBe(true);
-                expect(fs.existsSync(TEST_ENVIRONMENT.workingDir + IMP_LOG)).toBe(true);
+                expect(fs.existsSync(path.join(TEST_ENVIRONMENT.workingDir, APP_LOG))).toBe(true);
+                expect(fs.existsSync(path.join(TEST_ENVIRONMENT.workingDir, IMP_LOG))).toBe(true);
 
                 // Ensure that the app log is empty
-                const impLogStats = fs.statSync(TEST_ENVIRONMENT.workingDir + IMP_LOG);
+                const impLogStats = fs.statSync(path.join(TEST_ENVIRONMENT.workingDir, IMP_LOG));
                 expect(impLogStats.size).toBe(0);
 
                 // Ensure that the imp log has all levels
-                const appLogStats = fs.readFileSync(TEST_ENVIRONMENT.workingDir + APP_LOG).toString();
+                const appLogStats = fs.readFileSync(path.join(TEST_ENVIRONMENT.workingDir, APP_LOG)).toString();
 
                 // Check for each tag
                 expect(appLogStats).toContain("[TRACE]");

--- a/packages/imperative/__tests__/__integration__/imperative/__tests__/__integration__/cli/test/cli.imperative-test-cli.test.masking.integration.test.ts
+++ b/packages/imperative/__tests__/__integration__/imperative/__tests__/__integration__/cli/test/cli.imperative-test-cli.test.masking.integration.test.ts
@@ -20,9 +20,9 @@ import { TestLogger } from "../../../../../../src/TestLogger";
 let TEST_ENVIRONMENT: ITestEnvironment;
 
 // Log directories
-const APP_LOGS_DIR = "/imperative-test-cli/logs/";
+const APP_LOGS_DIR = "/logs/";
 const APP_LOG = APP_LOGS_DIR + "imperative-test-cli.log";
-const IMP_LOGS_DIR = "/imperative/logs/";
+const IMP_LOGS_DIR = "/logs/";
 const IMP_LOG = IMP_LOGS_DIR + "imperative.log";
 
 describe("imperative-test-cli test masking command", () => {

--- a/packages/imperative/__tests__/__integration__/imperative/__tests__/__integration__/cli/test/cli.imperative-test-cli.test.masking.integration.test.ts
+++ b/packages/imperative/__tests__/__integration__/imperative/__tests__/__integration__/cli/test/cli.imperative-test-cli.test.masking.integration.test.ts
@@ -11,6 +11,7 @@
 
 /* eslint-disable jest/expect-expect */
 import * as fs from "fs";
+import * as path from "path";
 import { runCliScript } from "../../../../../../src/TestUtil";
 import { ITestEnvironment } from "../../../../../../__src__/environment/doc/response/ITestEnvironment";
 import { SetupTestEnvironment } from "../../../../../../__src__/environment/SetupTestEnvironment";
@@ -20,10 +21,8 @@ import { TestLogger } from "../../../../../../src/TestLogger";
 let TEST_ENVIRONMENT: ITestEnvironment;
 
 // Log directories
-const APP_LOGS_DIR = "/logs/";
-const APP_LOG = APP_LOGS_DIR + "imperative-test-cli.log";
-const IMP_LOGS_DIR = "/logs/";
-const IMP_LOG = IMP_LOGS_DIR + "imperative.log";
+const APP_LOG = path.join("logs", "imperative-test-cli.log");
+const IMP_LOG = path.join("logs", "imperative.log");
 
 describe("imperative-test-cli test masking command", () => {
     // Create the unique test environment
@@ -63,8 +62,9 @@ describe("imperative-test-cli test masking command", () => {
     };
 
     const _testLogs = (_log: string) => {
-        expect(fs.existsSync(TEST_ENVIRONMENT.workingDir + (_log === "app" ? APP_LOG : IMP_LOG))).toBe(true);
-        const logContents = fs.readFileSync(TEST_ENVIRONMENT.workingDir + (_log === "app" ? APP_LOG : IMP_LOG)).toString();
+        const logPath = path.join(TEST_ENVIRONMENT.workingDir, _log === "app" ? APP_LOG : IMP_LOG);
+        expect(fs.existsSync(logPath)).toBe(true);
+        const logContents = fs.readFileSync(logPath).toString();
         for (const level of ["trace", "debug", "info", "warn", "error", "fatal"]) {
             expect(logContents).toContain(`[${level.toUpperCase()}]`);
             expect(logContents).toContain(_logPrefix(_log, level) + level === "trace" ? "secret" : "****");

--- a/packages/imperative/__tests__/src/example_clis/with_profiles/__integration__/ExampleLogging.integration.subtest.ts
+++ b/packages/imperative/__tests__/src/example_clis/with_profiles/__integration__/ExampleLogging.integration.subtest.ts
@@ -9,6 +9,7 @@
 *
 */
 
+import * as path from "path";
 import * as T from "../../../TestUtil";
 import { IImperativeConfig } from "../../../../../src/imperative";
 
@@ -16,7 +17,7 @@ describe("We should provide the ability to create, manage, and use profiles, " +
     "tested through an example CLI", function () {
     const cliBin = __dirname + "/../ProfileExampleCLI.ts";
     const config: IImperativeConfig = require(__dirname + "/../ProfileExampleConfiguration");
-    const logFile = config.defaultHome + "/logs/" + config.name + ".log";
+    const logFile = path.join(config.defaultHome as string, "logs", config.name + ".log");
 
     afterEach(function () {
         T.rimraf(logFile);

--- a/packages/imperative/__tests__/src/example_clis/with_profiles/__integration__/ExampleLogging.integration.subtest.ts
+++ b/packages/imperative/__tests__/src/example_clis/with_profiles/__integration__/ExampleLogging.integration.subtest.ts
@@ -16,7 +16,7 @@ describe("We should provide the ability to create, manage, and use profiles, " +
     "tested through an example CLI", function () {
     const cliBin = __dirname + "/../ProfileExampleCLI.ts";
     const config: IImperativeConfig = require(__dirname + "/../ProfileExampleConfiguration");
-    const logFile = config.defaultHome + "/" + config.name + "/logs/" + config.name + ".log";
+    const logFile = config.defaultHome + "/logs/" + config.name + ".log";
 
     afterEach(function () {
         T.rimraf(logFile);

--- a/packages/imperative/__tests__/src/packages/imperative/plugins/suites/UsingPlugins.ts
+++ b/packages/imperative/__tests__/src/packages/imperative/plugins/suites/UsingPlugins.ts
@@ -240,7 +240,7 @@ describe("Using a Plugin", () => {
         expect(result.stdout).toContain(`${randomTest}: Messages logged successfully to the following locations`);
 
         // Check imperative logger
-        const impLogLocation = join(config.defaultHome, "imperative", "logs", "imperative.log");
+        const impLogLocation = join(config.defaultHome, "logs", "imperative.log");
         const impLogContent = readFileSync(impLogLocation).toString();
         expect(result.stdout).toContain(resolve(impLogLocation));
         expect(impLogContent).not.toContain(`Log message from test plugin: DEBUG: ${randomTest}`);
@@ -249,7 +249,7 @@ describe("Using a Plugin", () => {
         expect(impLogContent).toContain(`Log message from test plugin: ERROR: ${randomTest}`);
 
         // Check App/Plugin  logger
-        const appLogLocation = join(config.defaultHome, config.name, "logs", config.name + ".log");
+        const appLogLocation = join(config.defaultHome, "logs", config.name + ".log");
         const appLogContent = readFileSync(appLogLocation).toString();
         expect(result.stdout).toContain(resolve(appLogLocation));
         expect(appLogContent).not.toContain(`Log message from test plugin: DEBUG: ${randomTest}`);

--- a/packages/imperative/__tests__/src/packages/imperative/plugins/test_plugins/normal_plugin_misc/lib/sample-plugin/cmd/imperative-logging/imperativeLogging.handler.js
+++ b/packages/imperative/__tests__/src/packages/imperative/plugins/test_plugins/normal_plugin_misc/lib/sample-plugin/cmd/imperative-logging/imperativeLogging.handler.js
@@ -31,8 +31,8 @@ class ImperativeLoggingHandler {
 
             var config = T.ImperativeConfig.instance.loadedConfig;
             params.response.console.log(`${params.arguments.test}: Messages logged successfully to the following locations`);
-            params.response.console.log(path.join(config.defaultHome, "imperative", "logs", "imperative.log"));
-            params.response.console.log(path.join(config.defaultHome, config.name, "logs", config.name + ".log"));
+            params.response.console.log(path.join(config.defaultHome, "logs", "imperative.log"));
+            params.response.console.log(path.join(config.defaultHome, "logs", config.name + ".log"));
             yield undefined;
         });
     }

--- a/packages/imperative/src/imperative/__tests__/LoggingConfigurer.unit.test.ts
+++ b/packages/imperative/src/imperative/__tests__/LoggingConfigurer.unit.test.ts
@@ -22,6 +22,7 @@ describe("LoggingConfigurer tests", () => {
     beforeAll(() => {
         jest.spyOn(os, "homedir").mockImplementation(() => fakeHome);
         jest.spyOn(path, "normalize").mockImplementation((p: string) => p);
+        jest.spyOn(path.posix, "join").mockImplementation((...ps: string[]) => ps.join("/"));
     });
 
     afterAll(() => {

--- a/packages/imperative/src/imperative/__tests__/__snapshots__/LoggingConfigurer.unit.test.ts.snap
+++ b/packages/imperative/src/imperative/__tests__/__snapshots__/LoggingConfigurer.unit.test.ts.snap
@@ -6,7 +6,7 @@ Object {
     "appenders": Object {
       "app": Object {
         "backups": 5,
-        "filename": "./someHome/sample/logs/sample.log",
+        "filename": "./someHome/logs/sample.log",
         "layout": Object {
           "pattern": "[%d{yyyy/MM/dd} %d{hh:mm:ss.SSS}] [%p] %m",
           "type": "pattern",
@@ -16,7 +16,7 @@ Object {
       },
       "default": Object {
         "backups": 5,
-        "filename": "./someHome/imperative/logs/imperative.log",
+        "filename": "./someHome/logs/imperative.log",
         "layout": Object {
           "pattern": "[%d{yyyy/MM/dd} %d{hh:mm:ss.SSS}] [%p] %m",
           "type": "pattern",
@@ -26,7 +26,7 @@ Object {
       },
       "imperative": Object {
         "backups": 5,
-        "filename": "./someHome/imperative/logs/imperative.log",
+        "filename": "./someHome/logs/imperative.log",
         "layout": Object {
           "pattern": "[%d{yyyy/MM/dd} %d{hh:mm:ss.SSS}] [%p] %m",
           "type": "pattern",
@@ -77,7 +77,7 @@ Object {
       },
       "default": Object {
         "backups": 5,
-        "filename": "./someHome/imperative/logs/imperative.log",
+        "filename": "./someHome/logs/imperative.log",
         "layout": Object {
           "pattern": "[%d{yyyy/MM/dd} %d{hh:mm:ss.SSS}] [%p] %m",
           "type": "pattern",
@@ -87,7 +87,7 @@ Object {
       },
       "imperative": Object {
         "backups": 5,
-        "filename": "./someHome/imperative/logs/imperative.log",
+        "filename": "./someHome/logs/imperative.log",
         "layout": Object {
           "pattern": "[%d{yyyy/MM/dd} %d{hh:mm:ss.SSS}] [%p] %m",
           "type": "pattern",
@@ -136,7 +136,7 @@ Object {
       },
       "default": Object {
         "backups": 5,
-        "filename": "./someHome/imperative/logs/imperative.log",
+        "filename": "./someHome/logs/imperative.log",
         "layout": Object {
           "pattern": "[%d{yyyy/MM/dd} %d{hh:mm:ss.SSS}] [%p] %m",
           "type": "pattern",
@@ -146,7 +146,7 @@ Object {
       },
       "extraOne": Object {
         "backups": 5,
-        "filename": "./someHome/extraOne/logs/extraOne.log",
+        "filename": "./someHome/logs/extraOne.log",
         "layout": Object {
           "pattern": "[%d{yyyy/MM/dd} %d{hh:mm:ss.SSS}] [%p] %m",
           "type": "pattern",
@@ -166,7 +166,7 @@ Object {
       },
       "imperative": Object {
         "backups": 5,
-        "filename": "./someHome/imperative/logs/imperative.log",
+        "filename": "./someHome/logs/imperative.log",
         "layout": Object {
           "pattern": "[%d{yyyy/MM/dd} %d{hh:mm:ss.SSS}] [%p] %m",
           "type": "pattern",
@@ -217,7 +217,7 @@ Object {
     "appenders": Object {
       "app": Object {
         "backups": 5,
-        "filename": "./someHome/sample/logs/sample.log",
+        "filename": "./someHome/logs/sample.log",
         "layout": Object {
           "pattern": "[%d{yyyy/MM/dd} %d{hh:mm:ss.SSS}] [%p] %m",
           "type": "pattern",
@@ -227,7 +227,7 @@ Object {
       },
       "default": Object {
         "backups": 5,
-        "filename": "./someHome/imperative/logs/imperative.log",
+        "filename": "./someHome/logs/imperative.log",
         "layout": Object {
           "pattern": "[%d{yyyy/MM/dd} %d{hh:mm:ss.SSS}] [%p] %m",
           "type": "pattern",
@@ -237,7 +237,7 @@ Object {
       },
       "imperative": Object {
         "backups": 5,
-        "filename": "./someHome/imperative/logs/imperative.log",
+        "filename": "./someHome/logs/imperative.log",
         "layout": Object {
           "pattern": "[%d{yyyy/MM/dd} %d{hh:mm:ss.SSS}] [%p] %m",
           "type": "pattern",
@@ -276,7 +276,7 @@ Object {
     "appenders": Object {
       "app": Object {
         "backups": 5,
-        "filename": "./someHome/notSample/logs/notSample.log",
+        "filename": "./someHome/logs/notSample.log",
         "layout": Object {
           "pattern": "[%d{yyyy/MM/dd} %d{hh:mm:ss.SSS}] [%p] %m",
           "type": "pattern",
@@ -286,7 +286,7 @@ Object {
       },
       "default": Object {
         "backups": 5,
-        "filename": "./someHome/imperative/logs/imperative.log",
+        "filename": "./someHome/logs/imperative.log",
         "layout": Object {
           "pattern": "[%d{yyyy/MM/dd} %d{hh:mm:ss.SSS}] [%p] %m",
           "type": "pattern",
@@ -296,7 +296,7 @@ Object {
       },
       "imperative": Object {
         "backups": 5,
-        "filename": "./someHome/imperative/logs/imperative.log",
+        "filename": "./someHome/logs/imperative.log",
         "layout": Object {
           "pattern": "[%d{yyyy/MM/dd} %d{hh:mm:ss.SSS}] [%p] %m",
           "type": "pattern",
@@ -335,7 +335,7 @@ Object {
     "appenders": Object {
       "app": Object {
         "backups": 5,
-        "filename": "./someHome/sample/logs/sample.log",
+        "filename": "./someHome/logs/sample.log",
         "layout": Object {
           "pattern": "[%d{yyyy/MM/dd} %d{hh:mm:ss.SSS}] [%p] %m",
           "type": "pattern",
@@ -345,7 +345,7 @@ Object {
       },
       "default": Object {
         "backups": 5,
-        "filename": "./someHome/imperative/logs/imperative.log",
+        "filename": "./someHome/logs/imperative.log",
         "layout": Object {
           "pattern": "[%d{yyyy/MM/dd} %d{hh:mm:ss.SSS}] [%p] %m",
           "type": "pattern",
@@ -355,7 +355,7 @@ Object {
       },
       "imperative": Object {
         "backups": 5,
-        "filename": "./someHome/imperative/logs/imperative.log",
+        "filename": "./someHome/logs/imperative.log",
         "layout": Object {
           "pattern": "[%d{yyyy/MM/dd} %d{hh:mm:ss.SSS}] [%p] %m",
           "type": "pattern",
@@ -394,7 +394,7 @@ Object {
     "appenders": Object {
       "app": Object {
         "backups": 5,
-        "filename": "./someHome/sample/logs/sample.log",
+        "filename": "./someHome/logs/sample.log",
         "layout": Object {
           "pattern": "[%d{yyyy/MM/dd} %d{hh:mm:ss.SSS}] [%p] %m",
           "type": "pattern",
@@ -404,7 +404,7 @@ Object {
       },
       "default": Object {
         "backups": 5,
-        "filename": "./someHome/imperative/logs/imperative.log",
+        "filename": "./someHome/logs/imperative.log",
         "layout": Object {
           "pattern": "[%d{yyyy/MM/dd} %d{hh:mm:ss.SSS}] [%p] %m",
           "type": "pattern",
@@ -414,7 +414,7 @@ Object {
       },
       "imperative": Object {
         "backups": 5,
-        "filename": "./someHome/imperative/logs/imperative.log",
+        "filename": "./someHome/logs/imperative.log",
         "layout": Object {
           "pattern": "[%d{yyyy/MM/dd} %d{hh:mm:ss.SSS}] [%p] %m",
           "type": "pattern",

--- a/packages/imperative/src/imperative/src/LoggingConfigurer.ts
+++ b/packages/imperative/src/imperative/src/LoggingConfigurer.ts
@@ -9,13 +9,12 @@
 *
 */
 
+import * as path from "path";
 import { IConfigLogging } from "../../logger/src/doc/IConfigLogging";
 import { Logger } from "../../logger/src/Logger";
 import { LoggerConfigBuilder } from "../../logger/src/LoggerConfigBuilder";
 import { IImperativeConfig } from "./doc/IImperativeConfig";
 import { Console } from "../../console";
-import { isNullOrUndefined } from "util";
-import { IO } from "../../io/src/IO";
 import { IImperativeLoggingConfig } from "./doc/IImperativeLoggingConfig";
 import { ImperativeError } from "../../error/src/ImperativeError";
 import { ImperativeExpect } from "../../expect/src/ImperativeExpect";
@@ -89,9 +88,9 @@ export class LoggingConfigurer {
         /**
          * All remaining logs are created here
          */
-        if (!isNullOrUndefined(imperativeConfig.logging.additionalLogging)) {
+        if (imperativeConfig.logging.additionalLogging != null) {
             imperativeConfig.logging.additionalLogging.forEach((logConfig) => {
-                if (isNullOrUndefined(logConfig.apiName)) {
+                if (logConfig.apiName == null) {
                     throw new ImperativeError({
                         msg: "apiName is required for additionalLoggers",
                     });
@@ -160,11 +159,9 @@ export class LoggingConfigurer {
      */
     private static configureLoggerByKey(
         home: string, imperativeConfig: IImperativeConfig, loggingConfig: IConfigLogging, entryKey: string, configKey: string) {
-        if (!isNullOrUndefined(imperativeConfig.logging)) {
-            if (!isNullOrUndefined(imperativeConfig.logging[configKey])) {
-                loggingConfig = LoggingConfigurer.configureLoggerByKeyHelper(
-                    home, imperativeConfig.logging[configKey], loggingConfig, entryKey, configKey);
-            }
+        if (imperativeConfig.logging != null && imperativeConfig.logging[configKey] != null) {
+            loggingConfig = LoggingConfigurer.configureLoggerByKeyHelper(
+                home, imperativeConfig.logging[configKey], loggingConfig, entryKey, configKey);
         }
 
         return loggingConfig;
@@ -184,12 +181,12 @@ export class LoggingConfigurer {
      */
     private static configureLoggerByKeyHelper(home: string, impLogConfig: IImperativeLoggingConfig,
         loggingConfig: IConfigLogging, entryKey: string, configKey: string) {
-        if (!isNullOrUndefined(impLogConfig.logFile)) {
+        if (impLogConfig.logFile != null) {
             const fullLogFilePath = home +
                 LoggingConfigurer.normalizeDir(impLogConfig.logFile);
             loggingConfig.log4jsConfig.appenders[entryKey].filename = fullLogFilePath as any;
         }
-        if (!isNullOrUndefined(impLogConfig.level)) {
+        if (impLogConfig.level != null) {
             Console.validateLevel(impLogConfig.level);
             loggingConfig.log4jsConfig.categories[entryKey].level = impLogConfig.level;
         }
@@ -269,11 +266,11 @@ export class LoggingConfigurer {
      */
     private static buildLoggingDefaultsByKey(
         imperativeConfig: IImperativeConfig, key: string, apiName: string, category = apiName): IImperativeConfig {
-        if (isNullOrUndefined(imperativeConfig.logging)) {
+        if (imperativeConfig.logging == null) {
             imperativeConfig.logging = {};
             imperativeConfig.logging[key] = {apiName, category};
         } else {
-            if (isNullOrUndefined(imperativeConfig.logging[key])) {
+            if (imperativeConfig.logging[key] == null) {
                 imperativeConfig.logging[key] = {apiName, category};
             } else {
                 imperativeConfig.logging[key].apiName = apiName;
@@ -296,7 +293,7 @@ export class LoggingConfigurer {
         if (file[0] === "/" || file[0] === "\\") {
             return file;
         } else {
-            return IO.FILE_DELIM + file;
+            return path.posix.sep + file;
         }
     }
 }

--- a/packages/imperative/src/io/__tests__/IO.unit.test.ts
+++ b/packages/imperative/src/io/__tests__/IO.unit.test.ts
@@ -151,7 +151,7 @@ describe("IO tests", () => {
             return pathSegments[0];
         });
         const willBeADir = ["pretend", "to", "create"];
-        const dir = willBeADir.join(IO.FILE_DELIM);
+        const dir = willBeADir.join(path.posix.sep);
         IO.createDirsSync(dir);
         expect(fnFm).toHaveBeenCalledTimes(willBeADir.length);
     });
@@ -167,7 +167,7 @@ describe("IO tests", () => {
             return pathSegments[0];
         });
         const willBeADir = ["pretend", "to", "create"];
-        const dir = willBeADir.join(IO.FILE_DELIM);
+        const dir = willBeADir.join(path.posix.sep);
         IO.createDirsSync(dir);
         expect(fnFm).not.toHaveBeenCalled();
     });
@@ -187,7 +187,7 @@ describe("IO tests", () => {
         fnPr.mockImplementation((...pathSegments: any[]) => {
             return pathSegments[0];
         });
-        const dir = willBeADir.join(IO.FILE_DELIM);
+        const dir = willBeADir.join(path.posix.sep);
         IO.createDirsSync(dir);
         expect(fnFm).toHaveBeenCalledTimes(willBeADir.length - 1);
     });
@@ -204,12 +204,12 @@ describe("IO tests", () => {
         });
         const fnPd = jest.mocked(path.dirname);
         fnPd.mockImplementation(((...pathSegments: any[]) => {
-            const toDir: string[] = pathSegments[0].split(IO.FILE_DELIM);
+            const toDir: string[] = pathSegments[0].split(path.posix.sep);
             toDir.pop();
-            return toDir.join(IO.FILE_DELIM);
+            return toDir.join(path.posix.sep);
         }) as any);
         const willBeADir = ["pretend", "to", "create", "test.txt"];
-        const dir = willBeADir.join(IO.FILE_DELIM);
+        const dir = willBeADir.join(path.posix.sep);
         IO.createDirsSyncFromFilePath(dir);
         expect(fnFm).toHaveBeenCalledTimes(willBeADir.length - 1);
     });
@@ -226,12 +226,12 @@ describe("IO tests", () => {
         });
         const fnPd = jest.mocked(path.dirname);
         fnPd.mockImplementation(((...pathSegments: any[]) => {
-            const toDir: string[] = pathSegments[0].split(IO.FILE_DELIM);
+            const toDir: string[] = pathSegments[0].split(path.posix.sep);
             toDir.pop();
-            return toDir.join(IO.FILE_DELIM);
+            return toDir.join(path.posix.sep);
         }) as any);
         const willBeADir = ["pretend", "to", "create", "test.txt"];
-        const dir = willBeADir.join(IO.FILE_DELIM);
+        const dir = willBeADir.join(path.posix.sep);
         IO.createDirsSyncFromFilePath(dir);
         expect(fnFm).not.toHaveBeenCalled();
     });
@@ -253,11 +253,11 @@ describe("IO tests", () => {
         });
         const fnPd = jest.mocked(path.dirname);
         fnPd.mockImplementation(((...pathSegments: any[]) => {
-            const toDir: string[] = pathSegments[0].split(IO.FILE_DELIM);
+            const toDir: string[] = pathSegments[0].split(path.posix.sep);
             toDir.pop();
-            return toDir.join(IO.FILE_DELIM);
+            return toDir.join(path.posix.sep);
         }) as any);
-        const dir = willBeADir.join(IO.FILE_DELIM);
+        const dir = willBeADir.join(path.posix.sep);
         IO.createDirsSyncFromFilePath(dir);
         expect(fnFm).toHaveBeenCalledTimes(willBeADir.length - 2);
     });

--- a/packages/imperative/src/io/src/IO.ts
+++ b/packages/imperative/src/io/src/IO.ts
@@ -30,11 +30,12 @@ export class IO {
 
     /**
      * File delimiter
+     * @deprecated Use `path.sep` or `path.posix.sep` instead
      * @static
      * @type {string}
      * @memberof IO
      */
-    public static readonly FILE_DELIM: string = "/";
+    public static readonly FILE_DELIM: string = path.posix.sep;
 
     /**
      * UTF8 identifier

--- a/packages/imperative/src/io/src/IO.ts
+++ b/packages/imperative/src/io/src/IO.ts
@@ -30,7 +30,7 @@ export class IO {
 
     /**
      * File delimiter
-     * @deprecated Use `path.sep` or `path.posix.sep` instead
+     * @deprecated Use `path.posix.sep` instead or `path.sep` for better cross-platform support
      * @static
      * @type {string}
      * @memberof IO
@@ -134,12 +134,12 @@ export class IO {
         ImperativeExpect.toBeDefinedAndNonBlank(dir, "dir");
         // we're splitting on a specific separator character, so replace \ with /
         // before splitting
-        const dirs = path.resolve(dir).replace(/\\/g, IO.FILE_DELIM).split(IO.FILE_DELIM);
+        const dirs = path.resolve(dir).replace(/\\/g, path.posix.sep).split(path.posix.sep);
 
         let createDir: string = "";
         for (const crDir of dirs) {
 
-            createDir += (crDir + IO.FILE_DELIM);
+            createDir += (crDir + path.posix.sep);
             IO.createDirSync(createDir);
         }
     }

--- a/packages/imperative/src/logger/__tests__/LoggerConfigBuilder.unit.test.ts
+++ b/packages/imperative/src/logger/__tests__/LoggerConfigBuilder.unit.test.ts
@@ -67,7 +67,7 @@ describe("LoggerConfigBuilder tests", () => {
 
     it("Should use getDefaultFileName to append the Imperative CLI home to a passed-in file path", () => {
         const testFile = "test";
-        const result = "/" + testFile + "/logs/" + testFile + ".log";
+        const result = "/logs/" + testFile + ".log";
         const builtPath = LoggerConfigBuilder.getDefaultFileName(testFile);
         expect(builtPath).toBe(result);
     });

--- a/packages/imperative/src/logger/__tests__/__snapshots__/LoggerConfigBuilder.unit.test.ts.snap
+++ b/packages/imperative/src/logger/__tests__/__snapshots__/LoggerConfigBuilder.unit.test.ts.snap
@@ -13,7 +13,7 @@ Object {
       },
       "sampleFile": Object {
         "backups": 5,
-        "filename": "./someHome/sampleFile/logs/sampleFile.log",
+        "filename": "./someHome/logs/sampleFile.log",
         "layout": Object {
           "pattern": "[%d{yyyy/MM/dd} %d{hh:mm:ss.SSS}] [%p] %m",
           "type": "pattern",
@@ -55,7 +55,7 @@ Object {
     "appenders": Object {
       "sampleFile": Object {
         "backups": 5,
-        "filename": "./someHome/sampleFile/logs/sampleFile.log",
+        "filename": "./someHome/logs/sampleFile.log",
         "layout": Object {
           "pattern": "[%d{yyyy/MM/dd} %d{hh:mm:ss.SSS}] [%p] %m",
           "type": "pattern",
@@ -96,7 +96,7 @@ Object {
       },
       "sampleFile1": Object {
         "backups": 5,
-        "filename": "./someHome/sampleFile1/logs/sampleFile1.log",
+        "filename": "./someHome/logs/sampleFile1.log",
         "layout": Object {
           "pattern": "[%d{yyyy/MM/dd} %d{hh:mm:ss.SSS}] [%p] %m",
           "type": "pattern",
@@ -106,7 +106,7 @@ Object {
       },
       "sampleFile2": Object {
         "backups": 5,
-        "filename": "./someHome/sampleFile2/logs/sampleFile2.log",
+        "filename": "./someHome/logs/sampleFile2.log",
         "layout": Object {
           "pattern": "[%d{yyyy/MM/dd} %d{hh:mm:ss.SSS}] [%p] %m",
           "type": "pattern",

--- a/packages/imperative/src/logger/src/LoggerConfigBuilder.ts
+++ b/packages/imperative/src/logger/src/LoggerConfigBuilder.ts
@@ -105,8 +105,7 @@ export class LoggerConfigBuilder {
      * @return {string} - the default file name for the log file
      */
     public static getDefaultFileName(name: string) {
-        return LoggerConfigBuilder.DEFAULT_LOG_DIR + name + IO.FILE_DELIM +
-        LoggerConfigBuilder.DEFAULT_LOG_FILE_DIR + name + LoggerConfigBuilder.DEFAULT_LOG_FILE_EXT;
+        return LoggerConfigBuilder.DEFAULT_LOG_DIR + LoggerConfigBuilder.DEFAULT_LOG_FILE_DIR + name + LoggerConfigBuilder.DEFAULT_LOG_FILE_EXT;
     }
 
     /**

--- a/packages/imperative/src/logger/src/LoggerConfigBuilder.ts
+++ b/packages/imperative/src/logger/src/LoggerConfigBuilder.ts
@@ -25,8 +25,15 @@ export class LoggerConfigBuilder {
     public static readonly DEFAULT_BACKEND = "NONE";
 
     public static readonly DEFAULT = "default";
+    /**
+     * @deprecated Use `DEFAULT_LOGS_DIR` instead.
+     */
     public static readonly DEFAULT_LOG_DIR = IO.FILE_DELIM;
+    /**
+     * @deprecated Use `DEFAULT_LOGS_DIR` instead.
+     */
     public static readonly DEFAULT_LOG_FILE_DIR = "logs" + IO.FILE_DELIM;
+    public static readonly DEFAULT_LOGS_DIR = "logs";
     public static readonly DEFAULT_LOG_FILE_EXT = ".log";
     public static readonly DEFAULT_LOG_FILE_MAX_SIZE = 10000000;  // 10MB log size
     public static readonly DEFAULT_LOG_FILE_BACKUPS = 5;
@@ -105,7 +112,7 @@ export class LoggerConfigBuilder {
      * @return {string} - the default file name for the log file
      */
     public static getDefaultFileName(name: string) {
-        return LoggerConfigBuilder.DEFAULT_LOG_DIR + LoggerConfigBuilder.DEFAULT_LOG_FILE_DIR + name + LoggerConfigBuilder.DEFAULT_LOG_FILE_EXT;
+        return path.posix.sep + path.posix.join(LoggerConfigBuilder.DEFAULT_LOGS_DIR, name + LoggerConfigBuilder.DEFAULT_LOG_FILE_EXT);
     }
 
     /**

--- a/packages/zosfiles/__tests__/__unit__/methods/download/Download.unit.test.ts
+++ b/packages/zosfiles/__tests__/__unit__/methods/download/Download.unit.test.ts
@@ -15,7 +15,6 @@ import { ImperativeError, IO, Session } from "@zowe/imperative";
 import { IDownloadOptions, TransferMode, Utilities, ZosFilesAttributes, ZosFilesMessages } from "../../../../src";
 import { ZosmfHeaders, ZosmfRestClient } from "@zowe/core-for-zowe-sdk";
 import { Download } from "../../../../src/methods/download/Download";
-import { posix, join } from "path";
 import { ZosFilesConstants } from "../../../../src/constants/ZosFiles.constants";
 import * as util from "util";
 import { IUSSListOptions, List } from "../../../../src/methods/list";
@@ -124,7 +123,7 @@ describe("z/OS Files - Download", () => {
                 caughtError = e;
             }
 
-            const endpoint = posix.join(ZosFilesConstants.RESOURCE, ZosFilesConstants.RES_DS_FILES, `-(${volume})`, dsname);
+            const endpoint = path.posix.join(ZosFilesConstants.RESOURCE, ZosFilesConstants.RES_DS_FILES, `-(${volume})`, dsname);
 
             expect(caughtError).toBeUndefined();
             expect(response).toEqual({
@@ -160,7 +159,7 @@ describe("z/OS Files - Download", () => {
                 caughtError = e;
             }
 
-            const endpoint = posix.join(ZosFilesConstants.RESOURCE, ZosFilesConstants.RES_DS_FILES, `-(${volume})`, dsname);
+            const endpoint = path.posix.join(ZosFilesConstants.RESOURCE, ZosFilesConstants.RES_DS_FILES, `-(${volume})`, dsname);
             const newDsContent = IO.processNewlines(dsContent.toString());
 
             expect(caughtError).toBeUndefined();
@@ -195,7 +194,7 @@ describe("z/OS Files - Download", () => {
                 caughtError = e;
             }
 
-            const endpoint = posix.join(ZosFilesConstants.RESOURCE, ZosFilesConstants.RES_DS_FILES, dsname);
+            const endpoint = path.posix.join(ZosFilesConstants.RESOURCE, ZosFilesConstants.RES_DS_FILES, dsname);
 
             expect(caughtError).toBeUndefined();
             expect(response).toEqual({
@@ -231,7 +230,7 @@ describe("z/OS Files - Download", () => {
                 caughtError = e;
             }
 
-            const endpoint = posix.join(ZosFilesConstants.RESOURCE, ZosFilesConstants.RES_DS_FILES, dsname);
+            const endpoint = path.posix.join(ZosFilesConstants.RESOURCE, ZosFilesConstants.RES_DS_FILES, dsname);
 
             expect(caughtError).toBeUndefined();
             expect(response).toEqual({
@@ -269,7 +268,7 @@ describe("z/OS Files - Download", () => {
                 caughtError = e;
             }
 
-            const endpoint = posix.join(ZosFilesConstants.RESOURCE, ZosFilesConstants.RES_DS_FILES, dsname);
+            const endpoint = path.posix.join(ZosFilesConstants.RESOURCE, ZosFilesConstants.RES_DS_FILES, dsname);
 
             expect(caughtError).toBeUndefined();
             expect(response).toEqual({
@@ -306,7 +305,7 @@ describe("z/OS Files - Download", () => {
                 caughtError = e;
             }
 
-            const endpoint = posix.join(ZosFilesConstants.RESOURCE, ZosFilesConstants.RES_DS_FILES, dsname);
+            const endpoint = path.posix.join(ZosFilesConstants.RESOURCE, ZosFilesConstants.RES_DS_FILES, dsname);
 
             expect(caughtError).toBeUndefined();
             expect(response).toEqual({
@@ -342,7 +341,7 @@ describe("z/OS Files - Download", () => {
                 caughtError = e;
             }
 
-            const endpoint = posix.join(ZosFilesConstants.RESOURCE, ZosFilesConstants.RES_DS_FILES, dsname);
+            const endpoint = path.posix.join(ZosFilesConstants.RESOURCE, ZosFilesConstants.RES_DS_FILES, dsname);
 
             expect(caughtError).toBeUndefined();
             expect(response).toEqual({
@@ -379,7 +378,7 @@ describe("z/OS Files - Download", () => {
                 caughtError = e;
             }
 
-            const endpoint = posix.join(ZosFilesConstants.RESOURCE, ZosFilesConstants.RES_DS_FILES, dsname);
+            const endpoint = path.posix.join(ZosFilesConstants.RESOURCE, ZosFilesConstants.RES_DS_FILES, dsname);
 
             expect(caughtError).toBeUndefined();
             expect(response).toEqual({
@@ -413,7 +412,7 @@ describe("z/OS Files - Download", () => {
                 caughtError = e;
             }
 
-            const endpoint = posix.join(ZosFilesConstants.RESOURCE, ZosFilesConstants.RES_DS_FILES, dsname);
+            const endpoint = path.posix.join(ZosFilesConstants.RESOURCE, ZosFilesConstants.RES_DS_FILES, dsname);
 
             expect(caughtError).toBeUndefined();
             expect(response).toEqual({
@@ -450,7 +449,7 @@ describe("z/OS Files - Download", () => {
                 caughtError = e;
             }
 
-            const endpoint = posix.join(ZosFilesConstants.RESOURCE, ZosFilesConstants.RES_DS_FILES, dsname);
+            const endpoint = path.posix.join(ZosFilesConstants.RESOURCE, ZosFilesConstants.RES_DS_FILES, dsname);
 
             expect(caughtError).toBeUndefined();
             expect(response).toEqual({
@@ -487,7 +486,7 @@ describe("z/OS Files - Download", () => {
             } catch (e) {
                 caughtError = e;
             }
-            const endpoint = posix.join(ZosFilesConstants.RESOURCE, ZosFilesConstants.RES_DS_FILES, `-(${volume})`, dsname);
+            const endpoint = path.posix.join(ZosFilesConstants.RESOURCE, ZosFilesConstants.RES_DS_FILES, `-(${volume})`, dsname);
 
             expect(caughtError).toBeUndefined();
             expect(response).toEqual({
@@ -529,7 +528,7 @@ describe("z/OS Files - Download", () => {
                 caughtError = e;
             }
 
-            const endpoint = posix.join(ZosFilesConstants.RESOURCE, ZosFilesConstants.RES_DS_FILES, dsname);
+            const endpoint = path.posix.join(ZosFilesConstants.RESOURCE, ZosFilesConstants.RES_DS_FILES, dsname);
 
             expect(response).toBeUndefined();
             expect(caughtError).toEqual(dummyError);
@@ -554,7 +553,7 @@ describe("z/OS Files - Download", () => {
                 caughtError = e;
             }
 
-            const endpoint = posix.join(ZosFilesConstants.RESOURCE, ZosFilesConstants.RES_DS_FILES, dsname);
+            const endpoint = path.posix.join(ZosFilesConstants.RESOURCE, ZosFilesConstants.RES_DS_FILES, dsname);
 
             expect(caughtError).toBeUndefined();
             expect(response).toEqual({
@@ -684,7 +683,7 @@ describe("z/OS Files - Download", () => {
             expect(downloadDatasetSpy).toHaveBeenCalledTimes(2);
             listApiResponse.items.forEach((mem) => {
                 expect(downloadDatasetSpy).toHaveBeenCalledWith(dummySession, `${dsname}(${mem.member})`, {
-                    file: `${dsFolder}/${mem.member.toLowerCase()}.txt`
+                    file: path.posix.join(dsFolder, mem.member.toLowerCase() + ".txt")
                 });
             });
         });
@@ -718,7 +717,7 @@ describe("z/OS Files - Download", () => {
             listApiResponse.items.forEach((mem) => {
                 expect(downloadDatasetSpy).toHaveBeenCalledWith(dummySession, `${dsname}(${mem.member})`, {
                     volume,
-                    file: `${directory}/${mem.member.toLowerCase()}${extension}`,
+                    file: path.posix.join(directory, mem.member.toLowerCase() + extension),
                     binary
                 });
             });
@@ -753,7 +752,7 @@ describe("z/OS Files - Download", () => {
             listApiResponse.items.forEach((mem) => {
                 expect(downloadDatasetSpy).toHaveBeenCalledWith(dummySession, `${dsname}(${mem.member})`, {
                     volume,
-                    file: `${directory}/${mem.member.toLowerCase()}${extension}`,
+                    file: path.posix.join(directory, mem.member.toLowerCase() + extension),
                     record
                 });
             });
@@ -789,7 +788,7 @@ describe("z/OS Files - Download", () => {
             listApiResponse.items.forEach((mem) => {
                 expect(downloadDatasetSpy).toHaveBeenCalledWith(dummySession, `${dsname}(${mem.member})`, {
                     volume,
-                    file: `${directory}/${mem.member.toLowerCase()}${extension}`,
+                    file: path.posix.join(directory, mem.member.toLowerCase() + extension),
                     binary,
                     encoding: undefined,
                     responseTimeout
@@ -827,7 +826,7 @@ describe("z/OS Files - Download", () => {
             listApiResponse.items.forEach((mem) => {
                 expect(downloadDatasetSpy).toHaveBeenCalledWith(dummySession, `${dsname}(${mem.member})`, {
                     volume,
-                    file: `${directory}/${mem.member.toLowerCase()}${extension}`,
+                    file: path.posix.join(directory, mem.member.toLowerCase() + extension),
                     record,
                     encoding: undefined,
                     responseTimeout
@@ -864,7 +863,7 @@ describe("z/OS Files - Download", () => {
             listApiResponse.items.forEach((mem) => {
                 expect(downloadDatasetSpy).toHaveBeenCalledWith(dummySession, `${dsname}(${mem.member})`, {
                     volume,
-                    file: `${directory}/${mem.member.toLowerCase()}${extension}`,
+                    file: path.posix.join(directory, mem.member.toLowerCase() + extension),
                     encoding
                 });
             });
@@ -898,7 +897,7 @@ describe("z/OS Files - Download", () => {
             listApiResponse.items.forEach((mem) => {
                 expect(downloadDatasetSpy).toHaveBeenCalledWith(dummySession, `${dsname}(${mem.member})`, {
                     volume,
-                    file: `${directory}/${mem.member.toLowerCase()}${extension}`
+                    file: path.posix.join(directory, mem.member.toLowerCase() + extension)
                 });
             });
         });
@@ -932,7 +931,7 @@ describe("z/OS Files - Download", () => {
             listApiResponse.items.forEach((mem) => {
                 expect(downloadDatasetSpy).toHaveBeenCalledWith(dummySession, `${dsname}(${mem.member})`, {
                     volume,
-                    file: `${directory}/${mem.member.toLowerCase()}${extension}`,
+                    file: path.posix.join(directory, mem.member.toLowerCase() + extension),
                     binary
                 });
             });
@@ -961,7 +960,7 @@ describe("z/OS Files - Download", () => {
             expect(downloadDatasetSpy).toHaveBeenCalledTimes(2);
             listApiResponse.items.forEach((mem) => {
                 expect(downloadDatasetSpy).toHaveBeenCalledWith(dummySession, `${dsname}(${mem.member})`, {
-                    file: `${dsFolder.toUpperCase()}/${mem.member}.txt`
+                    file: path.posix.join(dsFolder.toUpperCase(), mem.member + ".txt")
                 });
             });
         });
@@ -1014,7 +1013,7 @@ describe("z/OS Files - Download", () => {
             expect(downloadDatasetSpy).toHaveBeenCalledTimes(1);
             const firstItem = listApiResponse.items[0];
             expect(downloadDatasetSpy).toHaveBeenCalledWith(dummySession, `${dsname}(${firstItem.member})`, {
-                file: `${dsFolder}/${firstItem.member.toLowerCase()}.txt`
+                file: path.posix.join(dsFolder, firstItem.member.toLowerCase() + ".txt")
             });
         });
 
@@ -1046,10 +1045,10 @@ describe("z/OS Files - Download", () => {
 
             expect(downloadDatasetSpy).toHaveBeenCalledTimes(2);
             expect(downloadDatasetSpy).toHaveBeenCalledWith(dummySession, `${dsname}(${firstItem.member})`, {
-                file: `${dsFolder}/${firstItem.member.toLowerCase()}.txt`
+                file: path.posix.join(dsFolder, firstItem.member.toLowerCase() + ".txt")
             });
             expect(downloadDatasetSpy).toHaveBeenCalledWith(dummySession, `${dsname}(${secondItem.member})`, {
-                file: `${dsFolder}/${secondItem.member.toLowerCase()}.txt`
+                file: path.posix.join(dsFolder, secondItem.member.toLowerCase() + ".txt")
             });
         });
     });
@@ -1844,7 +1843,7 @@ describe("z/OS Files - Download", () => {
                 caughtError = e;
             }
 
-            const endpoint = posix.join(ZosFilesConstants.RESOURCE, ZosFilesConstants.RES_USS_FILES, encodeURIComponent(ussname.substr(1)));
+            const endpoint = path.posix.join(ZosFilesConstants.RESOURCE, ZosFilesConstants.RES_USS_FILES, encodeURIComponent(ussname.substr(1)));
 
             expect(caughtError).toBeUndefined();
             expect(response).toEqual({
@@ -1878,7 +1877,7 @@ describe("z/OS Files - Download", () => {
                 caughtError = e;
             }
 
-            const endpoint = posix.join(ZosFilesConstants.RESOURCE, ZosFilesConstants.RES_USS_FILES, encodeURIComponent(ussname.substr(1)));
+            const endpoint = path.posix.join(ZosFilesConstants.RESOURCE, ZosFilesConstants.RES_USS_FILES, encodeURIComponent(ussname.substr(1)));
 
             expect(caughtError).toBeUndefined();
             expect(response).toEqual({
@@ -1916,7 +1915,7 @@ describe("z/OS Files - Download", () => {
                 caughtError = e;
             }
 
-            const endpoint = posix.join(ZosFilesConstants.RESOURCE, ZosFilesConstants.RES_USS_FILES, encodeURIComponent(ussname.substr(1)));
+            const endpoint = path.posix.join(ZosFilesConstants.RESOURCE, ZosFilesConstants.RES_USS_FILES, encodeURIComponent(ussname.substr(1)));
 
             expect(caughtError).toBeUndefined();
             expect(response).toEqual({
@@ -1954,7 +1953,7 @@ describe("z/OS Files - Download", () => {
                 caughtError = e;
             }
 
-            const endpoint = posix.join(ZosFilesConstants.RESOURCE, ZosFilesConstants.RES_USS_FILES, encodeURIComponent(ussname.substr(1)));
+            const endpoint = path.posix.join(ZosFilesConstants.RESOURCE, ZosFilesConstants.RES_USS_FILES, encodeURIComponent(ussname.substr(1)));
 
             expect(caughtError).toBeUndefined();
             expect(response).toEqual({
@@ -1995,7 +1994,7 @@ describe("z/OS Files - Download", () => {
                 caughtError = e;
             }
 
-            const endpoint = posix.join(ZosFilesConstants.RESOURCE, ZosFilesConstants.RES_USS_FILES, encodeURIComponent(ussname.substr(1)));
+            const endpoint = path.posix.join(ZosFilesConstants.RESOURCE, ZosFilesConstants.RES_USS_FILES, encodeURIComponent(ussname.substr(1)));
 
             expect(caughtError).toBeUndefined();
             expect(response).toEqual({
@@ -2031,7 +2030,7 @@ describe("z/OS Files - Download", () => {
                 caughtError = e;
             }
 
-            const endpoint = posix.join(ZosFilesConstants.RESOURCE, ZosFilesConstants.RES_USS_FILES, encodeURIComponent(ussname.substr(1)));
+            const endpoint = path.posix.join(ZosFilesConstants.RESOURCE, ZosFilesConstants.RES_USS_FILES, encodeURIComponent(ussname.substr(1)));
 
             expect(caughtError).toBeUndefined();
             expect(response).toEqual({
@@ -2064,7 +2063,7 @@ describe("z/OS Files - Download", () => {
                 caughtError = e;
             }
 
-            const endpoint = posix.join(ZosFilesConstants.RESOURCE, ZosFilesConstants.RES_USS_FILES, encodeURIComponent(ussname.substr(1)));
+            const endpoint = path.posix.join(ZosFilesConstants.RESOURCE, ZosFilesConstants.RES_USS_FILES, encodeURIComponent(ussname.substr(1)));
 
             expect(caughtError).toBeUndefined();
             expect(response).toEqual({
@@ -2100,7 +2099,7 @@ describe("z/OS Files - Download", () => {
                 caughtError = e;
             }
 
-            const endpoint = posix.join(ZosFilesConstants.RESOURCE, ZosFilesConstants.RES_USS_FILES, encodeURIComponent(ussname.substr(1)));
+            const endpoint = path.posix.join(ZosFilesConstants.RESOURCE, ZosFilesConstants.RES_USS_FILES, encodeURIComponent(ussname.substr(1)));
 
             expect(caughtError).toBeUndefined();
             expect(response).toEqual({
@@ -2134,7 +2133,7 @@ describe("z/OS Files - Download", () => {
                 caughtError = e;
             }
 
-            const endpoint = posix.join(ZosFilesConstants.RESOURCE, ZosFilesConstants.RES_USS_FILES, encodeURIComponent(ussname.substr(1)));
+            const endpoint = path.posix.join(ZosFilesConstants.RESOURCE, ZosFilesConstants.RES_USS_FILES, encodeURIComponent(ussname.substr(1)));
 
             expect(caughtError).toBeUndefined();
             expect(response).toEqual({
@@ -2203,7 +2202,7 @@ describe("z/OS Files - Download", () => {
 
             expect(downloadUssFileSpy).toHaveBeenCalledTimes(1);
             expect(downloadUssFileSpy).toHaveBeenCalledWith(dummySession, ussDirName + "/file1", {
-                file: join(process.cwd(), "file1")
+                file: path.join(process.cwd(), "file1")
             });
         });
 
@@ -2235,7 +2234,7 @@ describe("z/OS Files - Download", () => {
             expect(caughtError.causeErrors).toEqual(dummyError);
 
             expect(mkdirPromiseSpy).toHaveBeenCalledTimes(1);
-            expect(mkdirPromiseSpy).toHaveBeenCalledWith(join(process.cwd(), "folder1"), { recursive: true });
+            expect(mkdirPromiseSpy).toHaveBeenCalledWith(path.join(process.cwd(), "folder1"), { recursive: true });
         });
 
         it("should download USS directory with download and list options", async () => {
@@ -2271,7 +2270,7 @@ describe("z/OS Files - Download", () => {
             expect(List.fileList).toHaveBeenCalledWith(dummySession, ussDirName,
                 { name: "*", ...listOptions });
             expect(Download.ussFile).toHaveBeenCalledWith(dummySession, ussDirName + "/file1",
-                { file: join(process.cwd(), "file1"), ...fileOptions });
+                { file: path.join(process.cwd(), "file1"), ...fileOptions });
         });
 
         it("should download USS directory when failFast is false", async () => {
@@ -2344,7 +2343,7 @@ describe("z/OS Files - Download", () => {
                 apiResponse: [fakeFileResponse]
             });
             expect(Download.ussFile).toHaveBeenCalledWith(dummySession, ussDirName + "/file1",
-                { file: join(process.cwd(), "file1"), maxConcurrentRequests: 0 });
+                { file: path.join(process.cwd(), "file1"), maxConcurrentRequests: 0 });
         });
 
         it("should download USS directory excluding hidden files", async () => {

--- a/packages/zosfiles/src/methods/download/Download.ts
+++ b/packages/zosfiles/src/methods/download/Download.ts
@@ -260,7 +260,7 @@ export class Download {
                 const fileName = options.preserveOriginalLetterCase ? mem.member : mem.member.toLowerCase();
                 return this.dataSet(session, `${dataSetName}(${mem.member})`, {
                     volume: options.volume,
-                    file: baseDir + IO.FILE_DELIM + fileName + IO.normalizeExtension(extension),
+                    file: posix.join(baseDir, fileName + IO.normalizeExtension(extension)),
                     binary: options.binary,
                     record: options.record,
                     encoding: options.encoding,
@@ -269,7 +269,7 @@ export class Download {
                     downloadErrors.push(err);
                     failedMembers.push(fileName);
                     // Delete the file that could not be downloaded
-                    IO.deleteFile(baseDir + IO.FILE_DELIM + fileName + IO.normalizeExtension(extension));
+                    IO.deleteFile(join(baseDir, fileName + IO.normalizeExtension(extension)));
                     // If we should fail fast, rethrow error
                     if (options.failFast || options.failFast === undefined) {
                         throw err;

--- a/packages/zosfiles/src/utils/ZosFilesUtils.ts
+++ b/packages/zosfiles/src/utils/ZosFilesUtils.ts
@@ -46,9 +46,9 @@ export class ZosFilesUtils {
      * @param  {string} dataSet - data set to break up into folders
      */
     public static getDirsFromDataSet(dataSet: string) {
-        let localDirectory = dataSet.replace(new RegExp(`\\${this.DSN_SEP}`, "g"), IO.FILE_DELIM).toLowerCase();
+        let localDirectory = dataSet.replace(new RegExp(`\\${this.DSN_SEP}`, "g"), path.posix.sep).toLowerCase();
         if (localDirectory.indexOf("(") >= 0 && localDirectory.indexOf(")") >= 0) {
-            localDirectory = localDirectory.replace(/\(/, IO.FILE_DELIM);
+            localDirectory = localDirectory.replace(/\(/, path.posix.sep);
             localDirectory = localDirectory.slice(0, -1);
         }
         return localDirectory;

--- a/packages/zosjobs/src/DeleteJobs.ts
+++ b/packages/zosjobs/src/DeleteJobs.ts
@@ -9,7 +9,8 @@
 *
 */
 
-import { AbstractSession, ImperativeExpect, IO, Logger } from "@zowe/imperative";
+import * as path from "path";
+import { AbstractSession, ImperativeExpect, Logger } from "@zowe/imperative";
 import { JobsConstants } from "./JobsConstants";
 import { ZosmfHeaders, ZosmfRestClient } from "@zowe/core-for-zowe-sdk";
 import { IJob } from "./doc/response/IJob";
@@ -75,7 +76,7 @@ export class DeleteJobs {
             headers.push(ZosmfHeaders.X_IBM_JOB_MODIFY_VERSION_2);
         }
 
-        const parameters: string = IO.FILE_DELIM + encodeURIComponent(parms.jobname) + IO.FILE_DELIM + encodeURIComponent(parms.jobid);
+        const parameters: string = path.posix.sep + encodeURIComponent(parms.jobname) + path.posix.sep + encodeURIComponent(parms.jobid);
         const responseJson = await ZosmfRestClient.deleteExpectJSON(session, JobsConstants.RESOURCE + parameters, headers);
 
         if (parms.modifyVersion === "2.0") {

--- a/packages/zosjobs/src/DownloadJobs.ts
+++ b/packages/zosjobs/src/DownloadJobs.ts
@@ -9,6 +9,7 @@
 *
 */
 
+import * as path from "path";
 import { AbstractSession, ImperativeExpect, IO, Logger } from "@zowe/imperative";
 import { JobsConstants } from "./JobsConstants";
 import { IDownloadAllSpoolContentParms } from "./doc/input/IDownloadAllSpoolContentParms";
@@ -141,20 +142,20 @@ export class DownloadJobs {
         let directory: string = parms.outDir ?? DownloadJobs.DEFAULT_JOBS_OUTPUT_DIR;
 
         if (parms.omitJobidDirectory == null || parms.omitJobidDirectory === false) {
-            directory += IO.FILE_DELIM + parms.jobFile.jobid;
+            directory += path.posix.sep + parms.jobFile.jobid;
         }
 
         if (parms.jobFile.procstep != null) {
-            directory += IO.FILE_DELIM + parms.jobFile.procstep;
+            directory += path.posix.sep + parms.jobFile.procstep;
         }
 
         if (parms.jobFile.stepname != null) {
-            directory += IO.FILE_DELIM + parms.jobFile.stepname;
+            directory += path.posix.sep + parms.jobFile.stepname;
         }
 
         const extension = parms.extension ?? DownloadJobs.DEFAULT_JOBS_OUTPUT_FILE_EXT;
 
-        return directory + IO.FILE_DELIM + parms.jobFile.ddname + extension;
+        return directory + path.posix.sep + parms.jobFile.ddname + extension;
     }
 
     /**


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->
Fixes https://github.com/zowe/zowe-cli/issues/2116

TODO:
* [x] ~Update default log location in ZE to match~
  * ZE already stores them in the same folder but a different location: `~/.vscode/extensions/zowe.vscode-extension-for-zowe-X.Y.Z/logs`
* [ ] Update default log location in Zowe docs

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->
Build the CLI from this PR and verify that logs are generated in the new location:
* `~/.zowe/logs/imperative.log`
* `~/.zowe/logs/zowe.log`

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [x] added/updated automated tests
- [x] updated the changelog
- [ ] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
