### PR TITLE
[v2] Modifying profiles to have correct comma placements within comments

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Zowe core SDK package will be documented in this file.
 
+## Recent Changes
+
+- BugFix: Modified Services.ts to have commented properties end with commas [#1049](https://github.com/zowe/zowe-cli/issues/1049)
+
 ## `7.25.0`
 
 - Enhancement: Added `X_IBM_INTRDR_FILE_ENCODING` header to `ZosmfHeaders` [#2139](https://github.com/zowe/zowe-cli/pull/2139)

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the Zowe core SDK package will be documented in this file
 
 ## Recent Changes
 
-- Enhancement: Modified Services.ts to have commented properties end with commas [#1049](https://github.com/zowe/zowe-cli/issues/1049)
+- Enhancement: Modified Services.ts to have commented properties end with commas. [#1049](https://github.com/zowe/zowe-cli/issues/1049)
 
 ## `7.25.0`
 

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the Zowe core SDK package will be documented in this file
 
 ## Recent Changes
 
-- BugFix: Modified Services.ts to have commented properties end with commas [#1049](https://github.com/zowe/zowe-cli/issues/1049)
+- Enhancement: Modified Services.ts to have commented properties end with commas [#1049](https://github.com/zowe/zowe-cli/issues/1049)
 
 ## `7.25.0`
 

--- a/packages/core/__tests__/apiml/__unit__/Services.unit.test.ts
+++ b/packages/core/__tests__/apiml/__unit__/Services.unit.test.ts
@@ -551,7 +551,7 @@ describe("APIML Services unit tests", () => {
     "defaults": {
         // Multiple services were detected.
         // Uncomment one of the lines below to set a different default.
-        //"type2": "test2.2"
+        //"type2": "test2.2",
         "type2": "test2.1"
     },
     "autoStore": true
@@ -648,7 +648,7 @@ describe("APIML Services unit tests", () => {
         "type3": "test3",
         // Multiple services were detected.
         // Uncomment one of the lines below to set a different default.
-        //"type4": "test4.2"
+        //"type4": "test4.2",
         "type4": "test4.1"
     },
     "autoStore": true

--- a/packages/core/__tests__/apiml/__unit__/Services.unit.test.ts
+++ b/packages/core/__tests__/apiml/__unit__/Services.unit.test.ts
@@ -399,11 +399,11 @@ describe("APIML Services unit tests", () => {
                 //"basePath": "test1/v2"
                 //"basePath": "test1/v3"
                 "basePath": "test1/v1"
-            `
+            `;
             const expectedJsonSnippet_notBase= `
                 //"type2": "test2.2",
                 "type2": "test2.1"
-            `
+            `;
             const testCase: IApimlProfileInfo[] = [
                 {
                     profName: "test1",
@@ -433,14 +433,14 @@ describe("APIML Services unit tests", () => {
                     ],
                     pluginConfigs: new Set(),
                     gatewayUrlConflicts: {}
-                }           
+                }
             ];
-            let actualJson = JSONC.stringify(Services.convertApimlProfileInfoToProfileConfig(testCase), null, ConfigConstants.INDENT);
-            
+            const actualJson = JSONC.stringify(Services.convertApimlProfileInfoToProfileConfig(testCase), null, ConfigConstants.INDENT);
+
             expect(actualJson.replace(/\s+/g, '')).toContain(expectedJsonSnippet_base.replace(/\s+/g, ''));
             expect(actualJson.replace(/\s+/g, '')).toContain(expectedJsonSnippet_notBase.replace(/\s+/g, ''));
 
-        })
+        });
 
         it("should create a config object without comments about conflicts", () => {
             const testCase: IApimlProfileInfo[] = [{

--- a/packages/core/__tests__/apiml/__unit__/Services.unit.test.ts
+++ b/packages/core/__tests__/apiml/__unit__/Services.unit.test.ts
@@ -392,6 +392,56 @@ describe("APIML Services unit tests", () => {
             expect(actualJson).toEqual(expectedJson);
         });
 
+        it("should properly apply comments and commas to profileInfoList", () => {
+            // should apply a comma to the end of all values in profile kvp except the last value
+            // should apply a comma to all commented profile types except base
+            const expectedJsonSnippet_base = `
+                //"basePath": "test1/v2"
+                //"basePath": "test1/v3"
+                "basePath": "test1/v1"
+            `
+            const expectedJsonSnippet_notBase= `
+                //"type2": "test2.2",
+                "type2": "test2.1"
+            `
+            const testCase: IApimlProfileInfo[] = [
+                {
+                    profName: "test1",
+                    profType: "type1",
+                    basePaths: [
+                        "test1/v1",
+                        "test1/v2",
+                        "test1/v3"
+                    ],
+                    pluginConfigs: new Set(),
+                    gatewayUrlConflicts: {}
+                },
+                {
+                    profName: "test2.1",
+                    profType: "type2",
+                    basePaths: [
+                        "test2.1/v1"
+                    ],
+                    pluginConfigs: new Set(),
+                    gatewayUrlConflicts: {}
+                },
+                {
+                    profName: "test2.2",
+                    profType: "type2",
+                    basePaths: [
+                        "test2.2/v1"
+                    ],
+                    pluginConfigs: new Set(),
+                    gatewayUrlConflicts: {}
+                }           
+            ];
+            let actualJson = JSONC.stringify(Services.convertApimlProfileInfoToProfileConfig(testCase), null, ConfigConstants.INDENT);
+            
+            expect(actualJson.replace(/\s+/g, '')).toContain(expectedJsonSnippet_base.replace(/\s+/g, ''));
+            expect(actualJson.replace(/\s+/g, '')).toContain(expectedJsonSnippet_notBase.replace(/\s+/g, ''));
+
+        })
+
         it("should create a config object without comments about conflicts", () => {
             const testCase: IApimlProfileInfo[] = [{
                 profName: "test0",

--- a/packages/core/__tests__/apiml/__unit__/Services.unit.test.ts
+++ b/packages/core/__tests__/apiml/__unit__/Services.unit.test.ts
@@ -705,6 +705,150 @@ describe("APIML Services unit tests", () => {
 }`;
             expect(actualJson).toEqual(expectedJson);
         });
+        it("should produce proper default file when multiple comments for a type are passed", () => {
+            const testCase: IApimlProfileInfo[] = [
+                {
+                    profName: "test3",
+                    profType: "type3",
+                    basePaths: [
+                        "test3/v1",
+                        "test3/v2",
+                        "test3/v3"
+                    ],
+                    pluginConfigs: new Set([{
+                        apiId: "test3-apiId",
+                        connProfType: "type3",
+                        pluginName: "type3-plugin-name"
+                    }]),
+                    gatewayUrlConflicts: {}
+                },
+                {
+                    profName: "test4.1",
+                    profType: "type4",
+                    basePaths: [
+                        "test4/v1",
+                        "test4/v2"
+                    ],
+                    pluginConfigs: new Set([
+                        {
+                            apiId: "test4.1-apiId",
+                            connProfType: "type4",
+                            pluginName: "type4.1-plugin-name"
+                        },
+                        {
+                            apiId: "test4.1-apiId",
+                            connProfType: "type4",
+                            pluginName: "type4.1-plugin-name-copy"
+                        }
+                    ]),
+                    gatewayUrlConflicts: {
+                        "type4.1-plugin-name": ["test4/v1"],
+                        "type4.1-plugin-name-copy": ["test4/v2", "test4/v3"]
+                    }
+                },
+                {
+                    profName: "test4.2",
+                    profType: "type4",
+                    basePaths: [
+                        "test4/v1"
+                    ],
+                    pluginConfigs: new Set(),
+                    gatewayUrlConflicts: {}
+                },
+                {
+                    profName: "test4.3",
+                    profType: "type4",
+                    basePaths: [
+                        "test4/v1"
+                    ],
+                    pluginConfigs: new Set(),
+                    gatewayUrlConflicts: {}
+                },
+                {
+                    profName: "base1",
+                    profType: "base",
+                    basePaths: [
+                        "base1/v1"
+                    ],
+                    pluginConfigs: new Set(),
+                    gatewayUrlConflicts: {}
+                },
+                {
+                    profName: "base2",
+                    profType: "base",
+                    basePaths: [
+                        "base2/v1"
+                    ],
+                    pluginConfigs: new Set(),
+                    gatewayUrlConflicts: {}
+                }
+            ];
+            const actualJson = JSONC.stringify(Services.convertApimlProfileInfoToProfileConfig(testCase), null, ConfigConstants.INDENT);
+            const expectedJson = `{
+    "profiles": {
+        "test3": {
+            "type": "type3",
+            "properties": {
+                // Multiple base paths were detected for this service.
+                // Uncomment one of the lines below to use a different one.
+                //"basePath": "test3/v2"
+                //"basePath": "test3/v3"
+                "basePath": "test3/v1"
+            }
+        },
+        "test4.1": {
+            "type": "type4",
+            "properties": {
+                // ---
+                // Warning: basePath conflict detected!
+                // Different plugins require different versions of the same API.
+                // List:
+                //     "type4.1-plugin-name": "test4/v1"
+                //     "type4.1-plugin-name-copy": "test4/v2", "test4/v3"
+                // ---
+                //"basePath": "test4/v2"
+                "basePath": "test4/v1"
+            }
+        },
+        "test4.2": {
+            "type": "type4",
+            "properties": {
+                "basePath": "test4/v1"
+            }
+        },
+        "test4.3": {
+            "type": "type4",
+            "properties": {
+                "basePath": "test4/v1"
+            }
+        },
+        "base1": {
+            "type": "base",
+            "properties": {
+                "basePath": "base1/v1"
+            }
+        },
+        "base2": {
+            "type": "base",
+            "properties": {
+                "basePath": "base2/v1"
+            }
+        }
+    },
+    "defaults": {
+        "type3": "test3",
+        // Multiple services were detected.
+        // Uncomment one of the lines below to set a different default.
+        //"type4": "test4.2",
+        //"type4": "test4.3",
+        "type4": "test4.1",
+        //"base": "base2"
+        "base": "base1"
+    },
+    "autoStore": true
+}`;
+            expect(actualJson).toEqual(expectedJson);
+        });
     });
 
 });

--- a/packages/core/src/apiml/Services.ts
+++ b/packages/core/src/apiml/Services.ts
@@ -207,7 +207,27 @@ export class Services {
 
         const _genCommentsHelper = (key: string, elements: string[]): string => {
             if (elements == null || elements.length === 0) return "";
-            return `//"${key}": "${elements.length === 1 ? elements[0] : elements.join('"\n//"' + key + '": "')}"`;
+            let kvPair: string = "";
+            let endComma = "";
+                        
+            // add comma to end of kvp depending on if base profile
+            if(!key.includes("base")){
+                endComma = ",";
+            }
+            if (elements.length === 1){
+                return `//"${key}": "${elements[0]}"${endComma}`;
+            } 
+            // format pair of kvp (add commas in expected places)
+            elements.forEach((element, index) => {
+                if (index === elements.length - 1) {
+                    kvPair += `\n//"${key}": "${element}"`;
+                } else {
+                    kvPair += `\n//"${key}": "${element}"${endComma}`;
+                }
+            });
+
+            return `${kvPair}${endComma}`;
+            // return `//"${key}": "${elements.length === 1 ? elements[0] : elements.join('"\n//"' + key + '": "')},"`;
         };
 
         profileInfoList?.forEach((profileInfo: IApimlProfileInfo) => {
@@ -271,6 +291,7 @@ export class Services {
                     ${JSONC.stringify(configDefaults, null, ConfigConstants.INDENT).slice(0, -1)}${Object.keys(configDefaults).length > 0 ? "," : ""}
                     // Multiple services were detected.
                     // Uncomment one of the lines below to set a different default.
+                    
                     ${_genCommentsHelper(defaultKey, conflictingDefaults[defaultKey])}
                     "${defaultKey}": "${trueDefault}"
                 }`);

--- a/packages/core/src/apiml/Services.ts
+++ b/packages/core/src/apiml/Services.ts
@@ -214,13 +214,9 @@ export class Services {
                 return `//"${key}": "${elements[0]}"${endComma}`;
             }
             // format pair of kvp (add commas in expected places)
-            elements.forEach((element, index) => {
-                if (index === elements.length - 1) {
-                    kvPair += `\n//"${key}": "${element}"`;
-                } else {
-                    kvPair += `\n//"${key}": "${element}"${endComma}`;
-                }
-            });
+            const kvPair = elements.reduce((all, current: string, index) => {
+                return all.concat(index === elements.length - 1 ? `\n//"${key}": "${element}"` :  `\n//"${key}": "${element}"${endComma}`);
+            }, "");
 
             return `${kvPair}${endComma}`;
             // return `//"${key}": "${elements.length === 1 ? elements[0] : elements.join('"\n//"' + key + '": "')},"`;

--- a/packages/core/src/apiml/Services.ts
+++ b/packages/core/src/apiml/Services.ts
@@ -207,7 +207,6 @@ export class Services {
 
         const _genCommentsHelper = (key: string, elements: string[]): string => {
             if (elements == null || elements.length === 0) return "";
-            let kvPair: string = "";
             // add comma to end of kvp depending on if base profile
             const endComma = key.includes("base") ? "" : ",";
             if (elements.length === 1){
@@ -215,11 +214,10 @@ export class Services {
             }
             // format pair of kvp (add commas in expected places)
             const kvPair = elements.reduce((all, current: string, index) => {
-                return all.concat(index === elements.length - 1 ? `\n//"${key}": "${element}"` :  `\n//"${key}": "${element}"${endComma}`);
+                return all.concat(index === elements.length - 1 ? `\n//"${key}": "${current}"` :  `\n//"${key}": "${current}"${endComma}`);
             }, "");
 
             return `${kvPair}${endComma}`;
-            // return `//"${key}": "${elements.length === 1 ? elements[0] : elements.join('"\n//"' + key + '": "')},"`;
         };
 
         profileInfoList?.forEach((profileInfo: IApimlProfileInfo) => {

--- a/packages/core/src/apiml/Services.ts
+++ b/packages/core/src/apiml/Services.ts
@@ -209,14 +209,13 @@ export class Services {
             if (elements == null || elements.length === 0) return "";
             let kvPair: string = "";
             let endComma = "";
-                        
             // add comma to end of kvp depending on if base profile
             if(!key.includes("base")){
                 endComma = ",";
             }
             if (elements.length === 1){
                 return `//"${key}": "${elements[0]}"${endComma}`;
-            } 
+            }
             // format pair of kvp (add commas in expected places)
             elements.forEach((element, index) => {
                 if (index === elements.length - 1) {

--- a/packages/core/src/apiml/Services.ts
+++ b/packages/core/src/apiml/Services.ts
@@ -207,17 +207,10 @@ export class Services {
 
         const _genCommentsHelper = (key: string, elements: string[]): string => {
             if (elements == null || elements.length === 0) return "";
-            // add comma to end of kvp depending on if base profile
-            const endComma = key.includes("base") ? "" : ",";
-            if (elements.length === 1){
-                return `//"${key}": "${elements[0]}"${endComma}`;
-            }
-            // format pair of kvp (add commas in expected places)
-            const kvPair = elements.reduce((all, current: string, index) => {
-                return all.concat(index === elements.length - 1 ? `\n//"${key}": "${current}"` :  `\n//"${key}": "${current}"${endComma}`);
-            }, "");
 
-            return `${kvPair}${endComma}`;
+            return elements.reduce((all, current: string, index) => {
+                return all.concat(key.includes("base") ? `\n//"${key}": "${current}"` : `\n//"${key}": "${current}",`);
+            }, "");
         };
 
         profileInfoList?.forEach((profileInfo: IApimlProfileInfo) => {
@@ -272,19 +265,29 @@ export class Services {
             }
         });
 
+        // Establish keys for object map for index check within loop
+        const defaultKeys = Object.keys(conflictingDefaults);
+
         for (const defaultKey in conflictingDefaults) {
             if (configDefaults[defaultKey] != null) {
                 const trueDefault = configDefaults[defaultKey];
                 delete configDefaults[defaultKey];
+                let jsonString = `
+                    ${JSONC.stringify(configDefaults, null, ConfigConstants.INDENT).slice(0, -1)}${Object.keys(configDefaults).length > 0 ? "," : ""}`;
+                const defaultKeyIndex = defaultKeys.indexOf(defaultKey);
 
-                configDefaults = JSONC.parse(`
-                    ${JSONC.stringify(configDefaults, null, ConfigConstants.INDENT).slice(0, -1)}${Object.keys(configDefaults).length > 0 ? "," : ""}
-                    // Multiple services were detected.
-                    // Uncomment one of the lines below to set a different default.
-                    
+                // Logic to ensure that comment block is not duplicated
+                if (defaultKeyIndex === 0) {
+                    jsonString += `
+                        // Multiple services were detected.
+                        // Uncomment one of the lines below to set a different default.`;
+                }
+                jsonString += `
                     ${_genCommentsHelper(defaultKey, conflictingDefaults[defaultKey])}
-                    "${defaultKey}": "${trueDefault}"
-                }`);
+                    "${defaultKey}": "${trueDefault}"`;
+                // Terminate the JSON string
+                jsonString += '\n}';
+                configDefaults = JSONC.parse(jsonString);
             }
         }
 

--- a/packages/core/src/apiml/Services.ts
+++ b/packages/core/src/apiml/Services.ts
@@ -208,11 +208,8 @@ export class Services {
         const _genCommentsHelper = (key: string, elements: string[]): string => {
             if (elements == null || elements.length === 0) return "";
             let kvPair: string = "";
-            let endComma = "";
             // add comma to end of kvp depending on if base profile
-            if(!key.includes("base")){
-                endComma = ",";
-            }
+            const endComma = key.includes("base") ? "" : ",";
             if (elements.length === 1){
                 return `//"${key}": "${elements[0]}"${endComma}`;
             }

--- a/packages/core/src/apiml/Services.ts
+++ b/packages/core/src/apiml/Services.ts
@@ -273,7 +273,7 @@ export class Services {
                 const trueDefault = configDefaults[defaultKey];
                 delete configDefaults[defaultKey];
                 let jsonString = `
-                    ${JSONC.stringify(configDefaults, null, ConfigConstants.INDENT).slice(0, -1)}${Object.keys(configDefaults).length > 0 ? "," : ""}`;
+                ${JSONC.stringify(configDefaults, null, ConfigConstants.INDENT).slice(0, -1)}${Object.keys(configDefaults).length > 0 ? "," : ""}`;
                 const defaultKeyIndex = defaultKeys.indexOf(defaultKey);
 
                 // Logic to ensure that comment block is not duplicated


### PR DESCRIPTION
**What It Does**
Applies a comma to the end of all values in profile kvp except the last value
Applies a comma to all commented profile types except base

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [x] added/updated automated tests
- [x] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)
