### PR TITLE
Fix error when downloading spool files with default encoding

### DIFF
--- a/packages/zosfiles/CHANGELOG.md
+++ b/packages/zosfiles/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Zowe z/OS files SDK package will be documented in this file.
 
+## Recent Changes
+
+- BugFix: Fixed `Get.dataSet` and `Get.USSFile` methods so that they return an empty buffer instead of null for empty files. [#2173](https://github.com/zowe/zowe-cli/pull/2173)
+
 ## `7.26.0`
 
 - BugFix: Fixed error where `Get.dataSet` and `Get.USSFile` methods could silently fail when downloading large data sets or files. [#2167](https://github.com/zowe/zowe-cli/pull/2167)

--- a/packages/zosfiles/__tests__/__unit__/methods/get/Get.unit.test.ts
+++ b/packages/zosfiles/__tests__/__unit__/methods/get/Get.unit.test.ts
@@ -109,6 +109,32 @@ describe("z/OS Files - View", () => {
             }));
         });
 
+        it("should get data set content when empty", async () => {
+            let response;
+            let caughtError;
+            zosmfExpectSpy.mockImplementationOnce(async (_session, options) => {
+                options.responseStream?.end();
+                return {};
+            });
+
+            try {
+                response = await Get.dataSet(dummySession, dsname);
+            } catch (e) {
+                caughtError = e;
+            }
+
+            const endpoint = posix.join(ZosFilesConstants.RESOURCE, ZosFilesConstants.RES_DS_FILES, dsname);
+
+            expect(caughtError).toBeUndefined();
+            expect(response).toEqual(Buffer.alloc(0));
+
+            expect(zosmfExpectSpy).toHaveBeenCalledTimes(1);
+            expect(zosmfExpectSpy).toHaveBeenCalledWith(dummySession, expect.objectContaining({
+                reqHeaders: [ZosmfHeaders.ACCEPT_ENCODING, ZosmfHeaders.TEXT_PLAIN],
+                resource: endpoint
+            }));
+        });
+
         it("should get data set content in binary mode", async () => {
             let response;
             let caughtError;
@@ -361,6 +387,32 @@ describe("z/OS Files - View", () => {
 
             expect(caughtError).toBeUndefined();
             expect(response).toEqual(content);
+
+            expect(zosmfExpectSpy).toHaveBeenCalledTimes(1);
+            expect(zosmfExpectSpy).toHaveBeenCalledWith(dummySession, expect.objectContaining({
+                reqHeaders: [ZosmfHeaders.ACCEPT_ENCODING, ZosmfHeaders.TEXT_PLAIN],
+                resource: endpoint
+            }));
+        });
+
+        it("should get uss file content when empty", async () => {
+            let response;
+            let caughtError;
+            zosmfExpectSpy.mockImplementationOnce(async (_session, options) => {
+                options.responseStream?.end();
+                return {};
+            });
+
+            try {
+                response = await Get.USSFile(dummySession, ussfile);
+            } catch (e) {
+                caughtError = e;
+            }
+
+            const endpoint = posix.join(ZosFilesConstants.RESOURCE, ZosFilesConstants.RES_USS_FILES, ussfile);
+
+            expect(caughtError).toBeUndefined();
+            expect(response).toEqual(Buffer.alloc(0));
 
             expect(zosmfExpectSpy).toHaveBeenCalledTimes(1);
             expect(zosmfExpectSpy).toHaveBeenCalledWith(dummySession, expect.objectContaining({

--- a/packages/zosfiles/src/methods/get/Get.ts
+++ b/packages/zosfiles/src/methods/get/Get.ts
@@ -40,7 +40,7 @@ export class Get {
             ...options,
             stream: responseStream
         });
-        return responseStream.read();
+        return responseStream.read() ?? Buffer.alloc(0);
     }
 
     /**
@@ -64,6 +64,6 @@ export class Get {
             ...options,
             stream: responseStream
         });
-        return responseStream.read();
+        return responseStream.read() ?? Buffer.alloc(0);
     }
 }

--- a/packages/zosjobs/CHANGELOG.md
+++ b/packages/zosjobs/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Zowe z/OS jobs SDK package will be documented in this file.
 
+## Recent Changes
+
+- BugFix: Fixed error in `DownloadJobs.downloadSpoolContentCommon` method when encoding parameter is not specified. [#2173](https://github.com/zowe/zowe-cli/pull/2173)
+
 ## `7.25.0`
 
 - Enhancement: Added the ability to set `internalReaderFileEncoding` on the `submitJcl`, `submitJclString`, `submitJclCommon`, `submitJclNotify`, and `submitJclNotifyCommon` Jobs APIs [#2139](https://github.com/zowe/zowe-cli/pull/2139)

--- a/packages/zosjobs/__tests__/__unit__/DownloadJobs.unit.test.ts
+++ b/packages/zosjobs/__tests__/__unit__/DownloadJobs.unit.test.ts
@@ -103,6 +103,10 @@ describe("DownloadJobs", () => {
 
         describe("downloadAllSpoolContentCommon", () => {
             it("should allow users to call downloadAllSpoolContentCommon with correct parameters", async () => {
+                let uri: string = "";
+                ZosmfRestClient.getStreamed = jest.fn(async (session: AbstractSession, resource: string, reqHeaders?: any[]): Promise<any> => {
+                    uri = resource;
+                });
                 const allSpoolParms: IDownloadAllSpoolContentParms = {
                     jobid: fakeJobID,
                     jobname: fakeJobName,
@@ -116,6 +120,7 @@ describe("DownloadJobs", () => {
 
                 expect(GetJobs.getSpoolFiles).toHaveBeenCalled();
                 expect(IO.createDirsSyncFromFilePath).toHaveBeenCalledWith(expectedFile);
+                expect(uri).not.toContain("fileEncoding");
             });
 
             it("should allow users to call downloadAllSpoolContentCommon with correct parameters and binary mode", async () => {

--- a/packages/zosjobs/src/DownloadJobs.ts
+++ b/packages/zosjobs/src/DownloadJobs.ts
@@ -122,7 +122,7 @@ export class DownloadJobs {
             parameters += "?mode=record";
         }
 
-        if (!parms.binary && !parms.record && parms.encoding?.trim() != "") {
+        if (!parms.binary && !parms.record && parms.encoding?.trim()) {
             parameters += "?fileEncoding=" + parms.encoding;
         }
 


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->
Fixes z/OSMF error when `DownloadJobs.downloadSpoolContentCommon` is called and `encoding` property is undefined.

Also corrects the behavior of `Get.dataSet` and `Get.USSFile` methods so that they return an empty buffer instead of null for empty files.

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->
Run the following system test files and ensure that all tests pass:
* `DownloadJobs.system.test.ts`
* `cli.dir.upload.dtu.system.test.ts`
* `cli.files.upload.stds.system.test.ts`

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [x] added/updated automated tests
- [x] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
