### PR TITLE
Verify credential manager access [v2]

### DIFF
--- a/packages/imperative/CHANGELOG.md
+++ b/packages/imperative/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to the Imperative package will be documented in this file.
 
 ## Recent Changes
 
-- Enhancement: Added `ProfileInfo.profileManagerWillLoad` function to verify the credential manager will load before attempting to use it. [#2111](https://github.com/zowe/zowe-cli/issues/2111)
+- Enhancement: Added `ProfileInfo.profileManagerWillLoad` function to verify the credential manager can load. [#2111](https://github.com/zowe/zowe-cli/issues/2111)
 
 ## `5.24.0`
 

--- a/packages/imperative/CHANGELOG.md
+++ b/packages/imperative/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to the Imperative package will be documented in this file.
 
+
+## Recent Changes
+
+- Enhancement: Added `ProfileInfo.profileManagerWillLoad` function to verify the credential manager will load before attempting to use it. [#2111](https://github.com/zowe/zowe-cli/issues/2111)
+
 ## `5.24.0`
 
 - Enhancement: Added `BufferBuilder` utility class to provide convenient way of downloading to a stream that can be read as a buffer. [#2167](https://github.com/zowe/zowe-cli/pull/2167)

--- a/packages/imperative/src/config/__tests__/ProfileInfo.TeamConfig.unit.test.ts
+++ b/packages/imperative/src/config/__tests__/ProfileInfo.TeamConfig.unit.test.ts
@@ -300,6 +300,34 @@ describe("TeamConfig ProfileInfo tests", () => {
         });
     });
 
+    describe("profileManagerWillLoad", () => {
+        it("should return false if secure credentials fail to load", async () => {
+            const profInfo = createNewProfInfo(teamProjDir);
+            jest.spyOn((profInfo as any).mCredentials, "isSecured", "get").mockReturnValueOnce(true);
+            jest.spyOn((profInfo as any).mCredentials, "loadManager").mockImplementationOnce(async () => {
+                throw new Error("bad credential manager");
+            });
+
+            const response = await profInfo.profileManagerWillLoad();
+            expect(response).toEqual(false);
+        });
+
+        it("should return true if secure credentials will load", async () => {
+            // ensure that we are not in the team project directory
+            const profInfo = createNewProfInfo(origDir);
+            const response = await profInfo.profileManagerWillLoad();
+            expect(response).toEqual(true);
+        });
+
+        it("should return true if credentials are not secure", async () => {
+            // ensure that we are not in the team project directory
+            const profInfo = createNewProfInfo(origDir);
+            (profInfo as any).mCredentials = {isSecured: false};
+            const response = await profInfo.profileManagerWillLoad();
+            expect(response).toEqual(true);
+        });
+    });
+
     describe("getDefaultProfile", () => {
 
         it("should return null if no default for that type exists", async () => {

--- a/packages/imperative/src/config/src/ProfileInfo.ts
+++ b/packages/imperative/src/config/src/ProfileInfo.ts
@@ -997,6 +997,25 @@ export class ProfileInfo {
         this.loadAllSchemas();
     }
 
+    //_________________________________________________________________________
+    /**
+     * Function to ensure the credential manager will load successfully
+     * Returns true if it will load, or the credentials are not secured. Returns false if it will not load.
+     */
+    public async profileManagerWillLoad(): Promise<boolean> {
+        if (this.mCredentials.isSecured) {
+            try {
+                await this.mCredentials.loadManager();
+                return true;
+            } catch (err) {
+                this.mImpLogger.warn("Failed to initialize secure credential manager: " + err.message);
+                return false;
+            }
+        } else {
+            return true;
+        }
+    }
+
     // _______________________________________________________________________
     /**
      * Returns an indicator of whether we are using a team configuration or


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->
Adds the `ProfileInfo.profileManagerWillLoad` function that returns if the credential manager will load without loading profiles.
Resolves #2111 in v3

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->
Run test suites

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [x] added/updated automated tests
- [x] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
