### PR TITLE
Display daemon messages on standard error

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -2,13 +2,17 @@
 
 All notable changes to the Zowe CLI package will be documented in this file.
 
+## Recent Changes
+
+- LTS Breaking: Send all Zowe Daemon informational messages, progress messages, and error messages to standard error instead of standard output [#1451](https://github.com/zowe/zowe-cli/issues/1451)
+
 ## `8.0.0-next.202405202020`
 
 - BugFix: Fixed a bug where a data set search would not return a search term if it was at the beginning of a line. [#2147](https://github.com/zowe/zowe-cli/pull/2147)
 
 ## `8.0.0-next.202405101931`
 
-- Enhancement: Added the ability to search for a string in a data set or PDS member matching a pattern with the `zowe zos-files search data-sets` comamnd.[#2095](https://github.com/zowe/zowe-cli/issues/2095)
+- Enhancement: Added the ability to search for a string in a data set or PDS member matching a pattern with the `zowe zos-files search data-sets` command.[#2095](https://github.com/zowe/zowe-cli/issues/2095)
 
 ## `8.0.0-next.202405061946`
 

--- a/zowex/Cargo.lock
+++ b/zowex/Cargo.lock
@@ -830,7 +830,7 @@ checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
 
 [[package]]
 name = "zowe"
-version = "1.2.2"
+version = "1.2.3"
 dependencies = [
  "base64",
  "fslock",

--- a/zowex/Cargo.toml
+++ b/zowex/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zowe"
-version = "1.2.2"
+version = "1.2.3"
 authors = ["Zowe Project"]
 edition = "2018"
 license = "EPL-2.0"

--- a/zowex/src/comm.rs
+++ b/zowex/src/comm.rs
@@ -9,7 +9,7 @@
 *
 */
 
-// Functions related to daemon cummunication.
+// Functions related to daemon communication.
 
 use std::io;
 use std::io::prelude::*;
@@ -96,11 +96,11 @@ pub async fn comm_establish_connection(
                 we_started_daemon = true;
                 cmd_to_show = proc_start_daemon(njs_zowe_path);
             } else if we_started_daemon && conn_retries > THREE_MIN_OF_RETRIES {
-                println!(
+                eprintln!(
                     "The Zowe daemon that we started is not running on socket: {}.",
                     daemon_socket
                 );
-                println!(
+                eprintln!(
                     "Command used to start the Zowe daemon was:\n    {}\nTerminating.",
                     cmd_to_show
                 );
@@ -115,7 +115,7 @@ pub async fn comm_establish_connection(
         };
 
         if conn_retries > 0 {
-            println!(
+            eprintln!(
                 "{} ({} of {})",
                 retry_msg, conn_retries, THREE_MIN_OF_RETRIES
             );
@@ -124,7 +124,7 @@ pub async fn comm_establish_connection(
         conn_retries += 1;
 
         if conn_retries > THREE_MIN_OF_RETRIES {
-            println!(
+            eprintln!(
                 "Terminating after {} connection retries.",
                 THREE_MIN_OF_RETRIES
             );
@@ -136,13 +136,13 @@ pub async fn comm_establish_connection(
 
         // before we wait too long, show diagnostics
         if conn_retries == RETRY_TO_SHOW_DIAG {
-            println!("\nThe Zowe daemon was started with these options:");
+            eprintln!("\nThe Zowe daemon was started with these options:");
             if we_started_daemon {
-                println!("Command = {}", cmd_to_show);
+                eprintln!("Command = {}", cmd_to_show);
             } else {
-                println!("Command = {}", daemon_proc_info.cmd);
+                eprintln!("Command = {}", daemon_proc_info.cmd);
             }
-            println!(
+            eprintln!(
                 "Process name = {}  pid = {}  socket = {}\n",
                 daemon_proc_info.name, daemon_proc_info.pid, daemon_socket
             );

--- a/zowex/src/proc.rs
+++ b/zowex/src/proc.rs
@@ -196,7 +196,7 @@ fn read_pid_for_user() -> Option<sysinfo::Pid> {
         Ok(ok_val) => ok_val,
         Err(err_val) => {
             // we should not continue if we cannot open an existing pid file
-            println!(
+            eprintln!(
                 "Unable to open file = {}\nDetails = {}",
                 pid_file_path.display(),
                 err_val
@@ -209,7 +209,7 @@ fn read_pid_for_user() -> Option<sysinfo::Pid> {
         Ok(ok_val) => ok_val,
         Err(err_val) => {
             // we should not continue if we cannot read an existing pid file
-            println!(
+            eprintln!(
                 "Unable to read file = {}\nDetails = {}",
                 pid_file_path.display(),
                 err_val
@@ -222,7 +222,7 @@ fn read_pid_for_user() -> Option<sysinfo::Pid> {
 
     if daemon_pid_for_user.user != executor {
         // our pid file should only contain our own user name
-        println!(
+        eprintln!(
             "User name of '{}' in file '{}' does not match current user = '{}'.",
             daemon_pid_for_user.user,
             pid_file_path.display(),
@@ -273,11 +273,11 @@ fn read_pid_for_user() -> Option<sysinfo::Pid> {
  */
 
 pub fn proc_start_daemon(njs_zowe_path: &str) -> String {
-    println!("Starting a background process to increase performance ...");
+    eprintln!("Starting a background process to increase performance ...");
 
     let daemon_arg = LAUNCH_DAEMON_OPTION;
     let mut cmd = Command::new(njs_zowe_path);
-    
+
     // Uses creation flags from https://learn.microsoft.com/en-us/windows/win32/procthread/process-creation-flags
     // Flags are CREATE_NO_WINDOW, CREATE_NEW_PROCESS_GROUP, and CREATE_UNICODE_ENVIRONMENT
     #[cfg(target_family = "windows")]
@@ -291,11 +291,11 @@ pub fn proc_start_daemon(njs_zowe_path: &str) -> String {
     {
         Ok(_unused) => { /* nothing to do */ }
         Err(error) => {
-            println!(
+            eprintln!(
                 "Failed to start the following process:\n    {} {}",
                 njs_zowe_path, daemon_arg
             );
-            println!("Due to this error:\n    {}", error);
+            eprintln!("Due to this error:\n    {}", error);
             std::process::exit(EXIT_CODE_CANNOT_START_DAEMON);
         }
     };

--- a/zowex/src/util.rs
+++ b/zowex/src/util.rs
@@ -44,7 +44,7 @@ pub fn util_get_nodejs_zowe_path() -> String {
      */
     let my_exe_result = env::current_exe();
     if my_exe_result.is_err() {
-        println!("Unable to get path to my own executable. Terminating.");
+        eprintln!("Unable to get path to my own executable. Terminating.");
         std::process::exit(EXIT_CODE_CANNOT_GET_MY_PATH);
     }
     let my_exe_path_buf = my_exe_result.unwrap();
@@ -73,8 +73,8 @@ pub fn util_get_nodejs_zowe_path() -> String {
         break;
     }
     if njs_zowe_path == NOT_FOUND {
-        println!("Could not find a NodeJS zowe command on your path.");
-        println!("Will not be able to run Zowe commands. Terminating.");
+        eprintln!("Could not find a NodeJS zowe command on your path.");
+        eprintln!("Will not be able to run Zowe commands. Terminating.");
         std::process::exit(EXIT_CODE_NO_NODEJS_ZOWE_ON_PATH);
     }
 
@@ -96,7 +96,7 @@ pub fn util_get_daemon_dir() -> Result<PathBuf, i32> {
         match home_dir() {
             Some(path_buf_val) => daemon_dir = path_buf_val,
             None => {
-                println!("Unable to get user's home directory.");
+                eprintln!("Unable to get user's home directory.");
                 return Err(EXIT_CODE_ENV_ERROR);
             }
         }
@@ -106,11 +106,11 @@ pub fn util_get_daemon_dir() -> Result<PathBuf, i32> {
 
     if !daemon_dir.exists() {
         if let Err(err_val) = std::fs::create_dir_all(&daemon_dir) {
-            println!(
+            eprintln!(
                 "Unable to create zowe daemon directory = {}.",
                 &daemon_dir.display()
             );
-            println!("Reason = {}.", err_val);
+            eprintln!("Reason = {}.", err_val);
             return Err(EXIT_CODE_FILE_IO_ERROR);
         }
     }
@@ -178,6 +178,6 @@ pub fn util_terminal_supports_color() -> i32 {
             return 1;
         }
     }
-    
+
     0
 }


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->

The zowe executable, which controls the daemon, now sends all informational messages, progress messages, and error messages to standard error instead of standard output.

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->

On Linux, you can run a command that starts the daemon and observe that the "starting" message goes to standard error.

```
$ zowe --version 2>stderr.txt
CLI Version: 8.0.0-next.202405161750
Zowe Release Version: V3

$ type stderr.txt
Starting a background process to increase performance ...
```

On Windows, redirecting stdout or stderr on a Zowe command when the daemon is being started locks stdout and stderr until the daemon process is terminated. The Zowe command hangs until the daemon is terminated. This is existing daemon behavior. Instead, run one Zowe command just to start the daemon. You can then redirect stdout and stderr on subsequent Zowe commands.

```
> zowe --version
Starting a background process to increase performance ...
CLI Version: 8.0.0-next.202405161750
Zowe Release Version: V3

# Now that the daemon is running, you can redirect stdout or stderr on Zowe commands.
# Corrupt your environment to cause a daemon communication error, which will
# display an error message on stderr.
#
# In File Explorer, on the file C:\Users\YourUserName\.zowe\daemon\daemon.lock,
# RightClick - Properties - Security - Edit
# Select your user name. Check the following 'Deny' boxes:
# Read & execute, Read, and Write

> zowe --version
Unable to create zowe daemon lock file = C:\Users\ej608771\.zowe\daemon\daemon.lock.
Reason = Access is denied. (os error 5).

> zowe --version 2> stderr.txt
> type stderr.txt
Unable to create zowe daemon lock file = C:\Users\ej608771\.zowe\daemon\daemon.lock.
Reason = Access is denied. (os error 5).

# Undo your changes if you want to run a daemon command ever again.
```

You can also confirm that the daemon's executable version number continues to be displayed on standard output.

```
> zowe --version-exe
1.2.3

> zowe --version-exe > stdout.txt
> type stdout.txt
1.2.3
```

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [x] added/updated automated tests
- [x] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->

Similar system tests fail on the master branch when run as daemon. My conclusion is that the system tests have not been affected by this change.