### PR TITLE
Display messages before prompting for properties

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Zowe CLI package will be documented in this file.
 
+## Recent Changes
+
+- LTS Breaking: Add informative messages identifying why a user is being prompted for connection property values during a CLI command.
+
 ## `8.0.0-next.202404032038`
 
 - BugFix: Fixed error in `zos-files list all-members` command that could occur when members contain control characters in the name. [#2104](https://github.com/zowe/zowe-cli/pull/2104)

--- a/packages/imperative/CHANGELOG.md
+++ b/packages/imperative/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Imperative package will be documented in this file.
 
+## Recent Changes
+
+- Enhancement: Add informative messages before prompting for connection property values in the CLI callback function getValuesBack.
+
 ## `8.0.0-next.202404191414`
 
 - Enhancement: Added a new class named ConvertV1Profiles to enable other apps to better convert V1 profiles into a current Zowe config file.

--- a/packages/imperative/src/imperative/__tests__/config/cmd/auto-init/BaseAutoInitHandler.unit.test.ts
+++ b/packages/imperative/src/imperative/__tests__/config/cmd/auto-init/BaseAutoInitHandler.unit.test.ts
@@ -10,7 +10,7 @@
 */
 
 import { IHandlerParameters } from "../../../../../cmd";
-import { ImperativeConfig, ProcessUtils } from "../../../../../utilities";
+import { ImperativeConfig, ProcessUtils, TextUtils } from "../../../../../utilities";
 import { FakeAutoInitHandler } from "./__data__/FakeAutoInitHandler";
 import * as lodash from "lodash";
 import * as jestDiff from "jest-diff";
@@ -57,6 +57,21 @@ describe("BaseAutoInitHandler", () => {
             }
         };
         stripAnsiSpy = (stripAnsi as any).mockImplementation(() => jest.requireActual("strip-ansi"));
+
+        // Pretend that wordWrap and chalk work. We do not care about their output in these tests
+        const wordWrapSpy = jest.spyOn(TextUtils, "wordWrap")
+            .mockReturnValue("Fake wrapped text");
+
+        Object.defineProperty(TextUtils, "chalk", {
+            configurable: true,
+            get: jest.fn(() => {
+                return {
+                    yellowBright: jest.fn(() => {
+                        return "Fake yellow in some text";
+                    })
+                };
+            })
+        });
     });
 
     afterEach(() => {

--- a/packages/imperative/src/imperative/__tests__/config/cmd/auto-init/BaseAutoInitHandler.unit.test.ts
+++ b/packages/imperative/src/imperative/__tests__/config/cmd/auto-init/BaseAutoInitHandler.unit.test.ts
@@ -58,9 +58,8 @@ describe("BaseAutoInitHandler", () => {
         };
         stripAnsiSpy = (stripAnsi as any).mockImplementation(() => jest.requireActual("strip-ansi"));
 
-        // Pretend that wordWrap and chalk work. We do not care about their output in these tests
-        const wordWrapSpy = jest.spyOn(TextUtils, "wordWrap")
-            .mockReturnValue("Fake wrapped text");
+        // Pretend that wordWrap and chalk work. We do not care about their output in these tests.
+        jest.spyOn(TextUtils, "wordWrap").mockReturnValue("Fake wrapped text");
 
         Object.defineProperty(TextUtils, "chalk", {
             configurable: true,

--- a/packages/imperative/src/rest/__tests__/session/ConnectionPropsForSessCfg.unit.test.ts
+++ b/packages/imperative/src/rest/__tests__/session/ConnectionPropsForSessCfg.unit.test.ts
@@ -1472,8 +1472,8 @@ describe("ConnectionPropsForSessCfg tests", () => {
             await getValuesCallBack(["hostname"]);
 
             expect(consoleMsgs).toContain("No Zowe client configuration exists.");
-            expect(consoleMsgs).toContain("Therefore, you will be asked for the connection properties");
-            expect(consoleMsgs).toContain("that are required to complete your command.");
+            expect(consoleMsgs).toContain("Therefore, you will be asked for the");
+            expect(consoleMsgs).toContain("connection properties that are required to complete your command.");
         });
 
         it("should state that V1 profiles are not supported", async () => {
@@ -1500,10 +1500,9 @@ describe("ConnectionPropsForSessCfg tests", () => {
             // call the function that we want to test
             await getValuesCallBack(["hostname"]);
 
-            expect(consoleMsgs).toContain("Only V1 profiles exist. V1 profiles are no longer supported.");
-            expect(consoleMsgs).toContain("You should convert your V1 profiles to a newer Zowe client configuration.");
-            expect(consoleMsgs).toContain("Therefore, you will be asked for the connection properties");
-            expect(consoleMsgs).toContain("that are required to complete your command.");
+            expect(consoleMsgs).toContain("Only V1 profiles exist. V1 profiles are no longer supported. You should convert");
+            expect(consoleMsgs).toContain("your V1 profiles to a newer Zowe client configuration. Therefore, you will be");
+            expect(consoleMsgs).toContain("asked for the connection properties that are required to complete your command.");
         });
 
         it("should state that connection properties are missing from config", async () => {
@@ -1530,10 +1529,9 @@ describe("ConnectionPropsForSessCfg tests", () => {
             // call the function that we want to test
             await getValuesCallBack(["hostname"]);
 
-            expect(consoleMsgs).toContain("Some required connection properties have not been specified");
-            expect(consoleMsgs).toContain("in your Zowe client configuration.");
-            expect(consoleMsgs).toContain("Therefore, you will be asked for the connection properties");
-            expect(consoleMsgs).toContain("that are required to complete your command.");
+            expect(consoleMsgs).toContain("Some required connection properties have not been specified in your Zowe client");
+            expect(consoleMsgs).toContain("configuration. Therefore, you will be asked for the connection properties that");
+            expect(consoleMsgs).toContain("are required to complete your command.");
         });
     });
 });

--- a/packages/imperative/src/rest/src/session/ConnectionPropsForSessCfg.ts
+++ b/packages/imperative/src/rest/src/session/ConnectionPropsForSessCfg.ts
@@ -360,30 +360,31 @@ export class ConnectionPropsForSessCfg {
      */
     private static getValuesBack(connOpts: IOptionsForAddConnProps): (properties: string[]) => Promise<{ [key: string]: any }> {
         return async (promptForValues: string[]) => {
-            /* ToDo: Uncomment this code block to display an informative message before prompting
-             * a user for connection values. Because 219 unit test fails and 144 system tests
-             * fail due to a minor difference in output, we chose not to implement this
-             * minor enhancement until we have time to devote to correcting so many tests.
-             *
-             * The following 'if' statement is only needed for tests which do not create a mock for
-             * the connOpts.parms.response.console.log property. In the real world, that property
-             * always exists for this CLI-only path of logic.
-             *
-            if (connOpts?.parms?.response?.console?.log) {
-                // we want to prompt for connection values, but first complain if user only has V1 profiles.
-                connOpts.parms.response.console.log("No Zowe client configuration exists.");
-                if (ConfigUtils.onlyV1ProfilesExist) {
+            /* The check for console.log in the following 'if' statement is only needed for tests
+             * which do not create a mock for the connOpts.parms.response.console.log property.
+             * In the real world, that property always exists for this CLI-only path of logic.
+             */
+            if (promptForValues.length > 0 && connOpts?.parms?.response?.console?.log) {
+                // We need to prompt for some values. Determine why we need to prompt.
+                if (ImperativeConfig.instance.config?.exists) {
+                    connOpts.parms.response.console.log(
+                        "Some required connection properties have not been specified\n" +
+                        "in your Zowe client configuration."
+                    );
+                } else if (ConfigUtils.onlyV1ProfilesExist) {
+                    // complain if user only has V1 profiles.
                     connOpts.parms.response.console.log(
                         "Only V1 profiles exist. V1 profiles are no longer supported.\n" +
                         "You should convert your V1 profiles to a newer Zowe client configuration."
                     );
+                } else {
+                    connOpts.parms.response.console.log("No Zowe client configuration exists.");
                 }
                 connOpts.parms.response.console.log(
                     "Therefore, you will be asked for the connection properties\n" +
                     "that are required to complete your command.\n"
                 );
             }
-            */
 
             const answers: { [key: string]: any } = {};
             const profileSchema = this.loadSchemaForSessCfgProps(connOpts.parms, promptForValues);

--- a/packages/imperative/src/rest/src/session/ConnectionPropsForSessCfg.ts
+++ b/packages/imperative/src/rest/src/session/ConnectionPropsForSessCfg.ts
@@ -9,7 +9,7 @@
 *
 */
 
-import { CliUtils, ImperativeConfig } from "../../../utilities";
+import { CliUtils, ImperativeConfig, TextUtils } from "../../../utilities";
 import { ICommandArguments, IHandlerParameters } from "../../../cmd";
 import { ImperativeError } from "../../../error";
 import { IOptionsForAddConnProps } from "./doc/IOptionsForAddConnProps";
@@ -20,7 +20,6 @@ import { ISession } from "./doc/ISession";
 import { IProfileProperty } from "../../../profiles";
 import { ConfigAutoStore } from "../../../config/src/ConfigAutoStore";
 import { ConfigUtils } from "../../../config/src/ConfigUtils";
-import { TextUtils } from "../../../utilities";
 
 /**
  * Extend options for IPromptOptions for internal wrapper method

--- a/packages/imperative/src/rest/src/session/ConnectionPropsForSessCfg.ts
+++ b/packages/imperative/src/rest/src/session/ConnectionPropsForSessCfg.ts
@@ -20,6 +20,7 @@ import { ISession } from "./doc/ISession";
 import { IProfileProperty } from "../../../profiles";
 import { ConfigAutoStore } from "../../../config/src/ConfigAutoStore";
 import { ConfigUtils } from "../../../config/src/ConfigUtils";
+import { TextUtils } from "../../../utilities";
 
 /**
  * Extend options for IPromptOptions for internal wrapper method
@@ -366,23 +367,21 @@ export class ConnectionPropsForSessCfg {
              */
             if (promptForValues.length > 0 && connOpts?.parms?.response?.console?.log) {
                 // We need to prompt for some values. Determine why we need to prompt.
+                let reasonForPrompts: string = "";
                 if (ImperativeConfig.instance.config?.exists) {
-                    connOpts.parms.response.console.log(
-                        "Some required connection properties have not been specified\n" +
-                        "in your Zowe client configuration."
-                    );
+                    reasonForPrompts += "Some required connection properties have not been specified " +
+                        "in your Zowe client configuration. ";
                 } else if (ConfigUtils.onlyV1ProfilesExist) {
-                    // complain if user only has V1 profiles.
-                    connOpts.parms.response.console.log(
-                        "Only V1 profiles exist. V1 profiles are no longer supported.\n" +
-                        "You should convert your V1 profiles to a newer Zowe client configuration."
-                    );
+                    reasonForPrompts += "Only V1 profiles exist. V1 profiles are no longer supported. " +
+                        "You should convert your V1 profiles to a newer Zowe client configuration. ";
                 } else {
-                    connOpts.parms.response.console.log("No Zowe client configuration exists.");
+                    reasonForPrompts += "No Zowe client configuration exists. ";
                 }
-                connOpts.parms.response.console.log(
-                    "Therefore, you will be asked for the connection properties\n" +
-                    "that are required to complete your command.\n"
+
+                reasonForPrompts += "Therefore, you will be asked for the connection properties " +
+                    "that are required to complete your command.\n";
+                connOpts.parms.response.console.log(TextUtils.wordWrap(
+                    TextUtils.chalk.yellowBright(reasonForPrompts))
                 );
             }
 

--- a/packages/imperative/src/utilities/src/TextUtils.ts
+++ b/packages/imperative/src/utilities/src/TextUtils.ts
@@ -36,7 +36,9 @@ export class TextUtils {
      *                                  by the user's terminal
      * @returns {number} - the width that will work best for the user's terminal
      */
-    public static getRecommendedWidth(preferredWidth: number = TextUtils.DEFAULT_WRAP_WIDTH): number {
+    public static getRecommendedWidth(
+        preferredWidth: number = process.stdout.columns ? process.stdout.columns : TextUtils.DEFAULT_WRAP_WIDTH
+    ): number {
         const widthSafeGuard = 8; // prevent partial words from continuing over lines
         const yargs = require("yargs");
         const maxWidth = !isNullOrUndefined(yargs.terminalWidth() && yargs.terminalWidth() > 0) ?

--- a/packages/imperative/src/utilities/src/TextUtils.ts
+++ b/packages/imperative/src/utilities/src/TextUtils.ts
@@ -37,7 +37,7 @@ export class TextUtils {
      * @returns {number} - the width that will work best for the user's terminal
      */
     public static getRecommendedWidth(
-        preferredWidth: number = process.stdout.columns ? process.stdout.columns : TextUtils.DEFAULT_WRAP_WIDTH
+        preferredWidth: number = process?.stdout?.columns ? process.stdout.columns : TextUtils.DEFAULT_WRAP_WIDTH
     ): number {
         const widthSafeGuard = 8; // prevent partial words from continuing over lines
         const yargs = require("yargs");


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->

Display informative messages identifying why a user is being prompted for connection properties during a CLI command

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->

Create a situation where some connection properties are missing. Run a Zowe command. See the messages before the prompts.

Three scenarios exist in which messages are displayed.

1. You have no configuration of any type. Note that unless your zosmf port is the default 443 value, the command will fail. This is the pre-existing behavior of Zowe CLI.
```
zowe zos-files list data-set "SYS1.PARMLIB*"
No Zowe client configuration exists.
Therefore, you will be asked for the connection properties
that are required to complete your command.

Enter the host name of your service: YourHostName
Enter the user name for your service (will be hidden):
Enter the password for your service (will be hidden):
```

2. You only have V1 profiles. Same behavior regarding the zosmf port.
```
zowe zos-files list data-set "SYS1.PARMLIB*"
Only V1 profiles exist. V1 profiles are no longer supported.
You should convert your V1 profiles to a newer Zowe client configuration.
Therefore, you will be asked for the connection properties
that are required to complete your command.

Enter the host name of your service: YourHostName
Enter the user name for your service (will be hidden):
Enter the password for your service (will be hidden):
```

3. Some properties are missing in your zowe.config.json file. In this example, hostname is missing, and autoStore is true.
```
zowe zos-files list data-set "SYS1.PARMLIB*"
Some required connection properties have not been specified
in your Zowe client configuration.
Therefore, you will be asked for the connection properties
that are required to complete your command.

Enter the host name of your service: YourHostName
Stored properties in C:\path\to\your\config\directory\zowe.config.json: host
SYS1.PARMLIB
SYS1.PARMLIB.ARCHIVE
SYS1.PARMLIB.NEW
SYS1.PARMLIBN

```

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [x] added/updated automated tests
- [x] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
