### PR TITLE
Fix Data-Set Search

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the Zowe CLI package will be documented in this file.
 
 ## Recent Changes
 
-- BugFix: Fixed a bug where a dataset search would not return a search term if it was at the beginning of a line. []()
+- BugFix: Fixed a bug where a data set search would not return a search term if it was at the beginning of a line. [#2147](https://github.com/zowe/zowe-cli/pull/2147)
 
 ## `8.0.0-next.202405101931`
 

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Zowe CLI package will be documented in this file.
 
+## Recent Changes
+
+- BugFix: Fixed a bug where a dataset search would not return a search term if it was at the beginning of a line. []()
+
 ## `8.0.0-next.202405101931`
 
 - Enhancement: Added the ability to search for a string in a data set or PDS member matching a pattern with the `zowe zos-files search data-sets` comamnd.[#2095](https://github.com/zowe/zowe-cli/issues/2095)

--- a/packages/zosfiles/CHANGELOG.md
+++ b/packages/zosfiles/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Zowe z/OS files SDK package will be documented in this file.
 
+## Recent Changes
+
+- BugFix: Fixed a bug where a dataset search would not return a search term if it was at the beginning of a line. []()
+
 ## `8.0.0-next.202405101931`
 
 - Enhancement: Added the ability to search for a string in a data set or PDS member matching a pattern. [#2095](https://github.com/zowe/zowe-cli/issues/2095)

--- a/packages/zosfiles/CHANGELOG.md
+++ b/packages/zosfiles/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the Zowe z/OS files SDK package will be documented in thi
 
 ## Recent Changes
 
-- BugFix: Fixed a bug where a dataset search would not return a search term if it was at the beginning of a line. []()
+- BugFix: Fixed a bug where a data set search would not return a search term if it was at the beginning of a line. [#2147](https://github.com/zowe/zowe-cli/pull/2147)
 
 ## `8.0.0-next.202405101931`
 

--- a/packages/zosfiles/src/methods/search/Search.ts
+++ b/packages/zosfiles/src/methods/search/Search.ts
@@ -327,9 +327,11 @@ export class Search {
 
                     if (searchLine.includes(searchOptions.searchString)) {
                         let lastCol = 0;
+                        let lastColIndexPlusLen = 0;
                         while (lastCol != -1) {
-                            const column = searchLine.indexOf(searchOptions.searchString, lastCol + searchOptions.searchString.length);
+                            const column = searchLine.indexOf(searchOptions.searchString, lastColIndexPlusLen);
                             lastCol = column;
+                            lastColIndexPlusLen = column + searchOptions.searchString.length;
                             if (column != -1) {
                                 // Append the real line - 1 indexed
                                 indicies.push({line: lineNum + 1, column: column + 1, contents: line});


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->
Fixes a logic error that results in search terms toward the beginning of a line not being found
Implements @adam-wolfe's suggested solution and adds regression tests

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [x] added/updated automated tests
- [x] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
