### PR TITLE
Fix Secrets SDK CI to work with MacOS ARM runners

### DIFF
--- a/.github/workflows/secrets-sdk.yml
+++ b/.github/workflows/secrets-sdk.yml
@@ -207,6 +207,7 @@ jobs:
             target: aarch64-apple-darwin
           - host: macos-latest
             target: x86_64-apple-darwin
+            architecture: x64
           - host: ubuntu-latest
             target: x86_64-unknown-linux-gnu
           - host: ubuntu-latest
@@ -232,6 +233,7 @@ jobs:
           node-version: ${{ matrix.node }}
           check-latest: true
           cache: npm
+          architecture: ${{ matrix.settings.architecture }}
       - name: Install dependencies
         run: npm ci --ignore-scripts
       - name: Download artifacts

--- a/.github/workflows/secrets-sdk.yml
+++ b/.github/workflows/secrets-sdk.yml
@@ -29,10 +29,9 @@ jobs:
         settings:
           - host: macos-latest
             target: x86_64-apple-darwin
-            build: |
-              npm run build
+            build: npm run build -- --target x86_64-apple-darwin
           - host: windows-latest
-            build: npm run build
+            build: npm run build -- --target x86_64-pc-windows-msvc
             target: x86_64-pc-windows-msvc
           - host: windows-latest
             build: |
@@ -67,13 +66,7 @@ jobs:
               CARGO=cross npm run build -- --target x86_64-unknown-linux-musl
           - host: macos-latest
             target: aarch64-apple-darwin
-            build: |
-              sudo rm -Rf /Library/Developer/CommandLineTools/SDKs/*;
-              export CC=$(xcrun -f clang);
-              export CXX=$(xcrun -f clang++);
-              SYSROOT=$(xcrun --sdk macosx --show-sdk-path);
-              export CFLAGS="-isysroot $SYSROOT -isystem $SYSROOT";
-              npm run build -- --target aarch64-apple-darwin
+            build: npm run build -- --target aarch64-apple-darwin
           - host: ubuntu-latest
             target: aarch64-unknown-linux-gnu
             use-cross: true
@@ -210,6 +203,8 @@ jobs:
         settings:
           - host: windows-latest
             target: x86_64-pc-windows-msvc
+          - host: macos-latest
+            target: aarch64-apple-darwin
           - host: macos-latest
             target: x86_64-apple-darwin
           - host: ubuntu-latest


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->
Applies changes from https://github.com/napi-rs/package-template/commit/299e2a6a2f252a7473f8cf194e1da1c137a3fd2c so that x64 and ARM binaries for MacOS are built correctly now that `macos-latest` runner defaults to ARM architecture

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->

**Review Checklist**
I certify that I have:
- [ ] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [ ] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
