### PR TITLE
Export new Proxy class from imperative

### DIFF
--- a/packages/imperative/CHANGELOG.md
+++ b/packages/imperative/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to the Imperative package will be documented in this file.
 
-## `7.28.1`
+## TBD Release
 
 - Bugfix: Export new Proxy class from Zowe imperative package.
 

--- a/packages/imperative/CHANGELOG.md
+++ b/packages/imperative/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Imperative package will be documented in this file.
 
+## `7.28.1`
+
+- Bugfix: Export new Proxy class from Zowe imperative package.
+
 ## `5.26.0`
 
 - Enhancement: Updated `ProfileInfo.updateProperty` function to support updating properties in typeless profiles. [#2196](https://github.com/zowe/zowe-cli/issues/2196)

--- a/packages/imperative/CHANGELOG.md
+++ b/packages/imperative/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to the Imperative package will be documented in this file.
 
-## TBD Release
+## Recent Changes
 
 - Bugfix: Export new Proxy class from Zowe imperative package.
 

--- a/packages/imperative/CHANGELOG.md
+++ b/packages/imperative/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the Imperative package will be documented in this file.
 
 ## Recent Changes
 
-- Bugfix: Export new Proxy class from Zowe imperative package.
+- Bugfix: Export new Proxy class from Zowe imperative package. [#2205](https://github.com/zowe/zowe-cli/pull/2205)
 
 ## `5.26.0`
 

--- a/packages/imperative/src/rest/index.ts
+++ b/packages/imperative/src/rest/index.ts
@@ -17,6 +17,7 @@ export * from "./src/client/doc/IRestClientError";
 export * from "./src/client/doc/IRestClientResponse";
 export * from "./src/client/doc/IRestOptions";
 export * from "./src/client/Headers";
+export * from "./src/client/Proxy";
 export * from "./src/client/AbstractRestClient";
 export * from "./src/client/CompressionUtils";
 export * from "./src/client/RestClient";


### PR DESCRIPTION
**What It Does**

export new Proxy class from imperative

**How to Test**

Extenders can not import new class using 7.27.0 that introduced the new Proxy support, class needs to be exported from package.

**Review Checklist**
I certify that I have:
- [ ] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [ ] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
