### PR TITLE
Create web help lockfile only when publishing package

### DIFF
--- a/packages/imperative/package.json
+++ b/packages/imperative/package.json
@@ -41,7 +41,8 @@
     "typedoc": "typedoc --options ./typedoc.json ./src/",
     "typedocSpecifySrc": "typedoc --options ./typedoc.json",
     "prepack": "node ../../scripts/prepareLicenses.js",
-    "clean": "rimraf lib tsconfig.tsbuildinfo"
+    "clean": "rimraf lib tsconfig.tsbuildinfo",
+    "prepublishOnly": "cd web-help && npm run deps:lockfile"
   },
   "dependencies": {
     "@types/yargs": "13.0.4",

--- a/packages/imperative/web-help/package.json
+++ b/packages/imperative/web-help/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "tsc --build ./tsconfig.json",
     "watch": "tsc --build ./tsconfig.json -w",
-    "prepare": "node ../../../scripts/rewriteShrinkwrap.js package-lock.json"
+    "deps:lockfile": "node ../../../scripts/rewriteShrinkwrap.js package-lock.json"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->
Fixes the nightly CLI bundle workflow which has still been failing: https://github.com/zowe/zowe-cli-standalone-package/actions/workflows/zowe-cli-bundle-all.yaml

We can generate the web help lockfile in the Imperative `prepublishOnly` script rather than in the web-help `prepare` script. This should limit the script so it only runs just before the Imperative package is published, and matches the way that we generate the CLI shrinkwrap file which also uses a `prepublishOnly` script 😋 

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->

**Review Checklist**
I certify that I have:
- [ ] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [ ] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
