### PR TITLE
Restore precedence of token over password in AbstractRestClient - V3

### DIFF
--- a/packages/imperative/CHANGELOG.md
+++ b/packages/imperative/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Imperative package will be documented in this file.
 
+## Recent Changes
+
+- BugFix: Restore the previous precedence of token over password in AbstractRestClient [#2109](https://github.com/zowe/zowe-cli/issues/2109)
+
 ## `8.0.0-next.202404301428`
 
 - Enhancement: Add informative messages before prompting for connection property values in the CLI callback function getValuesBack.

--- a/packages/imperative/src/rest/__tests__/client/RestClient.unit.test.ts
+++ b/packages/imperative/src/rest/__tests__/client/RestClient.unit.test.ts
@@ -23,6 +23,7 @@ import { RestClientError } from "../../src/client/RestClientError";
 import { IOptionsFullResponse } from "../../src/client/doc/IOptionsFullResponse";
 import { IRestClientResponse } from "../../src/client/doc/IRestClientResponse";
 import { CLIENT_PROPERTY } from "../../src/client/types/AbstractRestClientProperties";
+import { AbstractRestClient } from "../../src/client/AbstractRestClient";
 
 /**
  * RestClient is already tested vie the AbstractRestClient test, so we will extend RestClient
@@ -30,8 +31,14 @@ import { CLIENT_PROPERTY } from "../../src/client/types/AbstractRestClientProper
  */
 
 describe("RestClient tests", () => {
+    let setPasswordAuthSpy: any;
+
     beforeEach(() => {
         jest.clearAllMocks();
+
+        // pretend that basic auth was successfully set
+        setPasswordAuthSpy = jest.spyOn(AbstractRestClient.prototype as any, "setPasswordAuth");
+        setPasswordAuthSpy.mockReturnValue(true);
     });
 
     it("should add our custom header", async () => {

--- a/packages/imperative/src/rest/src/session/doc/ISession.ts
+++ b/packages/imperative/src/rest/src/session/doc/ISession.ts
@@ -171,4 +171,18 @@ export interface ISession {
      * @memberof ISession
      */
     storeCookie?: boolean;
+
+    /**
+     * Specifies the order of precedence for using different authentication types in this
+     * session. The order in the array determines which credential type is preferred.
+     * The type in authTypeOrder[0] is used first, authTypeOrder[1] second, etc.
+     * Values are specified using SessConstants.AUTH_TYPE_XXX values.
+     *
+     * The authTypeOrder property is currently controlled (hard-coded) within Zowe SDK functions.
+     * More control for Zowe consumers is anticipated in the future.
+     *
+     * @type {string[]}
+     * @memberof ISession
+     */
+    authTypeOrder?: string[];
 }


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->

Implements the same changes into V3 as the following pull request did in V2:
Reinstate token precedence over password in AbstractRestClient #2119

Related issue : Breaking Change in User/Password/Token Order of Precedence #2109 (already closed)

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [x] added/updated automated tests
- [x] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
