### PR TITLE
[v3] Ssh keypassphrase prompt

### DIFF
--- a/packages/cli/__tests__/zosuss/__unit__/issue/ssh/__snapshots__/Ssh.handler.unit.test.ts.snap
+++ b/packages/cli/__tests__/zosuss/__unit__/issue/ssh/__snapshots__/Ssh.handler.unit.test.ts.snap
@@ -6,4 +6,12 @@ exports[`issue ssh handler tests should be able to get stdout 2`] = `"TEST OUTPU
 
 exports[`issue ssh handler tests should be able to get stdout with cwd option 1`] = `"TEST OUTPUT"`;
 
+exports[`issue ssh handler tests should be able to get stdout with private key and key passphrase 1`] = `"TEST OUTPUT"`;
+
 exports[`issue ssh handler tests should be able to get stdout with privateKey 1`] = `"TEST OUTPUT"`;
+
+exports[`issue ssh handler tests should fail if user fails to enter incorrect key passphrase in 3 attempts 1`] = `"Maximum retry attempts reached. Authentication failed."`;
+
+exports[`issue ssh handler tests should prompt user for keyPassphrase if none is stored and privateKey requires one 1`] = `"TEST OUTPUT"`;
+
+exports[`issue ssh handler tests should reprompt user for keyPassphrase up to 3 times if stored passphrase failed 1`] = `"TEST OUTPUT"`;

--- a/packages/cli/__tests__/zosuss/__unit__/issue/ssh/__snapshots__/Ssh.handler.unit.test.ts.snap
+++ b/packages/cli/__tests__/zosuss/__unit__/issue/ssh/__snapshots__/Ssh.handler.unit.test.ts.snap
@@ -12,6 +12,10 @@ exports[`issue ssh handler tests should be able to get stdout with privateKey 1`
 
 exports[`issue ssh handler tests should fail if user fails to enter incorrect key passphrase in 3 attempts 1`] = `"Maximum retry attempts reached. Authentication failed."`;
 
+exports[`issue ssh handler tests should prompt for user and keyPassphrase if neither is stored 1`] = `"test"`;
+
+exports[`issue ssh handler tests should prompt for user and keyPassphrase if neither is stored 2`] = `"test"`;
+
 exports[`issue ssh handler tests should prompt user for keyPassphrase if none is stored and privateKey requires one 1`] = `"TEST OUTPUT"`;
 
 exports[`issue ssh handler tests should reprompt user for keyPassphrase up to 3 times if stored passphrase failed 1`] = `"TEST OUTPUT"`;

--- a/packages/cli/__tests__/zosuss/__unit__/issue/ssh/__snapshots__/Ssh.handler.unit.test.ts.snap
+++ b/packages/cli/__tests__/zosuss/__unit__/issue/ssh/__snapshots__/Ssh.handler.unit.test.ts.snap
@@ -14,8 +14,6 @@ exports[`issue ssh handler tests should fail if user fails to enter incorrect ke
 
 exports[`issue ssh handler tests should prompt for user and keyPassphrase if neither is stored 1`] = `"test"`;
 
-exports[`issue ssh handler tests should prompt for user and keyPassphrase if neither is stored 2`] = `"test"`;
-
 exports[`issue ssh handler tests should prompt user for keyPassphrase if none is stored and privateKey requires one 1`] = `"TEST OUTPUT"`;
 
 exports[`issue ssh handler tests should reprompt user for keyPassphrase up to 3 times if stored passphrase failed 1`] = `"TEST OUTPUT"`;

--- a/packages/imperative/CHANGELOG.md
+++ b/packages/imperative/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to the Imperative package will be documented in this file.
 
+## Recent Changes
+
+- BugFix: Resolved bug that resulted in user not being prompted for a keyPassphrase if in the secure array of ssh profile. [#1770](https://github.com/zowe/zowe-cli/issues/1770)
+- Enhancement: SshBaseHandler will now prompt user up to 3 times to enter the correct keyPassphrase in the case that the stored value is incorrect or no value is stored. [#1770](https://github.com/zowe/zowe-cli/issues/1770)
+
 ## `8.0.0-next.202407262216`
 
 - Update: See `5.26.1` for details

--- a/packages/imperative/CHANGELOG.md
+++ b/packages/imperative/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to the Imperative package will be documented in this file.
 
+## Recent Changes
+
+- BugFix: Resolved bug that resulted in user not being prompted for a keyPassphrase if in the secure array of ssh profile. [#1770](https://github.com/zowe/zowe-cli/issues/1770)
+- Enhancement: SshBaseHandler will now prompt user up to 3 times to enter the correct keyPassphrase in the case that the stored value is incorrect or no value is stored. [#1770](https://github.com/zowe/zowe-cli/issues/1770)
+
 ## `8.0.0-next.202407181255`
 
 - BugFix: Resolved bug that resulted in each plug-in to have identical public registries regardless of actual installation location/reference. [#2189](https://github.com/zowe/zowe-cli/pull/2189)

--- a/packages/imperative/CHANGELOG.md
+++ b/packages/imperative/CHANGELOG.md
@@ -2,11 +2,6 @@
 
 All notable changes to the Imperative package will be documented in this file.
 
-## Recent Changes
-
-- BugFix: Resolved bug that resulted in user not being prompted for a keyPassphrase if in the secure array of ssh profile. [#1770](https://github.com/zowe/zowe-cli/issues/1770)
-- Enhancement: SshBaseHandler will now prompt user up to 3 times to enter the correct keyPassphrase in the case that the stored value is incorrect or no value is stored. [#1770](https://github.com/zowe/zowe-cli/issues/1770)
-
 ## `8.0.0-next.202407262216`
 
 - Update: See `5.26.1` for details

--- a/packages/imperative/CHANGELOG.md
+++ b/packages/imperative/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the Imperative package will be documented in this file.
 
 ## Recent Changes
 
-- BugFix: Resolved bug that resulted in user not being prompted for a keyPassphrase if in the secure array of ssh profile. [#1770](https://github.com/zowe/zowe-cli/issues/1770)
+- BugFix: Resolved bug that resulted in user not being prompted for a key passphrase if it is located in the secure creditial array of the ssh profile. [#1770](https://github.com/zowe/zowe-cli/issues/1770)
 
 ## `8.0.0-next.202407262216`
 

--- a/packages/imperative/CHANGELOG.md
+++ b/packages/imperative/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Imperative package will be documented in this file.
 
+## Recent Changes
+
+- BugFix: Resolved bug that resulted in user not being prompted for a keyPassphrase if in the secure array of ssh profile. [#1770](https://github.com/zowe/zowe-cli/issues/1770)
+
 ## `8.0.0-next.202407262216`
 
 - Update: See `5.26.1` for details

--- a/packages/imperative/CHANGELOG.md
+++ b/packages/imperative/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the Imperative package will be documented in this file.
 
 ## Recent Changes
 
-- BugFix: Resolved bug that resulted in user not being prompted for a key passphrase if it is located in the secure creditial array of the ssh profile. [#1770](https://github.com/zowe/zowe-cli/issues/1770)
+- BugFix: Resolved bug that resulted in user not being prompted for a key passphrase if it is located in the secure credential array of the ssh profile. [#1770](https://github.com/zowe/zowe-cli/issues/1770)
 
 ## `8.0.0-next.202407262216`
 

--- a/packages/imperative/src/imperative/src/plugins/cmd/list/list.handler.ts
+++ b/packages/imperative/src/imperative/src/plugins/cmd/list/list.handler.ts
@@ -98,7 +98,8 @@ export default class ListHandler implements ICommandHandler {
 
         if(containsLegacyPlugin)
         {
-            listOutput = listOutput + `${chalk.yellow.bold("Plug-ins marked with (?) may be invalid or out of date, and might need to be reinstalled.")}` + "\n";
+            listOutput = listOutput + `${chalk.yellow.bold("Plug-ins marked with (?) may be invalid or out of date, and might need to be reinstalled.")}`;
+            listOutput = listOutput + "\n";
         }
 
         if (listOutput === "") {

--- a/packages/imperative/src/rest/__tests__/session/ConnectionPropsForSessCfg.unit.test.ts
+++ b/packages/imperative/src/rest/__tests__/session/ConnectionPropsForSessCfg.unit.test.ts
@@ -1690,7 +1690,7 @@ describe("ConnectionPropsForSessCfg tests", () => {
                     parms: parms as any,
                 }
             );
-        expect(ConnectionPropsForSessCfg.secureSessCfgProps).toContain("keyPassphrase");
+        expect((ConnectionPropsForSessCfg as any).secureSessCfgProps).toContain("keyPassphrase");
     });
     describe("getValuesBack private function", () => {
         // pretend that console.log works, but put data into a variable

--- a/packages/imperative/src/rest/__tests__/session/ConnectionPropsForSessCfg.unit.test.ts
+++ b/packages/imperative/src/rest/__tests__/session/ConnectionPropsForSessCfg.unit.test.ts
@@ -1,13 +1,13 @@
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Eclipse Public License v2.0 which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
- *
- * SPDX-License-Identifier: EPL-2.0
- *
- * Copyright Contributors to the Zowe Project.
- *
- */
+* This program and the accompanying materials are made available under the terms of the
+* Eclipse Public License v2.0 which accompanies this distribution, and is available at
+* https://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Copyright Contributors to the Zowe Project.
+*
+*/
 
 jest.mock("../../../logger/src/LoggerUtils");
 
@@ -1679,7 +1679,7 @@ describe("ConnectionPropsForSessCfg tests", () => {
                 },
             },
         };
-        const sessCfgWithConnProps: extendedSession =
+        const sessCfgWithConnProps: ISshSession =
             await ConnectionPropsForSessCfg.addPropsOrPrompt<ISshSession>(
                 initialSessCfg,
                 args,

--- a/packages/imperative/src/rest/__tests__/session/ConnectionPropsForSessCfg.unit.test.ts
+++ b/packages/imperative/src/rest/__tests__/session/ConnectionPropsForSessCfg.unit.test.ts
@@ -1,13 +1,13 @@
 /*
-* This program and the accompanying materials are made available under the terms of the
-* Eclipse Public License v2.0 which accompanies this distribution, and is available at
-* https://www.eclipse.org/legal/epl-v20.html
-*
-* SPDX-License-Identifier: EPL-2.0
-*
-* Copyright Contributors to the Zowe Project.
-*
-*/
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
 
 jest.mock("../../../logger/src/LoggerUtils");
 
@@ -24,24 +24,50 @@ import { IOverridePromptConnProps } from "../../src/session/doc/IOverridePromptC
 import { IOptionsForAddConnProps } from "../../src/session/doc/IOptionsForAddConnProps";
 import { ImperativeConfig } from "../../../utilities";
 import { ConfigUtils } from "../../../config/src/ConfigUtils";
-
-
-const certFilePath = join(__dirname, "..", "..", "..", "..", "__tests__", "__integration__", "cmd",
-    "__tests__", "integration", "cli", "auth", "__resources__", "fakeCert.cert");
-const certKeyFilePath = join(__dirname, "..", "..", "..", "..", "__tests__", "__integration__", "cmd",
-    "__tests__", "integration", "cli", "auth", "__resources__", "fakeKey.key");
+import { ISshSession } from "../../../../../zosuss/lib/doc/ISshSession";
+const certFilePath = join(
+    __dirname,
+    "..",
+    "..",
+    "..",
+    "..",
+    "__tests__",
+    "__integration__",
+    "cmd",
+    "__tests__",
+    "integration",
+    "cli",
+    "auth",
+    "__resources__",
+    "fakeCert.cert"
+);
+const certKeyFilePath = join(
+    __dirname,
+    "..",
+    "..",
+    "..",
+    "..",
+    "__tests__",
+    "__integration__",
+    "cmd",
+    "__tests__",
+    "integration",
+    "cli",
+    "auth",
+    "__resources__",
+    "fakeKey.key"
+);
 
 interface extendedSession extends ISession {
-    someKey?: string
+    someKey?: string;
 }
 
 describe("ConnectionPropsForSessCfg tests", () => {
-
     afterEach(() => {
         jest.clearAllMocks();
     });
 
-    it("authenticate with user and pass", async() => {
+    it("authenticate with user and pass", async () => {
         const initialSessCfg = {
             rejectUnauthorized: true,
         };
@@ -51,11 +77,13 @@ describe("ConnectionPropsForSessCfg tests", () => {
             host: "SomeHost",
             port: 11,
             user: "FakeUser",
-            password: "FakePassword"
+            password: "FakePassword",
         };
-        const sessCfgWithConnProps = await ConnectionPropsForSessCfg.addPropsOrPrompt<ISession>(
-            initialSessCfg, args
-        );
+        const sessCfgWithConnProps =
+            await ConnectionPropsForSessCfg.addPropsOrPrompt<ISession>(
+                initialSessCfg,
+                args
+            );
         expect(sessCfgWithConnProps.hostname).toBe("SomeHost");
         expect(sessCfgWithConnProps.port).toBe(11);
         expect(sessCfgWithConnProps.user).toBe("FakeUser");
@@ -67,58 +95,68 @@ describe("ConnectionPropsForSessCfg tests", () => {
         expect(sessCfgWithConnProps.certKey).toBeUndefined();
     });
 
-    it("authenticate with user, pass, and tokenType to get token", async() => {
+    it("authenticate with user, pass, and tokenType to get token", async () => {
         const initialSessCfg = {
             hostname: "SomeHost",
             port: 11,
-            rejectUnauthorized: true
+            rejectUnauthorized: true,
         };
         const args = {
             $0: "zowe",
             _: [""],
             user: "FakeUser",
             password: "FakePassword",
-            tokenType: SessConstants.TOKEN_TYPE_JWT
+            tokenType: SessConstants.TOKEN_TYPE_JWT,
         };
-        const sessCfgWithConnProps = await ConnectionPropsForSessCfg.addPropsOrPrompt<ISession>(
-            initialSessCfg, args, {requestToken: true}
-        );
+        const sessCfgWithConnProps =
+            await ConnectionPropsForSessCfg.addPropsOrPrompt<ISession>(
+                initialSessCfg,
+                args,
+                { requestToken: true }
+            );
         expect(sessCfgWithConnProps.hostname).toBe("SomeHost");
         expect(sessCfgWithConnProps.user).toBe("FakeUser");
         expect(sessCfgWithConnProps.password).toBe("FakePassword");
         expect(sessCfgWithConnProps.type).toBe(SessConstants.AUTH_TYPE_TOKEN);
-        expect(sessCfgWithConnProps.tokenType).toBe(SessConstants.TOKEN_TYPE_JWT);
+        expect(sessCfgWithConnProps.tokenType).toBe(
+            SessConstants.TOKEN_TYPE_JWT
+        );
         expect(sessCfgWithConnProps.tokenValue).toBeUndefined();
         expect(sessCfgWithConnProps.cert).toBeUndefined();
         expect(sessCfgWithConnProps.certKey).toBeUndefined();
     });
 
-    it("authenticate with user, pass, and *NO* tokenType to get token", async() => {
+    it("authenticate with user, pass, and *NO* tokenType to get token", async () => {
         const initialSessCfg = {
             hostname: "SomeHost",
             port: 11,
-            rejectUnauthorized: true
+            rejectUnauthorized: true,
         };
         const args = {
             $0: "zowe",
             _: [""],
             user: "FakeUser",
-            password: "FakePassword"
+            password: "FakePassword",
         };
-        const sessCfgWithConnProps = await ConnectionPropsForSessCfg.addPropsOrPrompt<ISession>(
-            initialSessCfg, args, {requestToken: true}
-        );
+        const sessCfgWithConnProps =
+            await ConnectionPropsForSessCfg.addPropsOrPrompt<ISession>(
+                initialSessCfg,
+                args,
+                { requestToken: true }
+            );
         expect(sessCfgWithConnProps.hostname).toBe("SomeHost");
         expect(sessCfgWithConnProps.user).toBe("FakeUser");
         expect(sessCfgWithConnProps.password).toBe("FakePassword");
         expect(sessCfgWithConnProps.type).toBe(SessConstants.AUTH_TYPE_TOKEN);
-        expect(sessCfgWithConnProps.tokenType).toBe(SessConstants.TOKEN_TYPE_JWT);
+        expect(sessCfgWithConnProps.tokenType).toBe(
+            SessConstants.TOKEN_TYPE_JWT
+        );
         expect(sessCfgWithConnProps.tokenValue).toBeUndefined();
         expect(sessCfgWithConnProps.cert).toBeUndefined();
         expect(sessCfgWithConnProps.certKey).toBeUndefined();
     });
 
-    it("authenticate with token value", async() => {
+    it("authenticate with token value", async () => {
         const initialSessCfg = {
             hostname: "SomeHost",
             port: 11,
@@ -129,9 +167,11 @@ describe("ConnectionPropsForSessCfg tests", () => {
             _: [""],
             tokenValue: "FakeToken",
         };
-        const sessCfgWithConnProps = await ConnectionPropsForSessCfg.addPropsOrPrompt<ISession>(
-            initialSessCfg, args
-        );
+        const sessCfgWithConnProps =
+            await ConnectionPropsForSessCfg.addPropsOrPrompt<ISession>(
+                initialSessCfg,
+                args
+            );
         expect(sessCfgWithConnProps.hostname).toBe("SomeHost");
         expect(sessCfgWithConnProps.tokenValue).toBe("FakeToken");
         expect(sessCfgWithConnProps.type).toBe(SessConstants.AUTH_TYPE_BEARER);
@@ -141,48 +181,56 @@ describe("ConnectionPropsForSessCfg tests", () => {
         expect(sessCfgWithConnProps.certKey).toBeUndefined();
     });
 
-    it("authenticate with token value and token type", async() => {
+    it("authenticate with token value and token type", async () => {
         const initialSessCfg = {
             hostname: "SomeHost",
             port: 11,
-            rejectUnauthorized: true
+            rejectUnauthorized: true,
         };
         const args = {
             $0: "zowe",
             _: [""],
             tokenValue: "FakeToken",
-            tokenType: SessConstants.TOKEN_TYPE_LTPA
+            tokenType: SessConstants.TOKEN_TYPE_LTPA,
         };
-        const sessCfgWithConnProps = await ConnectionPropsForSessCfg.addPropsOrPrompt<ISession>(
-            initialSessCfg, args
-        );
+        const sessCfgWithConnProps =
+            await ConnectionPropsForSessCfg.addPropsOrPrompt<ISession>(
+                initialSessCfg,
+                args
+            );
         expect(sessCfgWithConnProps.hostname).toBe("SomeHost");
         expect(sessCfgWithConnProps.tokenValue).toBe("FakeToken");
         expect(sessCfgWithConnProps.type).toBe(SessConstants.AUTH_TYPE_TOKEN);
-        expect(sessCfgWithConnProps.tokenType).toBe(SessConstants.TOKEN_TYPE_LTPA);
+        expect(sessCfgWithConnProps.tokenType).toBe(
+            SessConstants.TOKEN_TYPE_LTPA
+        );
         expect(sessCfgWithConnProps.user).toBeUndefined();
         expect(sessCfgWithConnProps.password).toBeUndefined();
         expect(sessCfgWithConnProps.cert).toBeUndefined();
         expect(sessCfgWithConnProps.certKey).toBeUndefined();
     });
 
-    it("authenticate with certFile and certKeyFile", async() => {
+    it("authenticate with certFile and certKeyFile", async () => {
         const initialSessCfg = {
             hostname: "SomeHost",
             port: 11,
-            rejectUnauthorized: true
+            rejectUnauthorized: true,
         };
         const args = {
             $0: "zowe",
             _: [""],
             certFile: certFilePath,
-            certKeyFile: certKeyFilePath
+            certKeyFile: certKeyFilePath,
         };
-        const sessCfgWithConnProps = await ConnectionPropsForSessCfg.addPropsOrPrompt<ISession>(
-            initialSessCfg, args
-        );
+        const sessCfgWithConnProps =
+            await ConnectionPropsForSessCfg.addPropsOrPrompt<ISession>(
+                initialSessCfg,
+                args
+            );
         expect(sessCfgWithConnProps.hostname).toBe("SomeHost");
-        expect(sessCfgWithConnProps.type).toBe(SessConstants.AUTH_TYPE_CERT_PEM);
+        expect(sessCfgWithConnProps.type).toBe(
+            SessConstants.AUTH_TYPE_CERT_PEM
+        );
         expect(sessCfgWithConnProps.cert).toBe(certFilePath);
         expect(sessCfgWithConnProps.certKey).toBe(certKeyFilePath);
         expect(sessCfgWithConnProps.user).toBeUndefined();
@@ -191,11 +239,11 @@ describe("ConnectionPropsForSessCfg tests", () => {
         expect(sessCfgWithConnProps.tokenValue).toBeUndefined();
     });
 
-    it("ignore token and cert if unsupported auth types and authenticate with user and pass", async() => {
+    it("ignore token and cert if unsupported auth types and authenticate with user and pass", async () => {
         const initialSessCfg = {
             hostname: "SomeHost",
             port: 11,
-            rejectUnauthorized: true
+            rejectUnauthorized: true,
         };
         const args = {
             $0: "zowe",
@@ -203,15 +251,18 @@ describe("ConnectionPropsForSessCfg tests", () => {
             cert: "fakeCert",
             certKey: "fakeCertKey",
             tokenType: SessConstants.TOKEN_TYPE_JWT,
-            tokenValue: "fakeToken"
+            tokenValue: "fakeToken",
         };
         const fakePromptFn = jest.fn().mockReturnValue({
-            "user": "FakeUser",
-            "password": "FakePassword"
+            user: "FakeUser",
+            password: "FakePassword",
         });
-        const sessCfgWithConnProps = await ConnectionPropsForSessCfg.addPropsOrPrompt<ISession>(
-            initialSessCfg, args, {getValuesBack: fakePromptFn, supportedAuthTypes: ["basic"]}
-        );
+        const sessCfgWithConnProps =
+            await ConnectionPropsForSessCfg.addPropsOrPrompt<ISession>(
+                initialSessCfg,
+                args,
+                { getValuesBack: fakePromptFn, supportedAuthTypes: ["basic"] }
+            );
         expect(fakePromptFn).toHaveBeenCalledWith(["user", "password"]);
         expect(sessCfgWithConnProps.hostname).toBe("SomeHost");
         expect(sessCfgWithConnProps.user).toBe("FakeUser");
@@ -219,11 +270,11 @@ describe("ConnectionPropsForSessCfg tests", () => {
         expect(sessCfgWithConnProps.type).toBe(SessConstants.AUTH_TYPE_BASIC);
     });
 
-    it("not set tokenValue if user and pass are defined", async() => {
+    it("not set tokenValue if user and pass are defined", async () => {
         const initialSessCfg = {
             hostname: "SomeHost",
             port: 11,
-            rejectUnauthorized: true
+            rejectUnauthorized: true,
         };
         const args = {
             $0: "zowe",
@@ -231,11 +282,13 @@ describe("ConnectionPropsForSessCfg tests", () => {
             user: "FakeUser",
             password: "FakePassword",
             tokenType: SessConstants.TOKEN_TYPE_JWT,
-            tokenValue: "FakeToken"
+            tokenValue: "FakeToken",
         };
-        const sessCfgWithConnProps = await ConnectionPropsForSessCfg.addPropsOrPrompt<ISession>(
-            initialSessCfg, args
-        );
+        const sessCfgWithConnProps =
+            await ConnectionPropsForSessCfg.addPropsOrPrompt<ISession>(
+                initialSessCfg,
+                args
+            );
         expect(sessCfgWithConnProps.hostname).toBe("SomeHost");
         expect(sessCfgWithConnProps.user).toBe("FakeUser");
         expect(sessCfgWithConnProps.password).toBe("FakePassword");
@@ -246,20 +299,23 @@ describe("ConnectionPropsForSessCfg tests", () => {
         expect(sessCfgWithConnProps.certKey).toBeUndefined();
     });
 
-    it("not prompt when asked not to prompt", async() => {
+    it("not prompt when asked not to prompt", async () => {
         const initialSessCfg = {
             hostname: "SomeHost",
             port: 11,
-            rejectUnauthorized: true
+            rejectUnauthorized: true,
         };
         const args = {
             $0: "zowe",
-            _: [""]
+            _: [""],
         };
 
-        const sessCfgWithConnProps: ISession = await ConnectionPropsForSessCfg.addPropsOrPrompt<ISession>(
-            initialSessCfg, args, {doPrompting: false}
-        );
+        const sessCfgWithConnProps: ISession =
+            await ConnectionPropsForSessCfg.addPropsOrPrompt<ISession>(
+                initialSessCfg,
+                args,
+                { doPrompting: false }
+            );
         expect(sessCfgWithConnProps.type).toBe(SessConstants.AUTH_TYPE_BASIC);
         expect(sessCfgWithConnProps.user).toBeUndefined();
         expect(sessCfgWithConnProps.password).toBeUndefined();
@@ -269,32 +325,37 @@ describe("ConnectionPropsForSessCfg tests", () => {
         expect(sessCfgWithConnProps.certKey).toBeUndefined();
     });
 
-    it("override with a different command line name", async() => {
+    it("override with a different command line name", async () => {
         const passFromPrompt = "somePass";
         const initialSessCfg: extendedSession = {
             hostname: "SomeHost",
             port: 11,
             user: "FakeUser",
             password: "somePass",
-            rejectUnauthorized: true
+            rejectUnauthorized: true,
         };
         const args = {
             $0: "zowe",
             _: [""],
-            someKeyOther: "somekeyvalue"
+            someKeyOther: "somekeyvalue",
         };
-        const overrides: IOverridePromptConnProps[] = [{
-            propertyName: "someKey",
-            argumentName: "someKeyOther",
-            propertiesOverridden: [
-                "password",
-                "tokenType",
-                "tokenValue",
-                "cert",
-                "certKey"
-            ]
-        }];
-        const mockClientPrompt = jest.spyOn(ConnectionPropsForSessCfg as any, "clientPrompt");
+        const overrides: IOverridePromptConnProps[] = [
+            {
+                propertyName: "someKey",
+                argumentName: "someKeyOther",
+                propertiesOverridden: [
+                    "password",
+                    "tokenType",
+                    "tokenValue",
+                    "cert",
+                    "certKey",
+                ],
+            },
+        ];
+        const mockClientPrompt = jest.spyOn(
+            ConnectionPropsForSessCfg as any,
+            "clientPrompt"
+        );
         // command handler prompt method (CLI versus SDK-based prompting)
         const commandHandlerPrompt = jest.fn(() => {
             return Promise.resolve(passFromPrompt);
@@ -303,13 +364,20 @@ describe("ConnectionPropsForSessCfg tests", () => {
         const parms = {
             response: {
                 console: {
-                    prompt: commandHandlerPrompt
-                }
-            }
+                    prompt: commandHandlerPrompt,
+                },
+            },
         };
-        const sessCfgWithConnProps: extendedSession = await ConnectionPropsForSessCfg.addPropsOrPrompt<extendedSession>(
-            initialSessCfg, args, {doPrompting: true, propertyOverrides: overrides, parms: (parms as any)}
-        );
+        const sessCfgWithConnProps: extendedSession =
+            await ConnectionPropsForSessCfg.addPropsOrPrompt<extendedSession>(
+                initialSessCfg,
+                args,
+                {
+                    doPrompting: true,
+                    propertyOverrides: overrides,
+                    parms: parms as any,
+                }
+            );
         expect(sessCfgWithConnProps.type).toBe(SessConstants.AUTH_TYPE_BASIC);
         expect(commandHandlerPrompt).not.toHaveBeenCalled(); // we are only testing that we call an already tested prompt method if in CLI mode
         expect(mockClientPrompt).not.toHaveBeenCalled();
@@ -322,31 +390,36 @@ describe("ConnectionPropsForSessCfg tests", () => {
         expect(sessCfgWithConnProps.certKey).toBeUndefined();
     });
 
-    it("override a session value when an override is specified on the command line", async() => {
+    it("override a session value when an override is specified on the command line", async () => {
         const passFromPrompt = "somePass";
         const initialSessCfg: extendedSession = {
             hostname: "SomeHost",
             port: 11,
             user: "FakeUser",
             password: "somePass",
-            rejectUnauthorized: true
+            rejectUnauthorized: true,
         };
         const args = {
             $0: "zowe",
             _: [""],
-            someKey: "somekeyvalue"
+            someKey: "somekeyvalue",
         };
-        const overrides: IOverridePromptConnProps[] = [{
-            propertyName: "someKey",
-            propertiesOverridden: [
-                "password",
-                "tokenType",
-                "tokenValue",
-                "cert",
-                "certKey"
-            ]
-        }];
-        const mockClientPrompt = jest.spyOn(ConnectionPropsForSessCfg as any, "clientPrompt");
+        const overrides: IOverridePromptConnProps[] = [
+            {
+                propertyName: "someKey",
+                propertiesOverridden: [
+                    "password",
+                    "tokenType",
+                    "tokenValue",
+                    "cert",
+                    "certKey",
+                ],
+            },
+        ];
+        const mockClientPrompt = jest.spyOn(
+            ConnectionPropsForSessCfg as any,
+            "clientPrompt"
+        );
         // command handler prompt method (CLI versus SDK-based prompting)
         const commandHandlerPrompt = jest.fn(() => {
             return Promise.resolve(passFromPrompt);
@@ -355,13 +428,20 @@ describe("ConnectionPropsForSessCfg tests", () => {
         const parms = {
             response: {
                 console: {
-                    prompt: commandHandlerPrompt
-                }
-            }
+                    prompt: commandHandlerPrompt,
+                },
+            },
         };
-        const sessCfgWithConnProps: extendedSession = await ConnectionPropsForSessCfg.addPropsOrPrompt<extendedSession>(
-            initialSessCfg, args, {doPrompting: true, propertyOverrides: overrides, parms: (parms as any)}
-        );
+        const sessCfgWithConnProps: extendedSession =
+            await ConnectionPropsForSessCfg.addPropsOrPrompt<extendedSession>(
+                initialSessCfg,
+                args,
+                {
+                    doPrompting: true,
+                    propertyOverrides: overrides,
+                    parms: parms as any,
+                }
+            );
         expect(sessCfgWithConnProps.type).toBe(SessConstants.AUTH_TYPE_BASIC);
         expect(commandHandlerPrompt).not.toHaveBeenCalled(); // we are only testing that we call an already tested prompt method if in CLI mode
         expect(mockClientPrompt).not.toHaveBeenCalled();
@@ -374,7 +454,7 @@ describe("ConnectionPropsForSessCfg tests", () => {
         expect(sessCfgWithConnProps.certKey).toBeUndefined();
     });
 
-    it("override a session value when an override is specified on the session", async() => {
+    it("override a session value when an override is specified on the session", async () => {
         const passFromPrompt = "somePass";
         const initialSessCfg: extendedSession = {
             hostname: "SomeHost",
@@ -382,74 +462,28 @@ describe("ConnectionPropsForSessCfg tests", () => {
             user: "FakeUser",
             password: "somePass",
             someKey: "somekeyvalue",
-            rejectUnauthorized: true
-        };
-        const args = {
-            $0: "zowe",
-            _: [""]
-        };
-        const overrides: IOverridePromptConnProps[] = [{
-            propertyName: "someKey",
-            propertiesOverridden: [
-                "password",
-                "tokenType",
-                "tokenValue",
-                "cert",
-                "certKey"
-            ]
-        }];
-        const mockClientPrompt = jest.spyOn(ConnectionPropsForSessCfg as any, "clientPrompt");
-        // command handler prompt method (CLI versus SDK-based prompting)
-        const commandHandlerPrompt = jest.fn(() => {
-            return Promise.resolve(passFromPrompt);
-        });
-        // pretend we have a command handler object
-        const parms = {
-            response: {
-                console: {
-                    prompt: commandHandlerPrompt
-                }
-            }
-        };
-        const sessCfgWithConnProps: extendedSession = await ConnectionPropsForSessCfg.addPropsOrPrompt<extendedSession>(
-            initialSessCfg, args, {doPrompting: true, propertyOverrides: overrides, parms: (parms as any)}
-        );
-        expect(sessCfgWithConnProps.type).toBe(SessConstants.AUTH_TYPE_BASIC);
-        expect(commandHandlerPrompt).not.toHaveBeenCalled(); // we are only testing that we call an already tested prompt method if in CLI mode
-        expect(mockClientPrompt).not.toHaveBeenCalled();
-        expect(sessCfgWithConnProps.user).toEqual("FakeUser");
-        expect(sessCfgWithConnProps.someKey).toEqual("somekeyvalue");
-        expect(sessCfgWithConnProps.password).toBeUndefined();
-        expect(sessCfgWithConnProps.tokenType).toBeUndefined();
-        expect(sessCfgWithConnProps.tokenValue).toBeUndefined();
-        expect(sessCfgWithConnProps.cert).toBeUndefined();
-        expect(sessCfgWithConnProps.certKey).toBeUndefined();
-    });
-
-    it("not prompt when an override is specified on the command line", async() => {
-        const passFromPrompt = "somePass";
-        const initialSessCfg: extendedSession = {
-            hostname: "SomeHost",
-            port: 11,
-            user: "FakeUser",
-            rejectUnauthorized: true
+            rejectUnauthorized: true,
         };
         const args = {
             $0: "zowe",
             _: [""],
-            someKey: "somekeyvalue"
         };
-        const overrides: IOverridePromptConnProps[] = [{
-            propertyName: "someKey",
-            propertiesOverridden: [
-                "password",
-                "tokenType",
-                "tokenValue",
-                "cert",
-                "certKey"
-            ]
-        }];
-        const mockClientPrompt = jest.spyOn(ConnectionPropsForSessCfg as any, "clientPrompt");
+        const overrides: IOverridePromptConnProps[] = [
+            {
+                propertyName: "someKey",
+                propertiesOverridden: [
+                    "password",
+                    "tokenType",
+                    "tokenValue",
+                    "cert",
+                    "certKey",
+                ],
+            },
+        ];
+        const mockClientPrompt = jest.spyOn(
+            ConnectionPropsForSessCfg as any,
+            "clientPrompt"
+        );
         // command handler prompt method (CLI versus SDK-based prompting)
         const commandHandlerPrompt = jest.fn(() => {
             return Promise.resolve(passFromPrompt);
@@ -458,13 +492,20 @@ describe("ConnectionPropsForSessCfg tests", () => {
         const parms = {
             response: {
                 console: {
-                    prompt: commandHandlerPrompt
-                }
-            }
+                    prompt: commandHandlerPrompt,
+                },
+            },
         };
-        const sessCfgWithConnProps: extendedSession = await ConnectionPropsForSessCfg.addPropsOrPrompt<extendedSession>(
-            initialSessCfg, args, {doPrompting: true, propertyOverrides: overrides, parms: (parms as any)}
-        );
+        const sessCfgWithConnProps: extendedSession =
+            await ConnectionPropsForSessCfg.addPropsOrPrompt<extendedSession>(
+                initialSessCfg,
+                args,
+                {
+                    doPrompting: true,
+                    propertyOverrides: overrides,
+                    parms: parms as any,
+                }
+            );
         expect(sessCfgWithConnProps.type).toBe(SessConstants.AUTH_TYPE_BASIC);
         expect(commandHandlerPrompt).not.toHaveBeenCalled(); // we are only testing that we call an already tested prompt method if in CLI mode
         expect(mockClientPrompt).not.toHaveBeenCalled();
@@ -477,30 +518,35 @@ describe("ConnectionPropsForSessCfg tests", () => {
         expect(sessCfgWithConnProps.certKey).toBeUndefined();
     });
 
-    it("not prompt when an override is specified on the session", async() => {
+    it("not prompt when an override is specified on the command line", async () => {
         const passFromPrompt = "somePass";
         const initialSessCfg: extendedSession = {
             hostname: "SomeHost",
             port: 11,
             user: "FakeUser",
             rejectUnauthorized: true,
-            someKey: "somekeyvalue"
         };
         const args = {
             $0: "zowe",
-            _: [""]
+            _: [""],
+            someKey: "somekeyvalue",
         };
-        const overrides: IOverridePromptConnProps[] = [{
-            propertyName: "someKey",
-            propertiesOverridden: [
-                "password",
-                "tokenType",
-                "tokenValue",
-                "cert",
-                "certKey"
-            ]
-        }];
-        const mockClientPrompt = jest.spyOn(ConnectionPropsForSessCfg as any, "clientPrompt");
+        const overrides: IOverridePromptConnProps[] = [
+            {
+                propertyName: "someKey",
+                propertiesOverridden: [
+                    "password",
+                    "tokenType",
+                    "tokenValue",
+                    "cert",
+                    "certKey",
+                ],
+            },
+        ];
+        const mockClientPrompt = jest.spyOn(
+            ConnectionPropsForSessCfg as any,
+            "clientPrompt"
+        );
         // command handler prompt method (CLI versus SDK-based prompting)
         const commandHandlerPrompt = jest.fn(() => {
             return Promise.resolve(passFromPrompt);
@@ -509,13 +555,20 @@ describe("ConnectionPropsForSessCfg tests", () => {
         const parms = {
             response: {
                 console: {
-                    prompt: commandHandlerPrompt
-                }
-            }
+                    prompt: commandHandlerPrompt,
+                },
+            },
         };
-        const sessCfgWithConnProps: extendedSession = await ConnectionPropsForSessCfg.addPropsOrPrompt<extendedSession>(
-            initialSessCfg, args, {doPrompting: true, propertyOverrides: overrides, parms: (parms as any)}
-        );
+        const sessCfgWithConnProps: extendedSession =
+            await ConnectionPropsForSessCfg.addPropsOrPrompt<extendedSession>(
+                initialSessCfg,
+                args,
+                {
+                    doPrompting: true,
+                    propertyOverrides: overrides,
+                    parms: parms as any,
+                }
+            );
         expect(sessCfgWithConnProps.type).toBe(SessConstants.AUTH_TYPE_BASIC);
         expect(commandHandlerPrompt).not.toHaveBeenCalled(); // we are only testing that we call an already tested prompt method if in CLI mode
         expect(mockClientPrompt).not.toHaveBeenCalled();
@@ -528,29 +581,35 @@ describe("ConnectionPropsForSessCfg tests", () => {
         expect(sessCfgWithConnProps.certKey).toBeUndefined();
     });
 
-    it("should prompt when an override is specified but is not present", async() => {
+    it("not prompt when an override is specified on the session", async () => {
         const passFromPrompt = "somePass";
         const initialSessCfg: extendedSession = {
             hostname: "SomeHost",
             port: 11,
             user: "FakeUser",
-            rejectUnauthorized: true
+            rejectUnauthorized: true,
+            someKey: "somekeyvalue",
         };
         const args = {
             $0: "zowe",
-            _: [""]
+            _: [""],
         };
-        const overrides: IOverridePromptConnProps[] = [{
-            propertyName: "someKey",
-            propertiesOverridden: [
-                "password",
-                "tokenType",
-                "tokenValue",
-                "cert",
-                "certKey"
-            ]
-        }];
-        const mockClientPrompt = jest.spyOn(ConnectionPropsForSessCfg as any, "clientPrompt");
+        const overrides: IOverridePromptConnProps[] = [
+            {
+                propertyName: "someKey",
+                propertiesOverridden: [
+                    "password",
+                    "tokenType",
+                    "tokenValue",
+                    "cert",
+                    "certKey",
+                ],
+            },
+        ];
+        const mockClientPrompt = jest.spyOn(
+            ConnectionPropsForSessCfg as any,
+            "clientPrompt"
+        );
         // command handler prompt method (CLI versus SDK-based prompting)
         const commandHandlerPrompt = jest.fn(() => {
             return Promise.resolve(passFromPrompt);
@@ -559,13 +618,82 @@ describe("ConnectionPropsForSessCfg tests", () => {
         const parms = {
             response: {
                 console: {
-                    prompt: commandHandlerPrompt
-                }
-            }
+                    prompt: commandHandlerPrompt,
+                },
+            },
         };
-        const sessCfgWithConnProps: extendedSession = await ConnectionPropsForSessCfg.addPropsOrPrompt<extendedSession>(
-            initialSessCfg, args, {doPrompting: true, propertyOverrides: overrides, parms: (parms as any)}
+        const sessCfgWithConnProps: extendedSession =
+            await ConnectionPropsForSessCfg.addPropsOrPrompt<extendedSession>(
+                initialSessCfg,
+                args,
+                {
+                    doPrompting: true,
+                    propertyOverrides: overrides,
+                    parms: parms as any,
+                }
+            );
+        expect(sessCfgWithConnProps.type).toBe(SessConstants.AUTH_TYPE_BASIC);
+        expect(commandHandlerPrompt).not.toHaveBeenCalled(); // we are only testing that we call an already tested prompt method if in CLI mode
+        expect(mockClientPrompt).not.toHaveBeenCalled();
+        expect(sessCfgWithConnProps.user).toEqual("FakeUser");
+        expect(sessCfgWithConnProps.someKey).toEqual("somekeyvalue");
+        expect(sessCfgWithConnProps.password).toBeUndefined();
+        expect(sessCfgWithConnProps.tokenType).toBeUndefined();
+        expect(sessCfgWithConnProps.tokenValue).toBeUndefined();
+        expect(sessCfgWithConnProps.cert).toBeUndefined();
+        expect(sessCfgWithConnProps.certKey).toBeUndefined();
+    });
+
+    it("should prompt when an override is specified but is not present", async () => {
+        const passFromPrompt = "somePass";
+        const initialSessCfg: extendedSession = {
+            hostname: "SomeHost",
+            port: 11,
+            user: "FakeUser",
+            rejectUnauthorized: true,
+        };
+        const args = {
+            $0: "zowe",
+            _: [""],
+        };
+        const overrides: IOverridePromptConnProps[] = [
+            {
+                propertyName: "someKey",
+                propertiesOverridden: [
+                    "password",
+                    "tokenType",
+                    "tokenValue",
+                    "cert",
+                    "certKey",
+                ],
+            },
+        ];
+        const mockClientPrompt = jest.spyOn(
+            ConnectionPropsForSessCfg as any,
+            "clientPrompt"
         );
+        // command handler prompt method (CLI versus SDK-based prompting)
+        const commandHandlerPrompt = jest.fn(() => {
+            return Promise.resolve(passFromPrompt);
+        });
+        // pretend we have a command handler object
+        const parms = {
+            response: {
+                console: {
+                    prompt: commandHandlerPrompt,
+                },
+            },
+        };
+        const sessCfgWithConnProps: extendedSession =
+            await ConnectionPropsForSessCfg.addPropsOrPrompt<extendedSession>(
+                initialSessCfg,
+                args,
+                {
+                    doPrompting: true,
+                    propertyOverrides: overrides,
+                    parms: parms as any,
+                }
+            );
         expect(sessCfgWithConnProps.type).toBe(SessConstants.AUTH_TYPE_BASIC);
         expect(commandHandlerPrompt).toHaveBeenCalled(); // we are only testing that we call an already tested prompt method if in CLI mode
         expect((mockClientPrompt.mock.calls[0][1] as any).parms).toBe(parms);
@@ -578,31 +706,36 @@ describe("ConnectionPropsForSessCfg tests", () => {
         expect(sessCfgWithConnProps.certKey).toBeUndefined();
     });
 
-    it("not prompt when an override is specified and should prioritize the argument value", async() => {
+    it("not prompt when an override is specified and should prioritize the argument value", async () => {
         const passFromPrompt = "somePass";
         const initialSessCfg: extendedSession = {
             hostname: "SomeHost",
             port: 11,
             user: "FakeUser",
             rejectUnauthorized: true,
-            someKey: "somekeyvalue"
+            someKey: "somekeyvalue",
         };
         const args = {
             $0: "zowe",
             _: [""],
-            someKey: "someotherkeyvalue"
+            someKey: "someotherkeyvalue",
         };
-        const overrides: IOverridePromptConnProps[] = [{
-            propertyName: "someKey",
-            propertiesOverridden: [
-                "password",
-                "tokenType",
-                "tokenValue",
-                "cert",
-                "certKey"
-            ]
-        }];
-        const mockClientPrompt = jest.spyOn(ConnectionPropsForSessCfg as any, "clientPrompt");
+        const overrides: IOverridePromptConnProps[] = [
+            {
+                propertyName: "someKey",
+                propertiesOverridden: [
+                    "password",
+                    "tokenType",
+                    "tokenValue",
+                    "cert",
+                    "certKey",
+                ],
+            },
+        ];
+        const mockClientPrompt = jest.spyOn(
+            ConnectionPropsForSessCfg as any,
+            "clientPrompt"
+        );
         // command handler prompt method (CLI versus SDK-based prompting)
         const commandHandlerPrompt = jest.fn(() => {
             return Promise.resolve(passFromPrompt);
@@ -611,13 +744,20 @@ describe("ConnectionPropsForSessCfg tests", () => {
         const parms = {
             response: {
                 console: {
-                    prompt: commandHandlerPrompt
-                }
-            }
+                    prompt: commandHandlerPrompt,
+                },
+            },
         };
-        const sessCfgWithConnProps: extendedSession = await ConnectionPropsForSessCfg.addPropsOrPrompt<extendedSession>(
-            initialSessCfg, args, {doPrompting: true, propertyOverrides: overrides, parms: (parms as any)}
-        );
+        const sessCfgWithConnProps: extendedSession =
+            await ConnectionPropsForSessCfg.addPropsOrPrompt<extendedSession>(
+                initialSessCfg,
+                args,
+                {
+                    doPrompting: true,
+                    propertyOverrides: overrides,
+                    parms: parms as any,
+                }
+            );
         expect(sessCfgWithConnProps.type).toBe(SessConstants.AUTH_TYPE_BASIC);
         expect(commandHandlerPrompt).not.toHaveBeenCalled(); // we are only testing that we call an already tested prompt method if in CLI mode
         expect(mockClientPrompt).not.toHaveBeenCalled();
@@ -630,21 +770,24 @@ describe("ConnectionPropsForSessCfg tests", () => {
         expect(sessCfgWithConnProps.certKey).toBeUndefined();
     });
 
-    it("get user name from prompt from daemon client", async() => {
+    it("get user name from prompt from daemon client", async () => {
         const userFromPrompt = "FakeUser";
         const passFromArgs = "FakePassword";
 
-        const mockClientPrompt = jest.spyOn(ConnectionPropsForSessCfg as any, "clientPrompt");
+        const mockClientPrompt = jest.spyOn(
+            ConnectionPropsForSessCfg as any,
+            "clientPrompt"
+        );
 
         const initialSessCfg = {
             hostname: "SomeHost",
             port: 11,
-            rejectUnauthorized: true
+            rejectUnauthorized: true,
         };
         const args = {
             $0: "zowe",
             _: [""],
-            password: passFromArgs
+            password: passFromArgs,
         };
 
         // command handler prompt method (CLI versus SDK-based prompting)
@@ -656,22 +799,25 @@ describe("ConnectionPropsForSessCfg tests", () => {
         const parms = {
             response: {
                 console: {
-                    prompt: commandHandlerPrompt
-                }
-            }
+                    prompt: commandHandlerPrompt,
+                },
+            },
         };
 
-        const sessCfgWithConnProps: ISession = await ConnectionPropsForSessCfg.addPropsOrPrompt<ISession>(
-            initialSessCfg, args, {
-                parms: parms as any // treat this as a CLI-based prompt
-            }
-        );
+        const sessCfgWithConnProps: ISession =
+            await ConnectionPropsForSessCfg.addPropsOrPrompt<ISession>(
+                initialSessCfg,
+                args,
+                {
+                    parms: parms as any, // treat this as a CLI-based prompt
+                }
+            );
 
         expect(commandHandlerPrompt).toHaveBeenCalled(); // we are only testing that we call an already tested prompt method if in CLI mode
-        expect((mockClientPrompt.mock.calls[0][1] as any).parms).toBe(parms);  // toBe is important here, parms object must be same as original
+        expect((mockClientPrompt.mock.calls[0][1] as any).parms).toBe(parms); // toBe is important here, parms object must be same as original
     });
 
-    it("get user name from prompt", async() => {
+    it("get user name from prompt", async () => {
         const userFromPrompt = "FakeUser";
         const passFromArgs = "FakePassword";
 
@@ -685,17 +831,19 @@ describe("ConnectionPropsForSessCfg tests", () => {
         const initialSessCfg = {
             hostname: "SomeHost",
             port: 11,
-            rejectUnauthorized: true
+            rejectUnauthorized: true,
         };
         const args = {
             $0: "zowe",
             _: [""],
-            password: passFromArgs
+            password: passFromArgs,
         };
 
-        const sessCfgWithConnProps: ISession = await ConnectionPropsForSessCfg.addPropsOrPrompt<ISession>(
-            initialSessCfg, args
-        );
+        const sessCfgWithConnProps: ISession =
+            await ConnectionPropsForSessCfg.addPropsOrPrompt<ISession>(
+                initialSessCfg,
+                args
+            );
         CliUtils.sleep = sleepReal;
         CliUtils.readPrompt = readPromptReal;
 
@@ -708,7 +856,7 @@ describe("ConnectionPropsForSessCfg tests", () => {
         expect(sessCfgWithConnProps.certKey).toBeUndefined();
     });
 
-    it("get password from prompt", async() => {
+    it("get password from prompt", async () => {
         const userFromArgs = "FakeUser";
         const passFromPrompt = "FakePassword";
 
@@ -722,17 +870,19 @@ describe("ConnectionPropsForSessCfg tests", () => {
         const initialSessCfg = {
             hostname: "SomeHost",
             port: 11,
-            rejectUnauthorized: true
+            rejectUnauthorized: true,
         };
         const args = {
             $0: "zowe",
             _: [""],
-            user: userFromArgs
+            user: userFromArgs,
         };
 
-        const sessCfgWithConnProps: ISession = await ConnectionPropsForSessCfg.addPropsOrPrompt<ISession>(
-            initialSessCfg, args
-        );
+        const sessCfgWithConnProps: ISession =
+            await ConnectionPropsForSessCfg.addPropsOrPrompt<ISession>(
+                initialSessCfg,
+                args
+            );
         CliUtils.sleep = sleepReal;
         CliUtils.readPrompt = readPromptReal;
 
@@ -745,7 +895,7 @@ describe("ConnectionPropsForSessCfg tests", () => {
         expect(sessCfgWithConnProps.certKey).toBeUndefined();
     });
 
-    it("get host name from prompt", async() => {
+    it("get host name from prompt", async () => {
         const hostFromPrompt = "FakeHost";
         const portFromArgs = 11;
         const userFromArgs = "FakeUser";
@@ -766,12 +916,14 @@ describe("ConnectionPropsForSessCfg tests", () => {
             _: [""],
             port: portFromArgs,
             user: userFromArgs,
-            password: passFromArgs
+            password: passFromArgs,
         };
 
-        const sessCfgWithConnProps: ISession = await ConnectionPropsForSessCfg.addPropsOrPrompt<ISession>(
-            initialSessCfg, args
-        );
+        const sessCfgWithConnProps: ISession =
+            await ConnectionPropsForSessCfg.addPropsOrPrompt<ISession>(
+                initialSessCfg,
+                args
+            );
         CliUtils.sleep = sleepReal;
         CliUtils.readPrompt = readPromptReal;
 
@@ -785,7 +937,7 @@ describe("ConnectionPropsForSessCfg tests", () => {
         expect(sessCfgWithConnProps.certKey).toBeUndefined();
     });
 
-    it("get port from prompt - string", async() => {
+    it("get port from prompt - string", async () => {
         const hostFromArgs = "FakeHost";
         const portFromPrompt = "11";
         const userFromArgs = "FakeUser";
@@ -799,19 +951,21 @@ describe("ConnectionPropsForSessCfg tests", () => {
         });
 
         const initialSessCfg = {
-            rejectUnauthorized: true
+            rejectUnauthorized: true,
         };
         const args = {
             $0: "zowe",
             _: [""],
             host: hostFromArgs,
             user: userFromArgs,
-            password: passFromArgs
+            password: passFromArgs,
         };
 
-        const sessCfgWithConnProps: ISession = await ConnectionPropsForSessCfg.addPropsOrPrompt<ISession>(
-            initialSessCfg, args
-        );
+        const sessCfgWithConnProps: ISession =
+            await ConnectionPropsForSessCfg.addPropsOrPrompt<ISession>(
+                initialSessCfg,
+                args
+            );
         CliUtils.sleep = sleepReal;
         CliUtils.readPrompt = readPromptReal;
 
@@ -824,7 +978,7 @@ describe("ConnectionPropsForSessCfg tests", () => {
         expect(sessCfgWithConnProps.tokenValue).toBeUndefined();
     });
 
-    it("get port from prompt - number", async() => {
+    it("get port from prompt - number", async () => {
         const hostFromArgs = "FakeHost";
         const portFromPrompt = 11;
         const userFromArgs = "FakeUser";
@@ -836,24 +990,29 @@ describe("ConnectionPropsForSessCfg tests", () => {
         CliUtils.readPrompt = jest.fn(() => {
             return Promise.resolve(portFromPrompt.toString());
         });
-        jest.spyOn(ConnectionPropsForSessCfg as any, "loadSchemaForSessCfgProps").mockReturnValueOnce({
-            port: { type: "number" }
+        jest.spyOn(
+            ConnectionPropsForSessCfg as any,
+            "loadSchemaForSessCfgProps"
+        ).mockReturnValueOnce({
+            port: { type: "number" },
         });
 
         const initialSessCfg = {
-            rejectUnauthorized: true
+            rejectUnauthorized: true,
         };
         const args = {
             $0: "zowe",
             _: [""],
             host: hostFromArgs,
             user: userFromArgs,
-            password: passFromArgs
+            password: passFromArgs,
         };
 
-        const sessCfgWithConnProps: ISession = await ConnectionPropsForSessCfg.addPropsOrPrompt<ISession>(
-            initialSessCfg, args
-        );
+        const sessCfgWithConnProps: ISession =
+            await ConnectionPropsForSessCfg.addPropsOrPrompt<ISession>(
+                initialSessCfg,
+                args
+            );
         CliUtils.sleep = sleepReal;
         CliUtils.readPrompt = readPromptReal;
 
@@ -866,7 +1025,7 @@ describe("ConnectionPropsForSessCfg tests", () => {
         expect(sessCfgWithConnProps.tokenValue).toBeUndefined();
     });
 
-    it("get port from prompt - zero", async() => {
+    it("get port from prompt - zero", async () => {
         const hostFromArgs = "FakeHost";
         const portFromArgs = 0;
         const portFromPrompt = 11;
@@ -879,12 +1038,15 @@ describe("ConnectionPropsForSessCfg tests", () => {
         CliUtils.readPrompt = jest.fn(() => {
             return Promise.resolve(portFromPrompt.toString());
         });
-        jest.spyOn(ConnectionPropsForSessCfg as any, "loadSchemaForSessCfgProps").mockReturnValueOnce({
-            port: { type: "number" }
+        jest.spyOn(
+            ConnectionPropsForSessCfg as any,
+            "loadSchemaForSessCfgProps"
+        ).mockReturnValueOnce({
+            port: { type: "number" },
         });
 
         const initialSessCfg = {
-            rejectUnauthorized: true
+            rejectUnauthorized: true,
         };
         const args = {
             $0: "zowe",
@@ -892,12 +1054,14 @@ describe("ConnectionPropsForSessCfg tests", () => {
             host: hostFromArgs,
             port: portFromArgs,
             user: userFromArgs,
-            password: passFromArgs
+            password: passFromArgs,
         };
 
-        const sessCfgWithConnProps: ISession = await ConnectionPropsForSessCfg.addPropsOrPrompt<ISession>(
-            initialSessCfg, args
-        );
+        const sessCfgWithConnProps: ISession =
+            await ConnectionPropsForSessCfg.addPropsOrPrompt<ISession>(
+                initialSessCfg,
+                args
+            );
         CliUtils.sleep = sleepReal;
         CliUtils.readPrompt = readPromptReal;
 
@@ -910,7 +1074,7 @@ describe("ConnectionPropsForSessCfg tests", () => {
         expect(sessCfgWithConnProps.tokenValue).toBeUndefined();
     });
 
-    it("get host name from prompt with custom service description", async() => {
+    it("get host name from prompt with custom service description", async () => {
         const hostFromPrompt = "FakeHost";
         const portFromArgs = 11;
         const userFromArgs = "FakeUser";
@@ -933,12 +1097,15 @@ describe("ConnectionPropsForSessCfg tests", () => {
             _: [""],
             port: portFromArgs,
             user: userFromArgs,
-            password: passFromArgs
+            password: passFromArgs,
         };
 
-        const sessCfgWithConnProps: ISession = await ConnectionPropsForSessCfg.addPropsOrPrompt<ISession>(
-            initialSessCfg, args, { serviceDescription: "my cool service" }
-        );
+        const sessCfgWithConnProps: ISession =
+            await ConnectionPropsForSessCfg.addPropsOrPrompt<ISession>(
+                initialSessCfg,
+                args,
+                { serviceDescription: "my cool service" }
+            );
         CliUtils.sleep = sleepReal;
         CliUtils.readPrompt = readPromptReal;
 
@@ -951,7 +1118,7 @@ describe("ConnectionPropsForSessCfg tests", () => {
         expect(sessCfgWithConnProps.tokenValue).toBeUndefined();
     });
 
-    it("get port from prompt with custom service description", async() => {
+    it("get port from prompt with custom service description", async () => {
         const hostFromArgs = "FakeHost";
         const portFromPrompt = 11;
         const userFromArgs = "FakeUser";
@@ -965,24 +1132,30 @@ describe("ConnectionPropsForSessCfg tests", () => {
             questionText = text;
             return Promise.resolve(portFromPrompt.toString());
         });
-        jest.spyOn(ConnectionPropsForSessCfg as any, "loadSchemaForSessCfgProps").mockReturnValueOnce({
-            port: { type: "number" }
+        jest.spyOn(
+            ConnectionPropsForSessCfg as any,
+            "loadSchemaForSessCfgProps"
+        ).mockReturnValueOnce({
+            port: { type: "number" },
         });
 
         const initialSessCfg = {
-            rejectUnauthorized: true
+            rejectUnauthorized: true,
         };
         const args = {
             $0: "zowe",
             _: [""],
             host: hostFromArgs,
             user: userFromArgs,
-            password: passFromArgs
+            password: passFromArgs,
         };
 
-        const sessCfgWithConnProps: ISession = await ConnectionPropsForSessCfg.addPropsOrPrompt<ISession>(
-            initialSessCfg, args, { serviceDescription: "my cool service" }
-        );
+        const sessCfgWithConnProps: ISession =
+            await ConnectionPropsForSessCfg.addPropsOrPrompt<ISession>(
+                initialSessCfg,
+                args,
+                { serviceDescription: "my cool service" }
+            );
         CliUtils.sleep = sleepReal;
         CliUtils.readPrompt = readPromptReal;
 
@@ -998,7 +1171,7 @@ describe("ConnectionPropsForSessCfg tests", () => {
         expect(sessCfgWithConnProps.certKey).toBeUndefined();
     });
 
-    it("get host name from prompt with hidden text - service profile", async() => {
+    it("get host name from prompt with hidden text - service profile", async () => {
         const hostFromPrompt = "FakeHost";
         const portFromArgs = 11;
         const userFromArgs = "FakeUser";
@@ -1014,7 +1187,7 @@ describe("ConnectionPropsForSessCfg tests", () => {
             _: [""],
             port: portFromArgs,
             user: userFromArgs,
-            password: passFromArgs
+            password: passFromArgs,
         };
 
         // command handler prompt method (CLI versus SDK-based prompting)
@@ -1029,28 +1202,34 @@ describe("ConnectionPropsForSessCfg tests", () => {
             arguments: {},
             response: {
                 console: {
-                    prompt: commandHandlerPrompt
-                }
-            }
+                    prompt: commandHandlerPrompt,
+                },
+            },
         };
 
-        jest.spyOn(ConfigAutoStore, "findActiveProfile").mockReturnValueOnce(["fruit", "mango"]);
+        jest.spyOn(ConfigAutoStore, "findActiveProfile").mockReturnValueOnce([
+            "fruit",
+            "mango",
+        ]);
         await setupConfigToLoad({
             profiles: {
                 mango: {
                     type: "fruit",
                     properties: {},
-                    secure: ["host"]
-                }
+                    secure: ["host"],
+                },
             },
-            defaults: { fruit: "mango" }
+            defaults: { fruit: "mango" },
         });
 
-        const sessCfgWithConnProps: ISession = await ConnectionPropsForSessCfg.addPropsOrPrompt<ISession>(
-            initialSessCfg, args, {
-                parms: parms as any // treat this as a CLI-based prompt
-            }
-        );
+        const sessCfgWithConnProps: ISession =
+            await ConnectionPropsForSessCfg.addPropsOrPrompt<ISession>(
+                initialSessCfg,
+                args,
+                {
+                    parms: parms as any, // treat this as a CLI-based prompt
+                }
+            );
 
         expect(questionText).toContain("(will be hidden)");
         expect(promptOpts.hideText).toBe(true);
@@ -1062,7 +1241,7 @@ describe("ConnectionPropsForSessCfg tests", () => {
         expect(sessCfgWithConnProps.tokenValue).toBeUndefined();
     });
 
-    it("get host name from prompt with hidden text - base profile", async() => {
+    it("get host name from prompt with hidden text - base profile", async () => {
         const hostFromPrompt = "FakeHost";
         const portFromArgs = 11;
         const userFromArgs = "FakeUser";
@@ -1078,7 +1257,7 @@ describe("ConnectionPropsForSessCfg tests", () => {
             _: [""],
             port: portFromArgs,
             user: userFromArgs,
-            password: passFromArgs
+            password: passFromArgs,
         };
 
         // command handler prompt method (CLI versus SDK-based prompting)
@@ -1093,32 +1272,38 @@ describe("ConnectionPropsForSessCfg tests", () => {
             arguments: {},
             response: {
                 console: {
-                    prompt: commandHandlerPrompt
-                }
-            }
+                    prompt: commandHandlerPrompt,
+                },
+            },
         };
 
-        jest.spyOn(ConfigAutoStore, "findActiveProfile").mockReturnValueOnce(["fruit", "mango"]);
+        jest.spyOn(ConfigAutoStore, "findActiveProfile").mockReturnValueOnce([
+            "fruit",
+            "mango",
+        ]);
         await setupConfigToLoad({
             profiles: {
                 mango: {
                     type: "fruit",
-                    properties: {}
+                    properties: {},
                 },
                 fruit: {
                     type: "base",
                     properties: {},
-                    secure: ["host"]
-                }
+                    secure: ["host"],
+                },
             },
-            defaults: { fruit: "mango", base: "fruit" }
+            defaults: { fruit: "mango", base: "fruit" },
         });
 
-        const sessCfgWithConnProps: ISession = await ConnectionPropsForSessCfg.addPropsOrPrompt<ISession>(
-            initialSessCfg, args, {
-                parms: parms as any // treat this as a CLI-based prompt
-            }
-        );
+        const sessCfgWithConnProps: ISession =
+            await ConnectionPropsForSessCfg.addPropsOrPrompt<ISession>(
+                initialSessCfg,
+                args,
+                {
+                    parms: parms as any, // treat this as a CLI-based prompt
+                }
+            );
 
         expect(questionText).toContain("(will be hidden)");
         expect(promptOpts.hideText).toBe(true);
@@ -1130,7 +1315,7 @@ describe("ConnectionPropsForSessCfg tests", () => {
         expect(sessCfgWithConnProps.tokenValue).toBeUndefined();
     });
 
-    it("throws an error if user doesn't enter port as a number", async() => {
+    it("throws an error if user doesn't enter port as a number", async () => {
         const hostFromArgs = "FakeHost";
         const portFromPrompt = "abcd";
         const userFromArgs = "FakeUser";
@@ -1142,24 +1327,30 @@ describe("ConnectionPropsForSessCfg tests", () => {
         CliUtils.readPrompt = jest.fn(() => {
             return Promise.resolve(portFromPrompt);
         });
-        jest.spyOn(ConnectionPropsForSessCfg as any, "loadSchemaForSessCfgProps").mockReturnValueOnce({
-            port: { type: "number" }
+        jest.spyOn(
+            ConnectionPropsForSessCfg as any,
+            "loadSchemaForSessCfgProps"
+        ).mockReturnValueOnce({
+            port: { type: "number" },
         });
 
         const initialSessCfg = {
-            rejectUnauthorized: true
+            rejectUnauthorized: true,
         };
         const args = {
             $0: "zowe",
             _: [""],
             host: hostFromArgs,
             user: userFromArgs,
-            password: passFromArgs
+            password: passFromArgs,
         };
 
         let theError;
         try {
-            await ConnectionPropsForSessCfg.addPropsOrPrompt<ISession>(initialSessCfg, args);
+            await ConnectionPropsForSessCfg.addPropsOrPrompt<ISession>(
+                initialSessCfg,
+                args
+            );
         } catch (err) {
             theError = err;
         }
@@ -1169,7 +1360,7 @@ describe("ConnectionPropsForSessCfg tests", () => {
         expect(theError.message).toBe("Specified port was not a number.");
     });
 
-    it("timeout waiting for user name", async() => {
+    it("timeout waiting for user name", async () => {
         const sleepReal = CliUtils.sleep;
         CliUtils.sleep = jest.fn();
         const readPromptReal = CliUtils.readPrompt;
@@ -1178,20 +1369,22 @@ describe("ConnectionPropsForSessCfg tests", () => {
         const initialSessCfg = {
             hostname: "SomeHost",
             port: 11,
-            rejectUnauthorized: true
+            rejectUnauthorized: true,
         };
         const args = {
             $0: "zowe",
             _: [""],
-            password: "FakePassword"
+            password: "FakePassword",
         };
 
         let sessCfgWithConnProps: ISession;
         let caughtError;
         try {
-            sessCfgWithConnProps = await ConnectionPropsForSessCfg.addPropsOrPrompt<ISession>(
-                initialSessCfg, args
-            );
+            sessCfgWithConnProps =
+                await ConnectionPropsForSessCfg.addPropsOrPrompt<ISession>(
+                    initialSessCfg,
+                    args
+                );
         } catch (thrownError) {
             caughtError = thrownError;
         }
@@ -1201,7 +1394,7 @@ describe("ConnectionPropsForSessCfg tests", () => {
         expect(caughtError.message).toBe("Timed out waiting for user.");
     });
 
-    it("timeout waiting for password", async() => {
+    it("timeout waiting for password", async () => {
         const sleepReal = CliUtils.sleep;
         CliUtils.sleep = jest.fn();
         const readPromptReal = CliUtils.readPrompt;
@@ -1210,20 +1403,22 @@ describe("ConnectionPropsForSessCfg tests", () => {
         const initialSessCfg = {
             hostname: "SomeHost",
             port: 11,
-            rejectUnauthorized: true
+            rejectUnauthorized: true,
         };
         const args = {
             $0: "zowe",
             _: [""],
-            user: "FakeUser"
+            user: "FakeUser",
         };
 
         let sessCfgWithConnProps: ISession;
         let caughtError;
         try {
-            sessCfgWithConnProps = await ConnectionPropsForSessCfg.addPropsOrPrompt<ISession>(
-                initialSessCfg, args
-            );
+            sessCfgWithConnProps =
+                await ConnectionPropsForSessCfg.addPropsOrPrompt<ISession>(
+                    initialSessCfg,
+                    args
+                );
         } catch (thrownError) {
             caughtError = thrownError;
         }
@@ -1233,7 +1428,7 @@ describe("ConnectionPropsForSessCfg tests", () => {
         expect(caughtError.message).toBe("Timed out waiting for password.");
     });
 
-    it("timeout waiting for host name", async() => {
+    it("timeout waiting for host name", async () => {
         const sleepReal = CliUtils.sleep;
         CliUtils.sleep = jest.fn();
         const readPromptReal = CliUtils.readPrompt;
@@ -1247,15 +1442,17 @@ describe("ConnectionPropsForSessCfg tests", () => {
             _: [""],
             port: 11,
             user: "FakeUser",
-            password: "FakePassword"
+            password: "FakePassword",
         };
 
         let sessCfgWithConnProps: ISession;
         let caughtError;
         try {
-            sessCfgWithConnProps = await ConnectionPropsForSessCfg.addPropsOrPrompt<ISession>(
-                initialSessCfg, args
-            );
+            sessCfgWithConnProps =
+                await ConnectionPropsForSessCfg.addPropsOrPrompt<ISession>(
+                    initialSessCfg,
+                    args
+                );
         } catch (thrownError) {
             caughtError = thrownError;
         }
@@ -1265,7 +1462,7 @@ describe("ConnectionPropsForSessCfg tests", () => {
         expect(caughtError.message).toBe("Timed out waiting for hostname.");
     });
 
-    it("timeout waiting for port number", async() => {
+    it("timeout waiting for port number", async () => {
         const sleepReal = CliUtils.sleep;
         CliUtils.sleep = jest.fn();
         const readPromptReal = CliUtils.readPrompt;
@@ -1279,15 +1476,17 @@ describe("ConnectionPropsForSessCfg tests", () => {
             _: [""],
             host: "SomeHost",
             user: "FakeUser",
-            password: "FakePassword"
+            password: "FakePassword",
         };
 
         let sessCfgWithConnProps: ISession;
         let caughtError;
         try {
-            sessCfgWithConnProps = await ConnectionPropsForSessCfg.addPropsOrPrompt<ISession>(
-                initialSessCfg, args
-            );
+            sessCfgWithConnProps =
+                await ConnectionPropsForSessCfg.addPropsOrPrompt<ISession>(
+                    initialSessCfg,
+                    args
+                );
         } catch (thrownError) {
             caughtError = thrownError;
         }
@@ -1299,7 +1498,8 @@ describe("ConnectionPropsForSessCfg tests", () => {
 
     it("should not log secure properties of session config", async () => {
         const mockLoggerDebug = jest.fn();
-        const getImperativeLoggerSpy = jest.spyOn(Logger, "getImperativeLogger")
+        const getImperativeLoggerSpy = jest
+            .spyOn(Logger, "getImperativeLogger")
             .mockReturnValueOnce({ debug: mockLoggerDebug } as any);
         (ConnectionPropsForSessCfg as any).logSessCfg({
             host: "SomeHost",
@@ -1307,7 +1507,7 @@ describe("ConnectionPropsForSessCfg tests", () => {
             user: "FakeUser",
             password: "FakePassword",
             tokenType: SessConstants.TOKEN_TYPE_JWT,
-            tokenValue: "FakeToken"
+            tokenValue: "FakeToken",
         });
         getImperativeLoggerSpy.mockRestore();
         expect(mockLoggerDebug).toHaveBeenCalledTimes(1);
@@ -1318,7 +1518,7 @@ describe("ConnectionPropsForSessCfg tests", () => {
         expect(logOutput).not.toContain("FakeToken");
     });
 
-    it("SSO CallBack with getValuesBack", async() => {
+    it("SSO CallBack with getValuesBack", async () => {
         const initialSessCfg = {
             rejectUnauthorized: true,
         };
@@ -1327,28 +1527,28 @@ describe("ConnectionPropsForSessCfg tests", () => {
             port: 11,
             user: "FakeUser",
             password: "FakePassword",
-            rejectUnauthorized: false
+            rejectUnauthorized: false,
         };
         const args = {
             $0: "zowe",
-            _: [""]
+            _: [""],
         };
         const fakeFunction = jest.fn((neededProps) => {
             for (const value of neededProps) {
                 switch (value) {
-                    case "hostname" :
+                    case "hostname":
                         neededProps[value] = fakeFunctionSessCfg.hostname;
                         break;
-                    case "port" :
+                    case "port":
                         neededProps[value] = fakeFunctionSessCfg.port;
                         break;
-                    case "user" :
+                    case "user":
                         neededProps[value] = fakeFunctionSessCfg.user;
                         break;
-                    case "password" :
+                    case "password":
                         neededProps[value] = fakeFunctionSessCfg.password;
                         break;
-                    case "rejectUnauthorized" :
+                    case "rejectUnauthorized":
                         neededProps[value] = initialSessCfg.rejectUnauthorized;
                         break;
                     default:
@@ -1357,9 +1557,12 @@ describe("ConnectionPropsForSessCfg tests", () => {
             }
             return neededProps;
         });
-        const sessCfgWithConnProps = await ConnectionPropsForSessCfg.addPropsOrPrompt<ISession>(
-            initialSessCfg, args, {getValuesBack: fakeFunction}
-        );
+        const sessCfgWithConnProps =
+            await ConnectionPropsForSessCfg.addPropsOrPrompt<ISession>(
+                initialSessCfg,
+                args,
+                { getValuesBack: fakeFunction }
+            );
         expect(sessCfgWithConnProps.hostname).toBe("SomeHost");
         expect(sessCfgWithConnProps.port).toBe(11);
         expect(sessCfgWithConnProps.user).toBe("FakeUser");
@@ -1371,7 +1574,7 @@ describe("ConnectionPropsForSessCfg tests", () => {
         expect(sessCfgWithConnProps.certKey).toBeUndefined();
     });
 
-    it("SSO CallBack with getValuesBack and partial session config", async() => {
+    it("SSO CallBack with getValuesBack and partial session config", async () => {
         const initialSessCfg = {
             password: "FakePassword",
             rejectUnauthorized: true,
@@ -1388,19 +1591,19 @@ describe("ConnectionPropsForSessCfg tests", () => {
         const fakeFunction = jest.fn((neededProps) => {
             for (const value of neededProps) {
                 switch (value) {
-                    case "hostname" :
+                    case "hostname":
                         neededProps[value] = fakeFunctionSessCfg.hostname;
                         break;
-                    case "port" :
+                    case "port":
                         neededProps[value] = fakeFunctionSessCfg.port;
                         break;
-                    case "user" :
+                    case "user":
                         neededProps[value] = args.user;
                         break;
-                    case "password" :
+                    case "password":
                         neededProps[value] = initialSessCfg.password;
                         break;
-                    case "rejectUnauthorized" :
+                    case "rejectUnauthorized":
                         neededProps[value] = initialSessCfg.rejectUnauthorized;
                         break;
                     default:
@@ -1409,9 +1612,12 @@ describe("ConnectionPropsForSessCfg tests", () => {
             }
             return neededProps;
         });
-        const sessCfgWithConnProps = await ConnectionPropsForSessCfg.addPropsOrPrompt<ISession>(
-            initialSessCfg, args, {getValuesBack: fakeFunction}
-        );
+        const sessCfgWithConnProps =
+            await ConnectionPropsForSessCfg.addPropsOrPrompt<ISession>(
+                initialSessCfg,
+                args,
+                { getValuesBack: fakeFunction }
+            );
         expect(sessCfgWithConnProps.hostname).toBe("SomeHost");
         expect(sessCfgWithConnProps.port).toBe(11);
         expect(sessCfgWithConnProps.user).toBe("FakeUser");
@@ -1422,20 +1628,83 @@ describe("ConnectionPropsForSessCfg tests", () => {
         expect(sessCfgWithConnProps.cert).toBeUndefined();
         expect(sessCfgWithConnProps.certKey).toBeUndefined();
     });
+    it("should set default values for elements of propsToPromptFor()", async () => {
+        jest.spyOn(ConfigAutoStore, "findActiveProfile").mockReturnValueOnce([
+            "fruit",
+            "mango",
+        ]);
+        await setupConfigToLoad({
+            profiles: {
+                mango: {
+                    type: "fruit",
+                    properties: {},
+                    secure: ["host"],
+                },
+            },
+            defaults: { fruit: "mango" },
+        });
+        const overrides: IOverridePromptConnProps[] = [
+            {
+                propertyName: "someKey",
+                argumentName: "someKeyOther",
+                propertiesOverridden: [
+                    "password",
+                    "tokenType",
+                    "tokenValue",
+                    "cert",
+                    "certKey",
+                ],
+            },
+        ];
+        const passFromPrompt = "somePass";
+        const initialSessCfg: extendedSession = {
+            hostname: "SomeHost",
+            port: 20,
+            user: "FakeUser",
+            rejectUnauthorized: true,
+        };
+        const args = {
+            $0: "zowe",
+            _: [""],
+            someKey: "somekeyvalue",
+        };
 
+        const commandHandlerPrompt = jest.fn(() => {
+            return Promise.resolve(passFromPrompt);
+        });
+        const parms = {
+            response: {
+                console: {
+                    prompt: commandHandlerPrompt,
+                },
+            },
+        };
+        const sessCfgWithConnProps: extendedSession =
+            await ConnectionPropsForSessCfg.addPropsOrPrompt<ISshSession>(
+                initialSessCfg,
+                args,
+                {
+                    doPrompting: true,
+                    propertyOverrides: overrides,
+                    propsToPromptFor: [{name: "keyPassphrase",isGivenValueValid: string => true}],
+                    parms: parms as any,
+                }
+            );
+        expect(ConnectionPropsForSessCfg.secureSessCfgProps).toContain("keyPassphrase");
+    });
     describe("getValuesBack private function", () => {
         // pretend that console.log works, but put data into a variable
         let consoleMsgs = "";
-        const connOpts:IOptionsForAddConnProps = {
+        const connOpts: IOptionsForAddConnProps = {
             parms: {
                 response: {
                     console: {
                         log: jest.fn((logArgs) => {
                             consoleMsgs += "\n" + logArgs;
-                        })
-                    }
-                }
-            }
+                        }),
+                    },
+                },
+            },
         } as any;
 
         let getValuesCallBack: any;
@@ -1443,12 +1712,13 @@ describe("ConnectionPropsForSessCfg tests", () => {
 
         beforeEach(() => {
             // establish a callback function with our fake console.log
-            getValuesCallBack = ConnectionPropsForSessCfg["getValuesBack"](connOpts);
+            getValuesCallBack =
+                ConnectionPropsForSessCfg["getValuesBack"](connOpts);
 
             // pretend that clientPrompt returns an answer
-            clientPromptSpy = jest.spyOn(ConnectionPropsForSessCfg as any, "clientPrompt").mockResolvedValue(
-                Promise.resolve("Some fake answer")
-            );
+            clientPromptSpy = jest
+                .spyOn(ConnectionPropsForSessCfg as any, "clientPrompt")
+                .mockResolvedValue(Promise.resolve("Some fake answer"));
             // clear log messages from last test
             consoleMsgs = "";
         });
@@ -1464,17 +1734,23 @@ describe("ConnectionPropsForSessCfg tests", () => {
                 configurable: true,
                 get: jest.fn(() => {
                     return {
-                        exists: false
+                        exists: false,
                     };
-                })
+                }),
             });
 
             // call the function that we want to test
             await getValuesCallBack(["hostname"]);
 
-            expect(consoleMsgs).toContain("No Zowe client configuration exists.");
-            expect(consoleMsgs).toContain("Therefore, you will be asked for the");
-            expect(consoleMsgs).toContain("connection properties that are required to complete your command.");
+            expect(consoleMsgs).toContain(
+                "No Zowe client configuration exists."
+            );
+            expect(consoleMsgs).toContain(
+                "Therefore, you will be asked for the"
+            );
+            expect(consoleMsgs).toContain(
+                "connection properties that are required to complete your command."
+            );
         });
 
         it("should state that V1 profiles are not supported", async () => {
@@ -1483,9 +1759,9 @@ describe("ConnectionPropsForSessCfg tests", () => {
                 configurable: true,
                 get: jest.fn(() => {
                     return {
-                        exists: false
+                        exists: false,
                     };
-                })
+                }),
             });
 
             /* Pretend that we only have V1 profiles.
@@ -1495,15 +1771,21 @@ describe("ConnectionPropsForSessCfg tests", () => {
                 configurable: true,
                 get: jest.fn(() => {
                     return true;
-                })
+                }),
             });
 
             // call the function that we want to test
             await getValuesCallBack(["hostname"]);
 
-            expect(consoleMsgs).toContain("Only V1 profiles exist. V1 profiles are no longer supported. You should convert");
-            expect(consoleMsgs).toContain("your V1 profiles to a newer Zowe client configuration. Therefore, you will be");
-            expect(consoleMsgs).toContain("asked for the connection properties that are required to complete your command.");
+            expect(consoleMsgs).toContain(
+                "Only V1 profiles exist. V1 profiles are no longer supported. You should convert"
+            );
+            expect(consoleMsgs).toContain(
+                "your V1 profiles to a newer Zowe client configuration. Therefore, you will be"
+            );
+            expect(consoleMsgs).toContain(
+                "asked for the connection properties that are required to complete your command."
+            );
         });
 
         it("should state that connection properties are missing from config", async () => {
@@ -1512,9 +1794,9 @@ describe("ConnectionPropsForSessCfg tests", () => {
                 configurable: true,
                 get: jest.fn(() => {
                     return {
-                        exists: true
+                        exists: true,
                     };
-                })
+                }),
             });
 
             /* Pretend that we do not have any V1 profiles.
@@ -1524,15 +1806,21 @@ describe("ConnectionPropsForSessCfg tests", () => {
                 configurable: true,
                 get: jest.fn(() => {
                     return false;
-                })
+                }),
             });
 
             // call the function that we want to test
             await getValuesCallBack(["hostname"]);
 
-            expect(consoleMsgs).toContain("Some required connection properties have not been specified in your Zowe client");
-            expect(consoleMsgs).toContain("configuration. Therefore, you will be asked for the connection properties that");
-            expect(consoleMsgs).toContain("are required to complete your command.");
+            expect(consoleMsgs).toContain(
+                "Some required connection properties have not been specified in your Zowe client"
+            );
+            expect(consoleMsgs).toContain(
+                "configuration. Therefore, you will be asked for the connection properties that"
+            );
+            expect(consoleMsgs).toContain(
+                "are required to complete your command."
+            );
         });
     });
 });

--- a/packages/imperative/src/rest/src/session/ConnectionPropsForSessCfg.ts
+++ b/packages/imperative/src/rest/src/session/ConnectionPropsForSessCfg.ts
@@ -360,7 +360,7 @@ export class ConnectionPropsForSessCfg {
      * NOTE(Kelosky): redundant from LoggerUtils.SECURE_PROMPT_OPTIONS - leaving
      * for future date to consolidate
      */
-    public static secureSessCfgProps: Set<string> = new Set(["user", "password", "tokenValue", "passphrase"]);
+    private static secureSessCfgProps: Set<string> = new Set(["user", "password", "tokenValue", "passphrase"]);
 
     /**
      * List of prompt messages that is used when the CLI prompts for session

--- a/packages/imperative/src/rest/src/session/ConnectionPropsForSessCfg.ts
+++ b/packages/imperative/src/rest/src/session/ConnectionPropsForSessCfg.ts
@@ -184,7 +184,7 @@ export class ConnectionPropsForSessCfg {
                 connOpts.propsToPromptFor.forEach(obj => {
                     if(obj.isGivenValueValid != null)
                     {
-                        if(!obj.isGivenValueValid(answers.keyPassphrase)) promptForValues = promptForValues.filter(item => obj.name !== item);
+                        if(!obj.isGivenValueValid(answers[obj.name])) promptForValues = promptForValues.filter(item => obj.name !== item);
                     }
                 });
             }

--- a/packages/imperative/src/rest/src/session/ConnectionPropsForSessCfg.ts
+++ b/packages/imperative/src/rest/src/session/ConnectionPropsForSessCfg.ts
@@ -113,8 +113,8 @@ export class ConnectionPropsForSessCfg {
         );
 
         // This function will provide all the needed properties in one array
-        let promptForValues: (keyof ISession)[] = [];
-        const doNotPromptForValues: (keyof ISession)[] = [];
+        let promptForValues: (keyof SessCfgType & string)[] = [];
+        const doNotPromptForValues: (keyof SessCfgType & string)[] = [];
 
         /* Add the override properties to the session object.
          */
@@ -127,7 +127,7 @@ export class ConnectionPropsForSessCfg {
                     if (cmdArgs[argName] != null) { (sessCfgToUse as any)[override.propertyName] = cmdArgs[argName]; }
                     for (const prop of override.propertiesOverridden) {
                         // Make sure we do not prompt for the overridden property.
-                        if (!doNotPromptForValues.includes(prop as any)) { doNotPromptForValues.push(prop as any); }
+                        if (!doNotPromptForValues.includes(prop)) { doNotPromptForValues.push(prop); }
                         if (prop in sessCfgToUse) { (sessCfgToUse as any)[prop] = undefined; }
                     }
                 }
@@ -172,7 +172,7 @@ export class ConnectionPropsForSessCfg {
         this.loadSecureSessCfgProps(connOptsToUse.parms, promptForValues);
 
         if (connOptsToUse.getValuesBack == null && connOptsToUse.doPrompting) {
-            connOptsToUse.getValuesBack = this.getValuesBack(connOptsToUse as any);
+            connOptsToUse.getValuesBack = this.getValuesBack(connOptsToUse);
         }
 
         if (connOptsToUse.getValuesBack != null) {
@@ -380,7 +380,7 @@ export class ConnectionPropsForSessCfg {
      * @param connOpts Options for adding connection properties
      * @returns Name-value pairs of connection properties
      */
-    private static getValuesBack(connOpts: IOptionsForAddConnProps): (properties: string[]) => Promise<{ [key: string]: any }> {
+    private static getValuesBack<SessCfgType extends ISession=ISession>(connOpts: IOptionsForAddConnProps<SessCfgType>): (properties: string[]) => Promise<{ [key: string]: any }> {
         return async (promptForValues: string[]) => {
             /* The check for console.log in the following 'if' statement is only needed for tests
              * which do not create a mock for the connOpts.parms.response.console.log property.

--- a/packages/imperative/src/rest/src/session/ConnectionPropsForSessCfg.ts
+++ b/packages/imperative/src/rest/src/session/ConnectionPropsForSessCfg.ts
@@ -184,7 +184,7 @@ export class ConnectionPropsForSessCfg {
                 connOpts.propsToPromptFor.forEach(obj => {
                     if(obj.isGivenValueValid != null)
                     {
-                        if(!obj.isGivenValueValid(answers)) promptForValues = promptForValues.filter(item => obj.name !== item);
+                        if(!obj.isGivenValueValid(answers.keyPassphrase)) promptForValues = promptForValues.filter(item => obj.name !== item);
                     }
                 });
             }

--- a/packages/imperative/src/rest/src/session/ConnectionPropsForSessCfg.ts
+++ b/packages/imperative/src/rest/src/session/ConnectionPropsForSessCfg.ts
@@ -329,7 +329,7 @@ export class ConnectionPropsForSessCfg {
             impLogger.debug("Using basic authentication");
             sessCfg.type = SessConstants.AUTH_TYPE_BASIC;
         }
-        ConnectionPropsForSessCfg.setTypeForTokenRequest(sessCfg, connOpts as any, cmdArgs.tokenType);
+        ConnectionPropsForSessCfg.setTypeForTokenRequest<SessCfgType>(sessCfg, connOpts, cmdArgs.tokenType);
         ConnectionPropsForSessCfg.logSessCfg(sessCfg);
     }
 
@@ -468,9 +468,9 @@ export class ConnectionPropsForSessCfg {
      * @param tokenType
      *       The type of token that we expect to receive.
      */
-    private static setTypeForTokenRequest(
-        sessCfg: any,
-        options: IOptionsForAddConnProps,
+    private static setTypeForTokenRequest<SessCfgType extends ISession=ISession>(
+        sessCfg: SessCfgType,
+        options: IOptionsForAddConnProps<SessCfgType>,
         tokenType: SessConstants.TOKEN_TYPE_CHOICES
     ) {
         const impLogger = Logger.getImperativeLogger();

--- a/packages/imperative/src/rest/src/session/ConnectionPropsForSessCfg.ts
+++ b/packages/imperative/src/rest/src/session/ConnectionPropsForSessCfg.ts
@@ -360,7 +360,7 @@ export class ConnectionPropsForSessCfg {
      * NOTE(Kelosky): redundant from LoggerUtils.SECURE_PROMPT_OPTIONS - leaving
      * for future date to consolidate
      */
-    private static secureSessCfgProps: Set<string> = new Set(["user", "password", "tokenValue", "passphrase"]);
+    public static secureSessCfgProps: Set<string> = new Set(["user", "password", "tokenValue", "passphrase"]);
 
     /**
      * List of prompt messages that is used when the CLI prompts for session

--- a/packages/imperative/src/rest/src/session/ConnectionPropsForSessCfg.ts
+++ b/packages/imperative/src/rest/src/session/ConnectionPropsForSessCfg.ts
@@ -380,7 +380,8 @@ export class ConnectionPropsForSessCfg {
      * @param connOpts Options for adding connection properties
      * @returns Name-value pairs of connection properties
      */
-    private static getValuesBack<SessCfgType extends ISession=ISession>(connOpts: IOptionsForAddConnProps<SessCfgType>): (properties: string[]) => Promise<{ [key: string]: any }> {
+    private static getValuesBack<SessCfgType extends ISession=ISession>(connOpts: IOptionsForAddConnProps<SessCfgType>):
+    (properties: string[]) => Promise<{ [key: string]: any }> {
         return async (promptForValues: string[]) => {
             /* The check for console.log in the following 'if' statement is only needed for tests
              * which do not create a mock for the connOpts.parms.response.console.log property.

--- a/packages/imperative/src/rest/src/session/doc/IOptionsForAddConnProps.ts
+++ b/packages/imperative/src/rest/src/session/doc/IOptionsForAddConnProps.ts
@@ -52,6 +52,10 @@ export interface IOptionsForAddConnProps<SessCfgType extends ISession=ISession> 
      */
     propertyOverrides?: IOverridePromptConnProps<SessCfgType>[];
 
+     /**
+     * Allows for passing for additional properties to prompt for.
+     * Utilized in the case of a incorrect/not stored key passphrase. s
+     */
     propsToPromptFor?:
     {
         name: keyof SessCfgType,

--- a/packages/imperative/src/rest/src/session/doc/IOptionsForAddConnProps.ts
+++ b/packages/imperative/src/rest/src/session/doc/IOptionsForAddConnProps.ts
@@ -61,7 +61,7 @@ export interface IOptionsForAddConnProps<SessCfgType extends ISession=ISession> 
         name: keyof SessCfgType,
         secure?: boolean,
         description?: string,
-        isGivenValueValid?: (givenValue: {[key: string]: any}) => boolean
+        isGivenValueValid?: (givenValue: string) => boolean
     }[];
 
     /**

--- a/packages/imperative/src/rest/src/session/doc/IOptionsForAddConnProps.ts
+++ b/packages/imperative/src/rest/src/session/doc/IOptionsForAddConnProps.ts
@@ -13,7 +13,7 @@ import { ISession, SessConstants } from "../../..";
 import { IHandlerParameters } from "../../../../cmd";
 import { AUTH_TYPE_CHOICES } from "../SessConstants";
 import { IOverridePromptConnProps } from "./IOverridePromptConnProps";
-
+import { IPropsToPromptFor } from "../doc/IPropsToPromptFor";
 /**
  * Interface for options supplied to ConnectionPropsForSessCfg.addPropsOrPrompt()
  * @export
@@ -56,13 +56,7 @@ export interface IOptionsForAddConnProps<SessCfgType extends ISession=ISession> 
      * Allows passing additional properties for which to prompt.
      * Used in cases of an incorrect or missing key passphrase.
      */
-    propsToPromptFor?:
-    {
-        name: keyof SessCfgType & string,
-        secure?: boolean,
-        description?: string,
-        isGivenValueValid?: (givenValue: string) => boolean
-    }[];
+    propsToPromptFor?: IPropsToPromptFor<SessCfgType>[];
 
     /**
      * Specifies the functionality that external applications will use for prompting.

--- a/packages/imperative/src/rest/src/session/doc/IOptionsForAddConnProps.ts
+++ b/packages/imperative/src/rest/src/session/doc/IOptionsForAddConnProps.ts
@@ -56,7 +56,8 @@ export interface IOptionsForAddConnProps<SessCfgType extends ISession=ISession> 
     {
         name: keyof SessCfgType,
         secure?: boolean,
-        description?: string
+        description?: string,
+        isGivenValueValid?: (givenValue: {[key: string]: any}) => boolean
     }[];
 
     /**

--- a/packages/imperative/src/rest/src/session/doc/IOptionsForAddConnProps.ts
+++ b/packages/imperative/src/rest/src/session/doc/IOptionsForAddConnProps.ts
@@ -58,7 +58,7 @@ export interface IOptionsForAddConnProps<SessCfgType extends ISession=ISession> 
      */
     propsToPromptFor?:
     {
-        name: keyof SessCfgType,
+        name: keyof SessCfgType & string,
         secure?: boolean,
         description?: string,
         isGivenValueValid?: (givenValue: string) => boolean

--- a/packages/imperative/src/rest/src/session/doc/IOptionsForAddConnProps.ts
+++ b/packages/imperative/src/rest/src/session/doc/IOptionsForAddConnProps.ts
@@ -52,9 +52,9 @@ export interface IOptionsForAddConnProps<SessCfgType extends ISession=ISession> 
      */
     propertyOverrides?: IOverridePromptConnProps<SessCfgType>[];
 
-     /**
-     * Allows for passing for additional properties to prompt for.
-     * Utilized in the case of a incorrect/not stored key passphrase. s
+    /**
+     * Allows passing additional properties for which to prompt.
+     * Used in cases of an incorrect or missing key passphrase.
      */
     propsToPromptFor?:
     {

--- a/packages/imperative/src/rest/src/session/doc/IOptionsForAddConnProps.ts
+++ b/packages/imperative/src/rest/src/session/doc/IOptionsForAddConnProps.ts
@@ -9,7 +9,7 @@
 *
 */
 
-import { SessConstants } from "../../..";
+import { ISession, SessConstants } from "../../..";
 import { IHandlerParameters } from "../../../../cmd";
 import { AUTH_TYPE_CHOICES } from "../SessConstants";
 import { IOverridePromptConnProps } from "./IOverridePromptConnProps";
@@ -19,8 +19,7 @@ import { IOverridePromptConnProps } from "./IOverridePromptConnProps";
  * @export
  * @interface ISession
  */
-export interface IOptionsForAddConnProps {
-
+export interface IOptionsForAddConnProps<SessCfgType extends ISession=ISession> {
     /**
      * Indicates that we want to generate a token.
      * When true, we use the user and password for the operation
@@ -51,7 +50,14 @@ export interface IOptionsForAddConnProps {
      * Specifies a list of authentication properties, and what they should override.
      * If one of these properties is available on the session, do not prompt for the other property.
      */
-    propertyOverrides?: IOverridePromptConnProps[];
+    propertyOverrides?: IOverridePromptConnProps<SessCfgType>[];
+
+    propsToPromptFor?:
+    {
+        name: keyof SessCfgType,
+        secure?: boolean,
+        description?: string
+    }[];
 
     /**
      * Specifies the functionality that external applications will use for prompting.

--- a/packages/imperative/src/rest/src/session/doc/IOverridePromptConnProps.ts
+++ b/packages/imperative/src/rest/src/session/doc/IOverridePromptConnProps.ts
@@ -36,5 +36,9 @@ export interface IOverridePromptConnProps<SessCfgType extends ISession=ISession>
      */
     propertiesOverridden: (keyof SessCfgType)[];
 
+    /**
+     * Allows for passing for additional properties to prompt for.
+     * Utilized in the case of a incorrect/not stored key passphrase.
+     */
     propsToPromptFor?: (keyof SessCfgType)[];
 }

--- a/packages/imperative/src/rest/src/session/doc/IOverridePromptConnProps.ts
+++ b/packages/imperative/src/rest/src/session/doc/IOverridePromptConnProps.ts
@@ -16,7 +16,7 @@ import { ISession } from "./ISession";
  * @export
  * @interface IOverridePromptConnProps
  */
-export interface IOverridePromptConnProps {
+export interface IOverridePromptConnProps<SessCfgType extends ISession=ISession> {
     /**
      * Indicates the session property that should be considered in the prompting logic.
      */
@@ -34,5 +34,7 @@ export interface IOverridePromptConnProps {
      * Prompting logic is only in place for host, port, user, and password, but cert, certKey, tokenType, and tokenValue may also need
      * to be overridden.
      */
-    propertiesOverridden: (keyof ISession)[];
+    propertiesOverridden: (keyof SessCfgType)[];
+
+    propsToPromptFor?: (keyof SessCfgType)[];
 }

--- a/packages/imperative/src/rest/src/session/doc/IOverridePromptConnProps.ts
+++ b/packages/imperative/src/rest/src/session/doc/IOverridePromptConnProps.ts
@@ -34,11 +34,11 @@ export interface IOverridePromptConnProps<SessCfgType extends ISession=ISession>
      * Prompting logic is only in place for host, port, user, and password, but cert, certKey, tokenType, and tokenValue may also need
      * to be overridden.
      */
-    propertiesOverridden: (keyof SessCfgType)[];
+    propertiesOverridden: (keyof SessCfgType & string)[];
 
     /**
      * Allows for passing for additional properties to prompt for.
      * Utilized in the case of a incorrect/not stored key passphrase.
      */
-    propsToPromptFor?: (keyof SessCfgType)[];
+    propsToPromptFor?: (keyof SessCfgType & string)[];
 }

--- a/packages/imperative/src/rest/src/session/doc/IOverridePromptConnProps.ts
+++ b/packages/imperative/src/rest/src/session/doc/IOverridePromptConnProps.ts
@@ -37,8 +37,8 @@ export interface IOverridePromptConnProps<SessCfgType extends ISession=ISession>
     propertiesOverridden: (keyof SessCfgType & string)[];
 
     /**
-     * Allows for passing for additional properties to prompt for.
-     * Utilized in the case of a incorrect/not stored key passphrase.
+     * Allows passing additional properties for which to prompt.
+     * Used in cases of an incorrect or missing key passphrase.
      */
     propsToPromptFor?: (keyof SessCfgType & string)[];
 }

--- a/packages/imperative/src/rest/src/session/doc/IPropsToPromptFor.ts
+++ b/packages/imperative/src/rest/src/session/doc/IPropsToPromptFor.ts
@@ -1,0 +1,8 @@
+import { ISession } from "../../..";
+
+export interface IPropsToPromptFor <SessCfgType extends ISession=ISession> {
+    name: keyof SessCfgType & string,
+    secure?: boolean,
+    description?: string,
+    isGivenValueValid?: (givenValue: string) => boolean
+}

--- a/packages/imperative/src/rest/src/session/doc/IPropsToPromptFor.ts
+++ b/packages/imperative/src/rest/src/session/doc/IPropsToPromptFor.ts
@@ -1,4 +1,15 @@
-import { ISession } from "../../..";
+/*
+* This program and the accompanying materials are made available under the terms of the
+* Eclipse Public License v2.0 which accompanies this distribution, and is available at
+* https://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Copyright Contributors to the Zowe Project.
+*
+*/
+
+import { ISession } from './ISession';
 
 export interface IPropsToPromptFor <SessCfgType extends ISession=ISession> {
     name: keyof SessCfgType & string,

--- a/packages/zosuss/CHANGELOG.md
+++ b/packages/zosuss/CHANGELOG.md
@@ -4,8 +4,8 @@ All notable changes to the Zowe z/OS USS SDK package will be documented in this 
 
 ## Recent Changes
 
-- BugFix: Resolved bug that resulted in user not being prompted for a key passphrase if it is located in the secure creditial array of the ssh profile. [#1770](https://github.com/zowe/zowe-cli/issues/1770)
-- Enhancement: SshBaseHandler.ts command processor will now prompt user up to 3 times to enter the correct keyPassphrase in the case that the stored value is incorrect or no value is stored. [#1770](https://github.com/zowe/zowe-cli/issues/1770)
+- BugFix: Resolved bug that resulted in user not being prompted for a key passphrase if it is located in the secure credential array of the ssh profile. [#1770](https://github.com/zowe/zowe-cli/issues/1770)
+- Enhancement: `SshBaseHandler` command processor will now prompt user up to 3 times to enter the correct keyPassphrase in the case that the stored value is incorrect or no value is stored. [#1770](https://github.com/zowe/zowe-cli/issues/1770)
 
 ## `8.0.0-next.202403132009`
 

--- a/packages/zosuss/CHANGELOG.md
+++ b/packages/zosuss/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to the Zowe z/OS USS SDK package will be documented in this file.
 
+## Recent Changes
+
+- BugFix: Resolved bug that resulted in user not being prompted for a keyPassphrase if in the secure array of ssh profile. [#1770](https://github.com/zowe/zowe-cli/issues/1770)
+- Enhancement: SshBaseHandler will now prompt user up to 3 times to enter the correct keyPassphrase in the case that the stored value is incorrect or no value is stored. [#1770](https://github.com/zowe/zowe-cli/issues/1770)
+
 ## `8.0.0-next.202403132009`
 
 - Enhancement: Provide more legible errors to user when they are missing user/password credentials while

--- a/packages/zosuss/CHANGELOG.md
+++ b/packages/zosuss/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the Zowe z/OS USS SDK package will be documented in this 
 
 ## Recent Changes
 
-- BugFix: Resolved bug that resulted in user not being prompted for a keyPassphrase if in the secure array of ssh profile. [#1770](https://github.com/zowe/zowe-cli/issues/1770)
+- BugFix: Resolved bug that resulted in user not being prompted for a key passphrase if it is located in the secure creditial array of the ssh profile. [#1770](https://github.com/zowe/zowe-cli/issues/1770)
 - Enhancement: SshBaseHandler.ts command processor will now prompt user up to 3 times to enter the correct keyPassphrase in the case that the stored value is incorrect or no value is stored. [#1770](https://github.com/zowe/zowe-cli/issues/1770)
 
 ## `8.0.0-next.202403132009`

--- a/packages/zosuss/CHANGELOG.md
+++ b/packages/zosuss/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to the Zowe z/OS USS SDK package will be documented in this 
 ## Recent Changes
 
 - BugFix: Resolved bug that resulted in user not being prompted for a keyPassphrase if in the secure array of ssh profile. [#1770](https://github.com/zowe/zowe-cli/issues/1770)
-- Enhancement: SshBaseHandler will now prompt user up to 3 times to enter the correct keyPassphrase in the case that the stored value is incorrect or no value is stored. [#1770](https://github.com/zowe/zowe-cli/issues/1770)
+- Enhancement: SshBaseHandler.ts command processor will now prompt user up to 3 times to enter the correct keyPassphrase in the case that the stored value is incorrect or no value is stored. [#1770](https://github.com/zowe/zowe-cli/issues/1770)
 
 ## `8.0.0-next.202403132009`
 

--- a/packages/zosuss/__tests__/__unit__/SshBaseHandler.unit.test.ts
+++ b/packages/zosuss/__tests__/__unit__/SshBaseHandler.unit.test.ts
@@ -228,4 +228,15 @@ describe("issue ssh handler tests", () => {
         expect(Shell.executeSsh).toHaveBeenCalledTimes(1);
         expect(testOutput).toMatchSnapshot();
     });
+    it("should be able to get stdout with privateKey", async () => {
+        Shell.executeSsh = jest.fn(async (session, command, stdoutHandler) => {
+            stdoutHandler(testOutput);
+        });
+        const handler = new myHandler();
+        const params = Object.assign({}, ...[DEFAULT_PARAMETERS_PRIVATE_KEY]);
+        params.arguments.command = "pwd";
+        await handler.process(params);
+        expect(Shell.executeSsh).toHaveBeenCalledTimes(1);
+        expect(testOutput).toMatchSnapshot();
+    });
 });

--- a/packages/zosuss/__tests__/__unit__/SshBaseHandler.unit.test.ts
+++ b/packages/zosuss/__tests__/__unit__/SshBaseHandler.unit.test.ts
@@ -228,15 +228,4 @@ describe("issue ssh handler tests", () => {
         expect(Shell.executeSsh).toHaveBeenCalledTimes(1);
         expect(testOutput).toMatchSnapshot();
     });
-    it("should be able to get stdout with privateKey", async () => {
-        Shell.executeSsh = jest.fn(async (session, command, stdoutHandler) => {
-            stdoutHandler(testOutput);
-        });
-        const handler = new myHandler();
-        const params = Object.assign({}, ...[DEFAULT_PARAMETERS_PRIVATE_KEY]);
-        params.arguments.command = "pwd";
-        await handler.process(params);
-        expect(Shell.executeSsh).toHaveBeenCalledTimes(1);
-        expect(testOutput).toMatchSnapshot();
-    });
 });

--- a/packages/zosuss/__tests__/__unit__/__snapshots__/SshBaseHandler.unit.test.ts.snap
+++ b/packages/zosuss/__tests__/__unit__/__snapshots__/SshBaseHandler.unit.test.ts.snap
@@ -1,0 +1,17 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`issue ssh handler tests should be able to get stdout 1`] = `"TEST OUTPUT"`;
+
+exports[`issue ssh handler tests should be able to get stdout 2`] = `"TEST OUTPUT"`;
+
+exports[`issue ssh handler tests should be able to get stdout with private key and key passphrase 1`] = `"TEST OUTPUT"`;
+
+exports[`issue ssh handler tests should be able to get stdout with privateKey 1`] = `"TEST OUTPUT"`;
+
+exports[`issue ssh handler tests should fail if user fails to enter incorrect key passphrase in 3 attempts 1`] = `"Maximum retry attempts reached. Authentication failed."`;
+
+exports[`issue ssh handler tests should prompt for user and keyPassphrase if neither is stored 1`] = `"test"`;
+
+exports[`issue ssh handler tests should prompt user for keyPassphrase if none is stored and privateKey requires one 1`] = `"TEST OUTPUT"`;
+
+exports[`issue ssh handler tests should reprompt user for keyPassphrase up to 3 times if stored passphrase failed 1`] = `"TEST OUTPUT"`;

--- a/packages/zosuss/__tests__/__unit__/__snapshots__/SshBaseHandler.unit.test.ts.snap
+++ b/packages/zosuss/__tests__/__unit__/__snapshots__/SshBaseHandler.unit.test.ts.snap
@@ -8,8 +8,6 @@ exports[`issue ssh handler tests should be able to get stdout with private key a
 
 exports[`issue ssh handler tests should be able to get stdout with privateKey 1`] = `"TEST OUTPUT"`;
 
-exports[`issue ssh handler tests should be able to get stdout with privateKey 2`] = `"TEST OUTPUT"`;
-
 exports[`issue ssh handler tests should fail if user fails to enter incorrect key passphrase in 3 attempts 1`] = `"Maximum retry attempts reached. Authentication failed."`;
 
 exports[`issue ssh handler tests should prompt for user and keyPassphrase if neither is stored 1`] = `"test"`;

--- a/packages/zosuss/__tests__/__unit__/__snapshots__/SshBaseHandler.unit.test.ts.snap
+++ b/packages/zosuss/__tests__/__unit__/__snapshots__/SshBaseHandler.unit.test.ts.snap
@@ -8,6 +8,8 @@ exports[`issue ssh handler tests should be able to get stdout with private key a
 
 exports[`issue ssh handler tests should be able to get stdout with privateKey 1`] = `"TEST OUTPUT"`;
 
+exports[`issue ssh handler tests should be able to get stdout with privateKey 2`] = `"TEST OUTPUT"`;
+
 exports[`issue ssh handler tests should fail if user fails to enter incorrect key passphrase in 3 attempts 1`] = `"Maximum retry attempts reached. Authentication failed."`;
 
 exports[`issue ssh handler tests should prompt for user and keyPassphrase if neither is stored 1`] = `"test"`;

--- a/packages/zosuss/src/SshBaseHandler.ts
+++ b/packages/zosuss/src/SshBaseHandler.ts
@@ -1,13 +1,13 @@
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Eclipse Public License v2.0 which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
- *
- * SPDX-License-Identifier: EPL-2.0
- *
- * Copyright Contributors to the Zowe Project.
- *
- */
+* This program and the accompanying materials are made available under the terms of the
+* Eclipse Public License v2.0 which accompanies this distribution, and is available at
+* https://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Copyright Contributors to the Zowe Project.
+*
+*/
 
 import {
     // AbstractSession,
@@ -120,9 +120,7 @@ export abstract class SshBaseHandler implements ICommandHandler {
                                                 let saveKP: boolean = true;
                                                 const result = utils.parseKey(
                                                     fs.readFileSync(
-                                                        sshSessCfgWithCreds[
-                                                            "privateKey"
-                                                        ]
+                                                        sshSessCfgWithCreds.privateKey
                                                     ),
                                                     givenValue.keyPassphrase
                                                 );
@@ -147,11 +145,10 @@ export abstract class SshBaseHandler implements ICommandHandler {
                         this.console.log(
                             "\n" +
                                 `Key passphrase authentication failed! (${
-                                    attempt + 1
+                                    ++attempt
                                 }/${maxAttempts})` +
                                 "\n"
                         );
-                        attempt++;
                         if (attempt >= maxAttempts) {
                             throw new Error(
                                 "Maximum retry attempts reached. Authentication failed."

--- a/packages/zosuss/src/SshBaseHandler.ts
+++ b/packages/zosuss/src/SshBaseHandler.ts
@@ -91,7 +91,7 @@ export abstract class SshBaseHandler implements ICommandHandler {
         try {
             await this.processCmd(commandParameters);
         } catch (e) {
-            commandParameters.response.console.log("Initial key passphrase authentication failed!" + "\n");
+            this.console.log("Initial key passphrase authentication failed!" + "\n");
             if (
                 e.message.includes("but no passphrase given") ||
                 e.message.includes("bad passphrase?")
@@ -144,7 +144,7 @@ export abstract class SshBaseHandler implements ICommandHandler {
                         await this.processCmd(commandParameters);
                         success = true;
                     } catch (retryError) {
-                        commandParameters.response.console.log(
+                        this.console.log(
                             "\n" +
                                 `Key passphrase authentication failed! (${
                                     attempt + 1

--- a/packages/zosuss/src/SshBaseHandler.ts
+++ b/packages/zosuss/src/SshBaseHandler.ts
@@ -114,15 +114,13 @@ export abstract class SshBaseHandler implements ICommandHandler {
                                     propsToPromptFor: [
                                         {
                                             name: "keyPassphrase",
-                                            isGivenValueValid: (givenValue: {
-                                                [key: string]: any;
-                                            }) => {
+                                            isGivenValueValid: (givenValue: string) => {
                                                 let saveKP: boolean = true;
                                                 const result = utils.parseKey(
                                                     fs.readFileSync(
                                                         sshSessCfgWithCreds.privateKey
                                                     ),
-                                                    givenValue.keyPassphrase
+                                                    givenValue
                                                 );
                                                 if (result instanceof Error)
                                                     saveKP =

--- a/packages/zosuss/src/SshBaseHandler.ts
+++ b/packages/zosuss/src/SshBaseHandler.ts
@@ -91,11 +91,11 @@ export abstract class SshBaseHandler implements ICommandHandler {
         try {
             await this.processCmd(commandParameters);
         } catch (e) {
-            this.console.log("Initial key passphrase authentication failed!" + "\n");
             if (
                 e.message.includes("but no passphrase given") ||
                 e.message.includes("bad passphrase?")
             ) {
+                this.console.log("Initial key passphrase authentication failed!" + "\n");
                 const maxAttempts = 3;
                 let attempt = 0;
                 let success = false;
@@ -154,6 +154,10 @@ export abstract class SshBaseHandler implements ICommandHandler {
                         }
                     }
                 }
+            }
+            else
+            {
+                throw e;
             }
         }
     }


### PR DESCRIPTION
**What It Does**

Resolved bug that resulted in user not being prompted for a keyPassphrase if in the secure array of ssh profile. 
SshBaseHandler will now prompt user up to 3 times to enter the correct keyPassphrase in the case that the stored value is incorrect or no value is stored

I certify that I have:
- [x] tested my changes
- [x] added/updated automated tests
- [x] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)
