### PR TITLE
Fix incomplete files when downloading data sets

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -14862,12 +14862,12 @@
       }
     },
     "node_modules/micromatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
-      "integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.7.tgz",
+      "integrity": "sha512-LPP/3KorzCwBxfeUuZmaR6bG2kdeHSbe0P2tY3FLRU4vYrjYz5hI4QZwV0njUx3jeuKe67YukQ1LSPZBKDqO/Q==",
       "dependencies": {
-        "braces": "^3.0.1",
-        "picomatch": "^2.2.3"
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
       },
       "engines": {
         "node": ">=8.6"
@@ -20991,7 +20991,6 @@
       "version": "7.25.2",
       "license": "EPL-2.0",
       "dependencies": {
-        "get-stream": "6.0.1",
         "minimatch": "5.0.1"
       },
       "devDependencies": {
@@ -26140,7 +26139,6 @@
         "@zowe/core-for-zowe-sdk": "7.25.2",
         "@zowe/imperative": "5.23.4",
         "@zowe/zos-uss-for-zowe-sdk": "7.24.3",
-        "get-stream": "6.0.1",
         "minimatch": "5.0.1"
       },
       "dependencies": {
@@ -32481,12 +32479,12 @@
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="
     },
     "micromatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
-      "integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.7.tgz",
+      "integrity": "sha512-LPP/3KorzCwBxfeUuZmaR6bG2kdeHSbe0P2tY3FLRU4vYrjYz5hI4QZwV0njUx3jeuKe67YukQ1LSPZBKDqO/Q==",
       "requires": {
-        "braces": "^3.0.1",
-        "picomatch": "^2.2.3"
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
       }
     },
     "mime": {

--- a/packages/imperative/CHANGELOG.md
+++ b/packages/imperative/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the Imperative package will be documented in this file.
 
+## Recent Changes
+
+- Enhancement: Added `BufferBuilder` utility class to provide convenient way of downloading to a stream that can be read as a buffer. [#2167](https://github.com/zowe/zowe-cli/pull/2167)
+- BugFix: Fixed error in REST client that when using stream could cause small data sets to download with incomplete contents. [#744](https://github.com/zowe/zowe-cli/issues/744)
+- BugFix: Updated `micromatch` dependency for technical currency. [#2167](https://github.com/zowe/zowe-cli/pull/2167)
+
 ## `5.23.4`
 
 - BugFix: Updated `braces` dependency for technical currency. [#2157](https://github.com/zowe/zowe-cli/pull/2157)

--- a/packages/imperative/src/rest/__tests__/client/AbstractRestClient.unit.test.ts
+++ b/packages/imperative/src/rest/__tests__/client/AbstractRestClient.unit.test.ts
@@ -524,7 +524,7 @@ describe("AbstractRestClient tests", () => {
         const fakeResponseStream: any = {
             write: jest.fn(),
             on: jest.fn(),
-            end: jest.fn(),
+            end: jest.fn((cb: any) => cb()),
             writableFinished: true
         };
         const fakeRequestStream: any = {

--- a/packages/imperative/src/rest/src/client/AbstractRestClient.ts
+++ b/packages/imperative/src/rest/src/client/AbstractRestClient.ts
@@ -26,7 +26,7 @@ import { Session } from "../session/Session";
 import * as path from "path";
 import { IRestClientError } from "./doc/IRestClientError";
 import { RestClientError } from "./RestClientError";
-import { Readable, Writable, finished } from "stream";
+import { Readable, Writable } from "stream";
 import { IO } from "../../../io";
 import { ITaskWithStatus, TaskProgress, TaskStage } from "../../../operations";
 import { NextVerFeatures, TextUtils } from "../../../utilities";
@@ -797,10 +797,6 @@ export abstract class AbstractRestClient {
             this.mTask.percentComplete = TaskProgress.ONE_HUNDRED_PERCENT;
             this.mTask.stageName = TaskStage.COMPLETE;
         }
-        if (this.mResponseStream != null) {
-            this.log.debug("Ending response stream");
-            this.mResponseStream.end();
-        }
         if (this.mContentEncoding != null && this.mData.length > 0) {
             this.log.debug("Decompressing encoded response");
             try {
@@ -818,7 +814,8 @@ export abstract class AbstractRestClient {
                 source: "http"
             }));
         } else if (this.mResponseStream != null) {
-            finished(this.mResponseStream, () => this.mResolve(this.dataString));
+            this.log.debug("Ending response stream");
+            this.mResponseStream.end(() => this.mResolve(this.dataString));
         } else {
             this.mResolve(this.dataString);
         }

--- a/packages/imperative/src/rest/src/client/AbstractRestClient.ts
+++ b/packages/imperative/src/rest/src/client/AbstractRestClient.ts
@@ -26,7 +26,7 @@ import { Session } from "../session/Session";
 import * as path from "path";
 import { IRestClientError } from "./doc/IRestClientError";
 import { RestClientError } from "./RestClientError";
-import { Readable, Writable } from "stream";
+import { Readable, Writable, finished } from "stream";
 import { IO } from "../../../io";
 import { ITaskWithStatus, TaskProgress, TaskStage } from "../../../operations";
 import { NextVerFeatures, TextUtils } from "../../../utilities";
@@ -817,12 +817,8 @@ export abstract class AbstractRestClient {
                 causeErrors: this.dataString,
                 source: "http"
             }));
-        } else if (this.mResponseStream != null && this.mResponseStream.writableEnded) {
-            // This will correct any instances where the finished event does not get emitted
-            // even though the stream processing has ended.
-            this.mResolve(this.dataString);
-        } else if (this.mResponseStream != null && !this.mResponseStream.writableFinished) {
-            this.mResponseStream.on("finish", () => this.mResolve(this.dataString));
+        } else if (this.mResponseStream != null) {
+            finished(this.mResponseStream, () => this.mResolve(this.dataString));
         } else {
             this.mResolve(this.dataString);
         }

--- a/packages/imperative/src/rest/src/client/AbstractRestClient.ts
+++ b/packages/imperative/src/rest/src/client/AbstractRestClient.ts
@@ -805,19 +805,25 @@ export abstract class AbstractRestClient {
                 this.mReject(err);
             }
         }
-        if (this.requestFailure) {
-            // Reject the promise with an error
-            const httpStatus = this.response == null ? undefined : this.response.statusCode;
-            this.mReject(this.populateError({
-                msg: "Rest API failure with HTTP(S) status " + httpStatus,
-                causeErrors: this.dataString,
-                source: "http"
-            }));
-        } else if (this.mResponseStream != null) {
+
+        const requestEnd = () => {
+            if (this.requestFailure) {
+                // Reject the promise with an error
+                const httpStatus = this.response == null ? undefined : this.response.statusCode;
+                this.mReject(this.populateError({
+                    msg: "Rest API failure with HTTP(S) status " + httpStatus,
+                    causeErrors: this.dataString,
+                    source: "http"
+                }));
+            } else {
+                this.mResolve(this.dataString);
+            }
+        };
+        if (this.mResponseStream != null) {
             this.log.debug("Ending response stream");
-            this.mResponseStream.end(() => this.mResolve(this.dataString));
+            this.mResponseStream.end(requestEnd);
         } else {
-            this.mResolve(this.dataString);
+            requestEnd();
         }
     }
 

--- a/packages/imperative/src/utilities/__tests__/BufferBuilder.unit.test.ts
+++ b/packages/imperative/src/utilities/__tests__/BufferBuilder.unit.test.ts
@@ -1,0 +1,30 @@
+/*
+* This program and the accompanying materials are made available under the terms of the
+* Eclipse Public License v2.0 which accompanies this distribution, and is available at
+* https://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Copyright Contributors to the Zowe Project.
+*
+*/
+
+import { BufferBuilder } from "../src/BufferBuilder";
+
+describe("BufferBuilder", () => {
+    it("calls the given callback on write", () => {
+        const bufBuilder = new BufferBuilder();
+        const callbackMock = jest.fn();
+        bufBuilder._write(new Uint8Array([1, 2, 3]), "binary", callbackMock);
+        expect(callbackMock).toHaveBeenCalled();
+    });
+
+    it("calls 'push' on read", () => {
+        const bufBuilder = new BufferBuilder();
+        const callbackMock = jest.fn();
+        const pushMock = jest.spyOn(bufBuilder, "push");
+        bufBuilder._write(new Uint8Array([1, 2, 3]), "binary", callbackMock);
+        bufBuilder._read(3);
+        expect(pushMock).toHaveBeenCalledTimes(2);
+    });
+});

--- a/packages/imperative/src/utilities/index.ts
+++ b/packages/imperative/src/utilities/index.ts
@@ -11,6 +11,7 @@
 
 export * from "./src/doc/IDaemonRequest";
 export * from "./src/doc/IDaemonResponse";
+export * from "./src/BufferBuilder";
 export * from "./src/DaemonRequest";
 export * from "./src/ExecUtils";
 export * from "./src/ImperativeConfig";

--- a/packages/imperative/src/utilities/src/BufferBuilder.ts
+++ b/packages/imperative/src/utilities/src/BufferBuilder.ts
@@ -1,0 +1,32 @@
+/*
+* This program and the accompanying materials are made available under the terms of the
+* Eclipse Public License v2.0 which accompanies this distribution, and is available at
+* https://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Copyright Contributors to the Zowe Project.
+*
+*/
+
+import { Duplex } from "stream";
+
+export class BufferBuilder extends Duplex {
+    private chunks: Uint8Array[];
+
+    public constructor() {
+        super();
+        this.chunks = [];
+    }
+
+    public _write(chunk: any, _encoding: BufferEncoding, callback: (error?: Error) => void): void {
+        this.chunks.push(chunk);
+        callback();
+    }
+
+    public _read(_size: number): void {
+        const concatBuf = Buffer.concat(this.chunks);
+        this.push(concatBuf);
+        this.push(null);
+    }
+}

--- a/packages/zosfiles/CHANGELOG.md
+++ b/packages/zosfiles/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Zowe z/OS files SDK package will be documented in this file.
 
+## Recent Changes
+
+- BugFix: Fixed error where `Get.dataSet` and `Get.USSFile` could silently fail when downloading large data sets or files. [#2167](https://github.com/zowe/zowe-cli/pull/2167)
+
 ## `7.24.0`
 
 - BugFix: Fixed error that could occur when listing data set members that contain control characters in the name. [#2104](https://github.com/zowe/zowe-cli/pull/2104)

--- a/packages/zosfiles/CHANGELOG.md
+++ b/packages/zosfiles/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the Zowe z/OS files SDK package will be documented in thi
 
 ## Recent Changes
 
-- BugFix: Fixed error where `Get.dataSet` and `Get.USSFile` could silently fail when downloading large data sets or files. [#2167](https://github.com/zowe/zowe-cli/pull/2167)
+- BugFix: Fixed error where `Get.dataSet` and `Get.USSFile` methods could silently fail when downloading large data sets or files. [#2167](https://github.com/zowe/zowe-cli/pull/2167)
 
 ## `7.24.0`
 

--- a/packages/zosfiles/package.json
+++ b/packages/zosfiles/package.json
@@ -46,7 +46,6 @@
     "prepack": "node ../../scripts/prepareLicenses.js"
   },
   "dependencies": {
-    "get-stream": "6.0.1",
     "minimatch": "5.0.1"
   },
   "devDependencies": {

--- a/packages/zosfiles/src/methods/get/Get.ts
+++ b/packages/zosfiles/src/methods/get/Get.ts
@@ -9,9 +9,7 @@
 *
 */
 
-import { PassThrough } from "stream";
-import getStream = require("get-stream");
-import { AbstractSession, ImperativeExpect } from "@zowe/imperative";
+import { AbstractSession, BufferBuilder, ImperativeExpect } from "@zowe/imperative";
 import { ZosFilesMessages } from "../../constants/ZosFiles.messages";
 import { Download } from "../download/Download";
 import { IGetOptions } from "./doc/IGetOptions";
@@ -37,12 +35,12 @@ export class Get {
         ImperativeExpect.toNotBeNullOrUndefined(dataSetName, ZosFilesMessages.missingDatasetName.message);
         ImperativeExpect.toNotBeEqual(dataSetName, "", ZosFilesMessages.missingDatasetName.message);
 
-        const responseStream = new PassThrough();
+        const responseStream = new BufferBuilder();
         await Download.dataSet(session, dataSetName, {
             ...options,
             stream: responseStream
         });
-        return getStream.buffer(responseStream);
+        return responseStream.read();
     }
 
     /**
@@ -61,11 +59,11 @@ export class Get {
         ImperativeExpect.toNotBeEqual(USSFileName, "", ZosFilesMessages.missingUSSFileName.message);
         ImperativeExpect.toNotBeEqual(options.record, true, ZosFilesMessages.unsupportedDataType.message); // This should never exist for USS files
 
-        const responseStream = new PassThrough();
+        const responseStream = new BufferBuilder();
         await Download.ussFile(session, USSFileName, {
             ...options,
             stream: responseStream
         });
-        return getStream.buffer(responseStream);
+        return responseStream.read();
     }
 }


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->
Fixes #744

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->
* Test that the issue with downloading small data sets using `BufferBuilder` is fixed:
```javascript
const { BufferBuilder, ProfileInfo } = require("@zowe/imperative");
const { Download } = require("@zowe/zos-files-for-zowe-sdk");

(async () => {
    // Load connection info from default z/OSMF profile
    const profInfo = new ProfileInfo("zowe");
    await profInfo.readProfilesFromDisk();
    const zosmfProfAttrs = profInfo.getDefaultProfile("zosmf");
    const zosmfMergedArgs = profInfo.mergeArgsForProfile(zosmfProfAttrs, { getSecureVals: true });
    const session = ProfileInfo.createSession(zosmfMergedArgs.knownArgs);
    const stream = new BufferBuilder();
    const response = await Download.dataSet(session, "SYS1.MACLIB(ABEND)", {stream});
    console.log(stream.read());
})();
```
* Test that there is no regression in cross-LPAR copy related to https://github.com/zowe/imperative/pull/1022
`zowe files copy dsclp <sourceDsname> <targetDsname> --target-zosmf-profile <profileName>`
where the source dsname points to a large sequential DS (>16KB)

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [x] added/updated automated tests
- [x] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
Thanks to @traeok for his `BufferBuilder` implementation in Zowe Explorer 😋 