### PR TITLE
[v3] Modifying profiles to have correct comma placements within comments

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to the Zowe core SDK package will be documented in this file.
 
+## Recent Changes
+
+- Enhancement: Modified Services.ts to have commented properties end with commas. [#1049](https://github.com/zowe/zowe-cli/issues/1049)
+
+
 ## `8.0.0-next.202403041352`
 
 - BugFix: Updated engine to Node 18.12.0. [#2074](https://github.com/zowe/zowe-cli/pull/2074)

--- a/packages/core/__tests__/apiml/__unit__/Services.unit.test.ts
+++ b/packages/core/__tests__/apiml/__unit__/Services.unit.test.ts
@@ -392,6 +392,56 @@ describe("APIML Services unit tests", () => {
             expect(actualJson).toEqual(expectedJson);
         });
 
+        it("should properly apply comments and commas to profileInfoList", () => {
+            // should apply a comma to the end of all values in profile kvp except the last value
+            // should apply a comma to all commented profile types except base
+            const expectedJsonSnippet_base = `
+                //"basePath": "test1/v2"
+                //"basePath": "test1/v3"
+                "basePath": "test1/v1"
+            `;
+            const expectedJsonSnippet_notBase= `
+                //"type2": "test2.2",
+                "type2": "test2.1"
+            `;
+            const testCase: IApimlProfileInfo[] = [
+                {
+                    profName: "test1",
+                    profType: "type1",
+                    basePaths: [
+                        "test1/v1",
+                        "test1/v2",
+                        "test1/v3"
+                    ],
+                    pluginConfigs: new Set(),
+                    gatewayUrlConflicts: {}
+                },
+                {
+                    profName: "test2.1",
+                    profType: "type2",
+                    basePaths: [
+                        "test2.1/v1"
+                    ],
+                    pluginConfigs: new Set(),
+                    gatewayUrlConflicts: {}
+                },
+                {
+                    profName: "test2.2",
+                    profType: "type2",
+                    basePaths: [
+                        "test2.2/v1"
+                    ],
+                    pluginConfigs: new Set(),
+                    gatewayUrlConflicts: {}
+                }
+            ];
+            const actualJson = JSONC.stringify(Services.convertApimlProfileInfoToProfileConfig(testCase), null, ConfigConstants.INDENT);
+
+            expect(actualJson.replace(/\s+/g, '')).toContain(expectedJsonSnippet_base.replace(/\s+/g, ''));
+            expect(actualJson.replace(/\s+/g, '')).toContain(expectedJsonSnippet_notBase.replace(/\s+/g, ''));
+
+        });
+
         it("should create a config object without comments about conflicts", () => {
             const testCase: IApimlProfileInfo[] = [{
                 profName: "test0",
@@ -551,7 +601,7 @@ describe("APIML Services unit tests", () => {
     "defaults": {
         // Multiple services were detected.
         // Uncomment one of the lines below to set a different default.
-        //"type2": "test2.2"
+        //"type2": "test2.2",
         "type2": "test2.1"
     },
     "autoStore": true
@@ -648,8 +698,152 @@ describe("APIML Services unit tests", () => {
         "type3": "test3",
         // Multiple services were detected.
         // Uncomment one of the lines below to set a different default.
-        //"type4": "test4.2"
+        //"type4": "test4.2",
         "type4": "test4.1"
+    },
+    "autoStore": true
+}`;
+            expect(actualJson).toEqual(expectedJson);
+        });
+        it("should produce proper default file when multiple comments for a type are passed", () => {
+            const testCase: IApimlProfileInfo[] = [
+                {
+                    profName: "test3",
+                    profType: "type3",
+                    basePaths: [
+                        "test3/v1",
+                        "test3/v2",
+                        "test3/v3"
+                    ],
+                    pluginConfigs: new Set([{
+                        apiId: "test3-apiId",
+                        connProfType: "type3",
+                        pluginName: "type3-plugin-name"
+                    }]),
+                    gatewayUrlConflicts: {}
+                },
+                {
+                    profName: "test4.1",
+                    profType: "type4",
+                    basePaths: [
+                        "test4/v1",
+                        "test4/v2"
+                    ],
+                    pluginConfigs: new Set([
+                        {
+                            apiId: "test4.1-apiId",
+                            connProfType: "type4",
+                            pluginName: "type4.1-plugin-name"
+                        },
+                        {
+                            apiId: "test4.1-apiId",
+                            connProfType: "type4",
+                            pluginName: "type4.1-plugin-name-copy"
+                        }
+                    ]),
+                    gatewayUrlConflicts: {
+                        "type4.1-plugin-name": ["test4/v1"],
+                        "type4.1-plugin-name-copy": ["test4/v2", "test4/v3"]
+                    }
+                },
+                {
+                    profName: "test4.2",
+                    profType: "type4",
+                    basePaths: [
+                        "test4/v1"
+                    ],
+                    pluginConfigs: new Set(),
+                    gatewayUrlConflicts: {}
+                },
+                {
+                    profName: "test4.3",
+                    profType: "type4",
+                    basePaths: [
+                        "test4/v1"
+                    ],
+                    pluginConfigs: new Set(),
+                    gatewayUrlConflicts: {}
+                },
+                {
+                    profName: "base1",
+                    profType: "base",
+                    basePaths: [
+                        "base1/v1"
+                    ],
+                    pluginConfigs: new Set(),
+                    gatewayUrlConflicts: {}
+                },
+                {
+                    profName: "base2",
+                    profType: "base",
+                    basePaths: [
+                        "base2/v1"
+                    ],
+                    pluginConfigs: new Set(),
+                    gatewayUrlConflicts: {}
+                }
+            ];
+            const actualJson = JSONC.stringify(Services.convertApimlProfileInfoToProfileConfig(testCase), null, ConfigConstants.INDENT);
+            const expectedJson = `{
+    "profiles": {
+        "test3": {
+            "type": "type3",
+            "properties": {
+                // Multiple base paths were detected for this service.
+                // Uncomment one of the lines below to use a different one.
+                //"basePath": "test3/v2"
+                //"basePath": "test3/v3"
+                "basePath": "test3/v1"
+            }
+        },
+        "test4.1": {
+            "type": "type4",
+            "properties": {
+                // ---
+                // Warning: basePath conflict detected!
+                // Different plugins require different versions of the same API.
+                // List:
+                //     "type4.1-plugin-name": "test4/v1"
+                //     "type4.1-plugin-name-copy": "test4/v2", "test4/v3"
+                // ---
+                //"basePath": "test4/v2"
+                "basePath": "test4/v1"
+            }
+        },
+        "test4.2": {
+            "type": "type4",
+            "properties": {
+                "basePath": "test4/v1"
+            }
+        },
+        "test4.3": {
+            "type": "type4",
+            "properties": {
+                "basePath": "test4/v1"
+            }
+        },
+        "base1": {
+            "type": "base",
+            "properties": {
+                "basePath": "base1/v1"
+            }
+        },
+        "base2": {
+            "type": "base",
+            "properties": {
+                "basePath": "base2/v1"
+            }
+        }
+    },
+    "defaults": {
+        "type3": "test3",
+        // Multiple services were detected.
+        // Uncomment one of the lines below to set a different default.
+        //"type4": "test4.2",
+        //"type4": "test4.3",
+        "type4": "test4.1",
+        //"base": "base2"
+        "base": "base1"
     },
     "autoStore": true
 }`;

--- a/packages/core/src/apiml/Services.ts
+++ b/packages/core/src/apiml/Services.ts
@@ -246,6 +246,9 @@ export class Services {
                     conflictingPluginsList += `
                     //     "${element}": "${profileInfo.gatewayUrlConflicts[element].join('", "')}"`;
                 });
+
+                // Typecasting because of this issue: https://github.com/kaelzhang/node-comment-json/issues/42
+
                 const basepathConflictMessage = `
                     // ---
                     // Warning: basePath conflict detected!
@@ -261,7 +264,7 @@ export class Services {
                         ${_genCommentsHelper("basePath", basePaths)}
                         "basePath": "${defaultBasePath}"
                     }`
-                );
+                ) as any;
             }
         });
 
@@ -287,7 +290,7 @@ export class Services {
                     "${defaultKey}": "${trueDefault}"`;
                 // Terminate the JSON string
                 jsonString += '\n}';
-                configDefaults = JSONC.parse(jsonString);
+                configDefaults = JSONC.parse(jsonString) as any;
             }
         }
 


### PR DESCRIPTION
What It Does
Applies a comma to the end of all values in profile kvp except the last value
Applies a comma to all commented profile types except base

Review Checklist
I certify that I have:

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [x] added/updated automated tests
- [x] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)

Additional Comments:
port from original on v2