### PR TITLE
fix/dev(v1): Fix gulp build tasks failing on Windows

### DIFF
--- a/gulp/DevelopmentTasks.ts
+++ b/gulp/DevelopmentTasks.ts
@@ -16,9 +16,7 @@ import { DefaultHelpGenerator, Imperative, ImperativeConfig } from "../packages/
 
 import { CliConstants } from "../packages/cli/src/CliConstants";
 
-// "npx" command allows us to issue CLIs from node_modules dependencies
-// without globally installing.
-const npx = "npx" + (require("os").platform() === "win32" ? ".cmd" : ""); // platform dependent extension for npx command
+const npm = "npm" + (require("os").platform() === "win32" ? ".cmd" : ""); // platform dependent extension for npm command
 
 const gulp = require('gulp');
 const ansiColors = require("ansi-colors");
@@ -33,7 +31,7 @@ const clearRequire = require("clear-require");
 const lint: ITaskFunction = (done) => {
     let lintProcess: SpawnSyncReturns<string>;
     try {
-        lintProcess = childProcess.spawnSync("npm", ["run", "lint"], {stdio: "inherit", shell: true});
+        lintProcess = childProcess.spawnSync(npm, ["run", "lint"], {stdio: "inherit", shell: true});
 
     } catch (e) {
         fancylog(ansiColors.red("Error encountered trying to run eslint"));
@@ -284,8 +282,8 @@ const buildAllClis: ITaskFunction = async () => {
     cliDirs.forEach((dir) => {
         // Build them all
         fancylog(`Build "${dir}" cli...`);
-        const buildResponse = childProcess.spawnSync((process.platform === "win32") ? "npm.cmd" : "npm", ["run", "build"],
-            {cwd: imperativeDirectory + `__tests__/__integration__/${dir}/`, stdio: "inherit"});
+        const buildResponse = childProcess.spawnSync(npm, ["run", "build"],
+            {cwd: imperativeDirectory + `__tests__/__integration__/${dir}/`, stdio: "inherit", shell: true});
         if (buildResponse.stdout && buildResponse.stdout.toString().length > 0) {
             fancylog(`***BUILD "${dir}" stdout:\n${buildResponse.stdout.toString()}`);
         }
@@ -311,8 +309,8 @@ const installAllCliDependencies: ITaskFunction = async () => {
     cliDirs.forEach((dir) => {
         // Perform an NPM install
         fancylog(`Executing "npm install" for "${dir}" cli to obtain dependencies...`);
-        const installResponse = childProcess.spawnSync((process.platform === "win32") ? "npm.cmd" : "npm", ["install"],
-            {cwd: imperativeDirectory + `__tests__/__integration__/${dir}/`, stdio: "inherit"});
+        const installResponse = childProcess.spawnSync(npm, ["install"],
+            {cwd: imperativeDirectory + `__tests__/__integration__/${dir}/`, stdio: "inherit", shell: true});
         if (installResponse.stdout && installResponse.stdout.toString().length > 0) {
             fancylog(`***INSTALL "${dir}" stdout:\n${installResponse.stdout.toString()}`);
         }


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->
Fixes gulp build tasks that invoke `npm.cmd` on Windows (see failing build [here](https://github.com/zowe/zowe-cli/actions/runs/8940668546/job/24559269093))

For details about why they broke in Node 20.12.2, see https://nodejs.org/en/blog/vulnerability/april-2024-security-releases-2

The `shell: true` is not best practices for security, but it's the easiest workaround and I think it's fine in v1-only dev scripts where we were already using it.

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->
If using Windows, upgrade to Node 20.12.2 or newer and verify that the zowe-v1-lts branch is able to build successfully with these changes

**Review Checklist**
I certify that I have:
- [ ] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [ ] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)

**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
- https://github.com/nodejs/node/issues/52681
- https://github.com/sindresorhus/execa/issues/987