### PR TITLE
[v1] Fail on error behavior

### DIFF
--- a/packages/imperative/CHANGELOG.md
+++ b/packages/imperative/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the Imperative package will be documented in this file.
 
 ## Recent Changes
 
-- BugFix: modified `plugins validate` to default to fail when an error occurs. `zowe plugins validate <plugin-name>` behaves as `zowe plugins validate <plugin-name> --fail-on-error` [#2221](https://github.com/zowe/zowe-cli/pull/2221)
+- BugFix: modified `plugins validate` command to default to fail when an error occurs. `zowe plugins validate <plugin-name>` command now behaves as the command `zowe plugins validate <plugin-name> --fail-on-error` [#2221](https://github.com/zowe/zowe-cli/pull/2221)
 
 ## `4.18.25`
 

--- a/packages/imperative/CHANGELOG.md
+++ b/packages/imperative/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Imperative package will be documented in this file.
 
+## Recent Changes
+
+- BugFix: modified `plugins validate` to default to fail when an error occurs. `zowe plugins validate <plugin-name>` behaves as `zowe plugins validate <plugin-name> --fail-on-error` [#2221](https://github.com/zowe/zowe-cli/pull/2221)
+
 ## `4.18.25`
 
 - BugFix: Fixed error in REST client that when using stream could cause small data sets to download with incomplete contents. [#744](https://github.com/zowe/zowe-cli/issues/744)

--- a/packages/imperative/src/imperative/src/plugins/cmd/validate/validate.definition.ts
+++ b/packages/imperative/src/imperative/src/plugins/cmd/validate/validate.definition.ts
@@ -42,7 +42,7 @@ export const validateDefinition: ICommandDefinition = {
             type: "boolean",
             description: "Enables throwing an error and setting an error code if plugin validation detects an error",
             required: false,
-            defaultValue: false
+            defaultValue: true
         },
         {
             name: "fail-on-warning",


### PR DESCRIPTION
modified `plugins validate` to default to fail when an error occurs. `zowe plugins validate <plugin-name>` behaves as `zowe plugins validate <plugin-name> --fail-on-error`

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [x] added/updated automated tests
- [x] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)
