### PR TITLE
[v3] Update next for deprecation replacement

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -26,7 +26,9 @@ jobs:
       uses: dtolnay/rust-toolchain@stable
 
     - name: Check Node Vulnerabilities
-      run: npm audit --production --audit-level=moderate
+      run: |
+        npm install --package-lock-only --ignore-scripts --no-audit --save-prod --workspace=packages/imperative ./packages/imperative/web-help
+        npm audit --production --audit-level=moderate
 
     # TODO Consider using actions-rs/audit-check after https://github.com/actions-rs/audit-check/issues/116 is fixed
     - name: Check Daemon Vulnerabilities

--- a/__tests__/__packages__/cli-test-utils/tsconfig.json
+++ b/__tests__/__packages__/cli-test-utils/tsconfig.json
@@ -4,6 +4,7 @@
     "target": "es5",
     "module": "commonjs",
     "declaration": true,
+    "declarationMap": true,
     "outDir": "./lib",
     "rootDir": "./src",
     "strict": true,

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -5910,8 +5910,7 @@
         "url": "https://opencollective.com/bootstrap"
       },
       "peerDependencies": {
-        "jquery": "1.9.1 - 3",
-        "popper.js": "^1.16.1"
+        "@popperjs/core": "^2.11.8"
       }
     },
     "node_modules/boxen": {
@@ -13700,8 +13699,8 @@
       "license": "MIT",
       "dependencies": {
         "nanoid": "^3.3.7",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
+        "picocolors": "^1.0.1",
+        "source-map-js": "^1.2.0"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
@@ -14489,6 +14488,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/scroll-into-view-if-needed": {
+      "version": "2.2.29",
+      "resolved": "https://registry.npmjs.org/scroll-into-view-if-needed/-/scroll-into-view-if-needed-2.2.29.tgz",
+      "integrity": "sha512-hxpAR6AN+Gh53AdAimHM6C8oTN1ppwVZITihix+WqalywBeFcQ6LdQP5ABNl26nX8GTEL7VT+b8lKpdqq65wXg==",
+      "dev": true,
+      "dependencies": {
+        "compute-scroll-into-view": "^1.0.17"
       }
     },
     "node_modules/select": {
@@ -16620,20 +16628,20 @@
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "balloon-css": "^1.0.4",
-        "bootstrap": "^4.4.1",
-        "clipboard": "^2.0.4",
-        "github-markdown-css": "^5.1.0",
-        "jquery": "^3.4.1",
-        "jstree": "^3.3.8",
-        "scroll-into-view-if-needed": "2.2.22",
-        "split.js": "^1.5.11",
-        "url-search-params-polyfill": "^8.0.0"
+        "balloon-css": "^1.2.0",
+        "bootstrap": "^5.3.3",
+        "clipboard": "^2.0.11",
+        "github-markdown-css": "^5.6.1",
+        "jquery": "^3.7.1",
+        "jstree": "^3.3.16",
+        "scroll-into-view-if-needed": "2.2.29",
+        "split.js": "^1.6.5",
+        "url-search-params-polyfill": "^8.2.5"
       },
       "devDependencies": {
-        "@types/jquery": "^3.3.31",
-        "@types/jstree": "^3.3.39",
-        "postcss": "^8.3.6",
+        "@types/jquery": "^3.5.30",
+        "@types/jstree": "^3.3.46",
+        "postcss": "^8.4.41",
         "postcss-url": "^10.1.3"
       }
     },

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4486,7 +4486,9 @@
       }
     },
     "node_modules/@types/jquery": {
-      "version": "3.5.19",
+      "version": "3.5.30",
+      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.5.30.tgz",
+      "integrity": "sha512-nbWKkkyb919DOUxjmRVk8vwtDb0/k8FKncmUKFi+NY+QXqWltooxTrswvz4LspQwxvLdvzBN1TImr6cw3aQx2A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4512,7 +4514,9 @@
       }
     },
     "node_modules/@types/jstree": {
-      "version": "3.3.44",
+      "version": "3.3.46",
+      "resolved": "https://registry.npmjs.org/@types/jstree/-/jstree-3.3.46.tgz",
+      "integrity": "sha512-Xj+lbRetEsI1TkP2cmQuCDSCT7qD3OUUCtok/8q2f2hx4PCXkBdjRO7AnS8CNj/tKsqjjZ0Pq6cNfyRcqDumsw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5902,13 +5906,21 @@
       "license": "MIT"
     },
     "node_modules/bootstrap": {
-      "version": "4.6.1",
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.3.tgz",
+      "integrity": "sha512-8HLCdWgyoMguSO9o+aH+iuZ+aht+mzW0u3HIMzVu7Srrpv7EBBxTnrFlSCskwdY1+EOFQSm7uMJhNQHkdPcmjg==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/twbs"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/bootstrap"
+        }
+      ],
       "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/bootstrap"
-      },
       "peerDependencies": {
         "@popperjs/core": "^2.11.8"
       }
@@ -8798,9 +8810,14 @@
       }
     },
     "node_modules/github-markdown-css": {
-      "version": "5.2.0",
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/github-markdown-css/-/github-markdown-css-5.6.1.tgz",
+      "integrity": "sha512-DItLFgHd+s7HQmk63YN4/TdvLeRqk1QP7pPKTTPrDTYoI5x7f/luJWSOZxesmuxBI2srHp8RDyoZd+9WF+WK8Q==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
@@ -10744,24 +10761,6 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/jest-stare/node_modules/bootstrap": {
-      "version": "5.3.3",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/twbs"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/bootstrap"
-        }
-      ],
-      "license": "MIT",
-      "peerDependencies": {
-        "@popperjs/core": "^2.11.8"
-      }
-    },
     "node_modules/jest-stare/node_modules/find-up": {
       "version": "3.0.0",
       "dev": true,
@@ -10864,7 +10863,9 @@
       }
     },
     "node_modules/jquery": {
-      "version": "3.6.0",
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.1.tgz",
+      "integrity": "sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg==",
       "dev": true,
       "license": "MIT"
     },
@@ -13567,7 +13568,9 @@
       }
     },
     "node_modules/picocolors": {
-      "version": "1.0.0",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.1.tgz",
+      "integrity": "sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew==",
       "dev": true,
       "license": "ISC"
     },
@@ -13680,7 +13683,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.35",
+      "version": "8.4.41",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.41.tgz",
+      "integrity": "sha512-TesUflQ0WKZqAvg52PWL6kHgLKP6xB6heTOdoYM0Wt2UHyxNa4K25EZZMgKns3BH1RLVbZCREPpLY0rhnNoHVQ==",
       "dev": true,
       "funding": [
         {
@@ -14808,7 +14813,9 @@
       }
     },
     "node_modules/source-map-js": {
-      "version": "1.0.2",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.0.tgz",
+      "integrity": "sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -16589,14 +16596,6 @@
       "license": "ISC",
       "engines": {
         "node": ">=16"
-      }
-    },
-    "packages/imperative/node_modules/scroll-into-view-if-needed": {
-      "version": "2.2.22",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "compute-scroll-into-view": "^1.0.12"
       }
     },
     "packages/imperative/node_modules/uuid": {

--- a/packages/cli/src/zosuss/issue/ssh/Ssh.definition.ts
+++ b/packages/cli/src/zosuss/issue/ssh/Ssh.definition.ts
@@ -38,6 +38,5 @@ export const SshDefinition: ICommandDefinition = {
     examples: [{
         description: "Issue a simple command, giving the working directory",
         options: "\"npm install express\" --cwd /u/cicprov/mnt/CICPY01I/bundles/myapp "
-    }],
-    deprecatedReplacement: "aaa"
+    }]
 };

--- a/packages/cli/src/zosuss/issue/ssh/Ssh.definition.ts
+++ b/packages/cli/src/zosuss/issue/ssh/Ssh.definition.ts
@@ -38,6 +38,5 @@ export const SshDefinition: ICommandDefinition = {
     examples: [{
         description: "Issue a simple command, giving the working directory",
         options: "\"npm install express\" --cwd /u/cicprov/mnt/CICPY01I/bundles/myapp "
-    }],
-    deprecatedReplacement: ""
+    }]
 };

--- a/packages/cli/src/zosuss/issue/ssh/Ssh.definition.ts
+++ b/packages/cli/src/zosuss/issue/ssh/Ssh.definition.ts
@@ -38,5 +38,6 @@ export const SshDefinition: ICommandDefinition = {
     examples: [{
         description: "Issue a simple command, giving the working directory",
         options: "\"npm install express\" --cwd /u/cicprov/mnt/CICPY01I/bundles/myapp "
-    }]
+    }],
+    deprecatedReplacement: "aaa"
 };

--- a/packages/cli/src/zosuss/issue/ssh/Ssh.definition.ts
+++ b/packages/cli/src/zosuss/issue/ssh/Ssh.definition.ts
@@ -38,5 +38,6 @@ export const SshDefinition: ICommandDefinition = {
     examples: [{
         description: "Issue a simple command, giving the working directory",
         options: "\"npm install express\" --cwd /u/cicprov/mnt/CICPY01I/bundles/myapp "
-    }]
+    }],
+    deprecatedReplacement: ""
 };

--- a/packages/imperative/CHANGELOG.md
+++ b/packages/imperative/CHANGELOG.md
@@ -434,6 +434,16 @@ All notable changes to the Imperative package will be documented in this file.
 
 - Major: First major version bump for V3
 
+## `5.27.0`
+
+- BugFix: Modified `showMsgWhenDeprecated` function to allow an empty string as a parameter when no replacement is available for the deprecated command. When no replacement is available an alternative message will be printed. [#2041](https://github.com/zowe/zowe-cli/issues/2041)
+- BugFix: Resolved bug that resulted in user not being prompted for a key passphrase if it is located in the secure credential array of the ssh profile. [#1770](https://github.com/zowe/zowe-cli/issues/1770)
+
+## `5.26.3`
+
+- BugFix: Fixed issue in local web help with highlighted sidebar item getting out of sync. [#2215](https://github.com/zowe/zowe-cli/pull/2215)
+- BugFix: Updated web help dependencies for technical currency. [#2215](https://github.com/zowe/zowe-cli/pull/2215)
+
 ## `5.26.2`
 
 - BugFix: Refactored code to reduce the use of deprecated functions to prepare for upcoming Node.js 22 support. [#2191](https://github.com/zowe/zowe-cli/issues/2191)

--- a/packages/imperative/CHANGELOG.md
+++ b/packages/imperative/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Imperative package will be documented in this file.
 
+## Recent Changes
+
+- Update: See `5.26.3` and `5.27.0` for details
+
 ## `8.0.0-next.202408131445`
 
 - Update: See `5.26.2` for details

--- a/packages/imperative/__tests__/__integration__/cmd/__tests__/integration/cli/profiles/Cmd.cli.profile.option.mapping.integration.test.ts
+++ b/packages/imperative/__tests__/__integration__/cmd/__tests__/integration/cli/profiles/Cmd.cli.profile.option.mapping.integration.test.ts
@@ -301,7 +301,6 @@ describe("cmd-cli profile mapping", () => {
         const moldType = "none";
         const response = runCliScript(__dirname + "/__scripts__/profiles/name_type_undefined.sh",
             TEST_ENVIRONMENT.workingDir, [color, description, moldType]);
-
         // name and type should be undefined since we did not specify them via command line
         expect(response.stderr.toString()).toBe("");
         expect(response.stdout.toString()).toContain("Name: undefined");
@@ -317,7 +316,6 @@ describe("cmd-cli profile mapping", () => {
         const cliType = "Big";
         const response = runCliScript(__dirname + "/__scripts__/profiles/name_type_specify.sh",
             TEST_ENVIRONMENT.workingDir, [color, description, moldType, cliName, cliType]);
-
         // name and type should be undefined since we did not specify them via command line
         expect(response.stderr.toString()).toBe("");
         expect(response.stdout.toString()).toContain("Name: " + cliName);

--- a/packages/imperative/package.json
+++ b/packages/imperative/package.json
@@ -20,6 +20,7 @@
   "files": [
     "lib",
     "web-help/dist",
+    "web-help/package*.json",
     "web-diff"
   ],
   "publishConfig": {
@@ -40,7 +41,8 @@
     "typedoc": "typedoc --options ./typedoc.json ./src/",
     "typedocSpecifySrc": "typedoc --options ./typedoc.json",
     "prepack": "node ../../scripts/prepareLicenses.js",
-    "clean": "rimraf lib tsconfig.tsbuildinfo"
+    "clean": "rimraf lib tsconfig.tsbuildinfo",
+    "prepublishOnly": "cd web-help && npm run deps:lockfile"
   },
   "dependencies": {
     "@types/yargs": "^17.0.32",

--- a/packages/imperative/src/cmd/src/help/DefaultHelpGenerator.ts
+++ b/packages/imperative/src/cmd/src/help/DefaultHelpGenerator.ts
@@ -222,7 +222,7 @@ export class DefaultHelpGenerator extends AbstractHelpGenerator {
                 let summaryText: string = "";
                 summaryText += command.summary || command.description;
 
-                if (command.deprecatedReplacement) {
+                if (command.deprecatedReplacement != null) {
                     // Mark with the deprecated tag
                     summaryText += this.grey(" (deprecated)");
                 } else if (command.experimental) {
@@ -359,10 +359,18 @@ export class DefaultHelpGenerator extends AbstractHelpGenerator {
             || this.mCommandDefinition.summary;
 
         // we place the deprecated message in the DESCRIPTION help section
-        if (this.mCommandDefinition.deprecatedReplacement) {
+        if (this.mCommandDefinition.deprecatedReplacement != null) {
             const noNewlineInText = this.mCommandDefinition.deprecatedReplacement.replace(/\n/g, " ");
             description += this.grey("\n\nWarning: This " + this.mCommandDefinition.type +
-                " has been deprecated.\nRecommended replacement: " + noNewlineInText);
+                " has been deprecated.\n");
+            if(this.mCommandDefinition.deprecatedReplacement === "")
+            {
+                description += this.grey("Obsolete component. No replacement exists");
+            }
+            else
+            {
+                description += this.grey("Recommended replacement: " + noNewlineInText);
+            }
         }
         if (this.mProduceMarkdown) {
             description = this.escapeMarkdown(description);  // escape Markdown special characters

--- a/packages/imperative/src/cmd/src/help/DefaultHelpGenerator.ts
+++ b/packages/imperative/src/cmd/src/help/DefaultHelpGenerator.ts
@@ -359,7 +359,7 @@ export class DefaultHelpGenerator extends AbstractHelpGenerator {
         let description = this.mCommandDefinition.description || this.mCommandDefinition.summary;
         // Use consolidated deprecated message logic
         description +=
-            this.grey(CliUtils.generateDeprecatedMessage(this.mCommandDefinition.deprecatedReplacement, this.mCommandDefinition.type, true));
+            this.grey(CliUtils.generateDeprecatedMessage(this.mCommandDefinition, true));
         if (this.mProduceMarkdown) {
             description = this.escapeMarkdown(description);
         }

--- a/packages/imperative/src/cmd/src/help/DefaultHelpGenerator.ts
+++ b/packages/imperative/src/cmd/src/help/DefaultHelpGenerator.ts
@@ -19,7 +19,7 @@ import { IHelpGeneratorParms } from "./doc/IHelpGeneratorParms";
 import { IHelpGeneratorFactoryParms } from "./doc/IHelpGeneratorFactoryParms";
 import { compareCommands, ICommandDefinition } from "../../src/doc/ICommandDefinition";
 import stripAnsi = require("strip-ansi");
-import { CliUtils } from "../../../utilities/src/CliUtils"
+import { CliUtils } from "../../../utilities/src/CliUtils";
 
 /**
  * Imperative default help generator. Accepts the command definitions and constructs
@@ -358,7 +358,8 @@ export class DefaultHelpGenerator extends AbstractHelpGenerator {
         }
         let description = this.mCommandDefinition.description || this.mCommandDefinition.summary;
         // Use consolidated deprecated message logic
-        description += this.grey(CliUtils.generateDeprecatedMessage(this.mCommandDefinition.deprecatedReplacement, this.mCommandDefinition.type, true));
+        description +=
+            this.grey(CliUtils.generateDeprecatedMessage(this.mCommandDefinition.deprecatedReplacement, this.mCommandDefinition.type, true));
         if (this.mProduceMarkdown) {
             description = this.escapeMarkdown(description);
         }

--- a/packages/imperative/src/cmd/src/help/DefaultHelpGenerator.ts
+++ b/packages/imperative/src/cmd/src/help/DefaultHelpGenerator.ts
@@ -19,6 +19,7 @@ import { IHelpGeneratorParms } from "./doc/IHelpGeneratorParms";
 import { IHelpGeneratorFactoryParms } from "./doc/IHelpGeneratorFactoryParms";
 import { compareCommands, ICommandDefinition } from "../../src/doc/ICommandDefinition";
 import stripAnsi = require("strip-ansi");
+import { CliUtils } from "../../../utilities/src/CliUtils"
 
 /**
  * Imperative default help generator. Accepts the command definitions and constructs
@@ -355,25 +356,11 @@ export class DefaultHelpGenerator extends AbstractHelpGenerator {
         if (!this.mProduceMarkdown) {
             descriptionForHelp += this.buildHeader("DESCRIPTION");
         }
-        let description = this.mCommandDefinition.description
-            || this.mCommandDefinition.summary;
-
-        // we place the deprecated message in the DESCRIPTION help section
-        if (this.mCommandDefinition.deprecatedReplacement != null) {
-            const noNewlineInText = this.mCommandDefinition.deprecatedReplacement.replace(/\n/g, " ");
-            description += this.grey("\n\nWarning: This " + this.mCommandDefinition.type +
-                " has been deprecated.\n");
-            if(this.mCommandDefinition.deprecatedReplacement === "")
-            {
-                description += this.grey("Obsolete component. No replacement exists");
-            }
-            else
-            {
-                description += this.grey("Recommended replacement: " + noNewlineInText);
-            }
-        }
+        let description = this.mCommandDefinition.description || this.mCommandDefinition.summary;
+        // Use consolidated deprecated message logic
+        description += this.grey(CliUtils.generateDeprecatedMessage(this.mCommandDefinition.deprecatedReplacement, this.mCommandDefinition.type, true));
         if (this.mProduceMarkdown) {
-            description = this.escapeMarkdown(description);  // escape Markdown special characters
+            description = this.escapeMarkdown(description);
         }
         if (this.skipTextWrap) {
             descriptionForHelp += TextUtils.indentLines(description, this.mProduceMarkdown ? "" : DefaultHelpGenerator.HELP_INDENT);

--- a/packages/imperative/src/cmd/src/utils/CommandUtils.ts
+++ b/packages/imperative/src/cmd/src/utils/CommandUtils.ts
@@ -66,8 +66,7 @@ export class CommandUtils {
             if (CommandUtils.optionWasSpecified(option, commandDefinition, commandArguments)) {
                 // don't print "true" for boolean options
                 command += " " + CliUtils.getDashFormOfOption(option) + " ";
-                command += CommandUtils.getOptionDefinitionFromName(option, commandDefinition).type
-                === "boolean" ? "" : commandArguments[option];
+                command += CommandUtils.getOptionDefinitionFromName(option, commandDefinition)?.type === "boolean" ? "" : commandArguments[option];
             }
         }
         return command.trim();

--- a/packages/imperative/src/rest/__tests__/session/ConnectionPropsForSessCfg.unit.test.ts
+++ b/packages/imperative/src/rest/__tests__/session/ConnectionPropsForSessCfg.unit.test.ts
@@ -1753,6 +1753,41 @@ describe("ConnectionPropsForSessCfg tests", () => {
             );
         });
 
+        it("should state that V1 profiles are not supported", async () => {
+            // Pretend that we do not have a zowe config.
+            Object.defineProperty(ImperativeConfig.instance, "config", {
+                configurable: true,
+                get: jest.fn(() => {
+                    return {
+                        exists: false,
+                    };
+                }),
+            });
+
+            /* Pretend that we only have V1 profiles.
+             * onlyV1ProfilesExist is a getter property, so mock the property.
+             */
+            Object.defineProperty(ConfigUtils, "onlyV1ProfilesExist", {
+                configurable: true,
+                get: jest.fn(() => {
+                    return true;
+                }),
+            });
+
+            // call the function that we want to test
+            await getValuesCallBack(["hostname"]);
+
+            expect(consoleMsgs).toContain(
+                "Only V1 profiles exist. V1 profiles are no longer supported. You should convert"
+            );
+            expect(consoleMsgs).toContain(
+                "your V1 profiles to a newer Zowe client configuration. Therefore, you will be"
+            );
+            expect(consoleMsgs).toContain(
+                "asked for the connection properties that are required to complete your command."
+            );
+        });
+        
         it("should state that connection properties are missing from config", async () => {
             // Pretend that we have a zowe config.
             Object.defineProperty(ImperativeConfig.instance, "config", {

--- a/packages/imperative/src/rest/__tests__/session/ConnectionPropsForSessCfg.unit.test.ts
+++ b/packages/imperative/src/rest/__tests__/session/ConnectionPropsForSessCfg.unit.test.ts
@@ -1787,7 +1787,7 @@ describe("ConnectionPropsForSessCfg tests", () => {
                 "asked for the connection properties that are required to complete your command."
             );
         });
-        
+
         it("should state that connection properties are missing from config", async () => {
             // Pretend that we have a zowe config.
             Object.defineProperty(ImperativeConfig.instance, "config", {

--- a/packages/imperative/src/rest/__tests__/session/ConnectionPropsForSessCfg.unit.test.ts
+++ b/packages/imperative/src/rest/__tests__/session/ConnectionPropsForSessCfg.unit.test.ts
@@ -25,6 +25,7 @@ import { IOptionsForAddConnProps } from "../../src/session/doc/IOptionsForAddCon
 import { ImperativeConfig } from "../../../utilities";
 import { ConfigUtils } from "../../../config/src/ConfigUtils";
 import { ISshSession } from "../../../../../zosuss/lib/doc/ISshSession";
+
 const certFilePath = join(
     __dirname,
     "..",
@@ -57,7 +58,6 @@ const certKeyFilePath = join(
     "__resources__",
     "fakeKey.key"
 );
-
 interface extendedSession extends ISession {
     someKey?: string;
 }
@@ -1750,41 +1750,6 @@ describe("ConnectionPropsForSessCfg tests", () => {
             );
             expect(consoleMsgs).toContain(
                 "connection properties that are required to complete your command."
-            );
-        });
-
-        it("should state that V1 profiles are not supported", async () => {
-            // Pretend that we do not have a zowe config.
-            Object.defineProperty(ImperativeConfig.instance, "config", {
-                configurable: true,
-                get: jest.fn(() => {
-                    return {
-                        exists: false,
-                    };
-                }),
-            });
-
-            /* Pretend that we only have V1 profiles.
-             * onlyV1ProfilesExist is a getter property, so mock the property.
-             */
-            Object.defineProperty(ConfigUtils, "onlyV1ProfilesExist", {
-                configurable: true,
-                get: jest.fn(() => {
-                    return true;
-                }),
-            });
-
-            // call the function that we want to test
-            await getValuesCallBack(["hostname"]);
-
-            expect(consoleMsgs).toContain(
-                "Only V1 profiles exist. V1 profiles are no longer supported. You should convert"
-            );
-            expect(consoleMsgs).toContain(
-                "your V1 profiles to a newer Zowe client configuration. Therefore, you will be"
-            );
-            expect(consoleMsgs).toContain(
-                "asked for the connection properties that are required to complete your command."
             );
         });
 

--- a/packages/imperative/src/rest/src/session/ConnectionPropsForSessCfg.ts
+++ b/packages/imperative/src/rest/src/session/ConnectionPropsForSessCfg.ts
@@ -144,7 +144,6 @@ export class ConnectionPropsForSessCfg {
                 this.promptTextForValues[obj.name.toString()] = obj.description;
             });
         }
-
         // check what properties are needed to be prompted
         if (ConnectionPropsForSessCfg.propHasValue(sessCfgToUse.hostname) === false && !doNotPromptForValues.includes("hostname")) {
             promptForValues.push("hostname");
@@ -188,7 +187,6 @@ export class ConnectionPropsForSessCfg {
                     }
                 });
             }
-
             // validate what values are given back and move it to sessCfgToUse
             for (const value of promptForValues) {
                 if (ConnectionPropsForSessCfg.propHasValue(answers[value])) {
@@ -415,7 +413,8 @@ export class ConnectionPropsForSessCfg {
                 let answer;
                 while (answer === undefined) {
                     const hideText = profileSchema[value]?.secure || this.secureSessCfgProps.has(value);
-                    let promptText = `${this.promptTextForValues[value] ?? `Enter your ${value} for`} ${serviceDescription}`;
+                    const valuePrompt = this.promptTextForValues[value] ?? `Enter your ${value} for`;
+                    let promptText = `${valuePrompt} ${serviceDescription}`;
                     if (hideText) {
                         promptText += " (will be hidden)";
                     }
@@ -473,7 +472,7 @@ export class ConnectionPropsForSessCfg {
         sessCfg: SessCfgType,
         options: IOptionsForAddConnProps<SessCfgType>,
         tokenType: SessConstants.TOKEN_TYPE_CHOICES
-    ) {
+    )  {
         const impLogger = Logger.getImperativeLogger();
         if (options.requestToken) {
             impLogger.debug("Requesting a token");

--- a/packages/imperative/src/utilities/__tests__/CliUtils.unit.test.ts
+++ b/packages/imperative/src/utilities/__tests__/CliUtils.unit.test.ts
@@ -226,6 +226,7 @@ describe("CliUtils", () => {
             CliUtils.showMsgWhenDeprecated(handlerParms);
             expect(responseErrText).toEqual("Recommended replacement: " +
                 handlerParms.definition.deprecatedReplacement);
+            expect(responseErrText).not.toContain("Obsolete component. No replacement exists");
         });
 
         it("should not produce a deprecated message when not deprecated", () => {
@@ -233,6 +234,14 @@ describe("CliUtils", () => {
             delete handlerParms.definition.deprecatedReplacement;
             CliUtils.showMsgWhenDeprecated(handlerParms);
             expect(responseErrText).toEqual(notSetYet);
+            expect(responseErrText).not.toContain("Obsolete component. No replacement exists");
+        });
+
+        it("should produce alternative text when deprecatedReplacement is an empty string", () => {
+            responseErrText = notSetYet;
+            handlerParms.definition.deprecatedReplacement = "";
+            CliUtils.showMsgWhenDeprecated(handlerParms);
+            expect(responseErrText).toContain("Obsolete component. No replacement exists");
         });
     });
 

--- a/packages/imperative/src/utilities/__tests__/CliUtils.unit.test.ts
+++ b/packages/imperative/src/utilities/__tests__/CliUtils.unit.test.ts
@@ -208,7 +208,7 @@ describe("CliUtils", () => {
         it("should produce a deprecated message when deprecated", () => {
             responseErrText = notSetYet;
             CliUtils.showMsgWhenDeprecated(handlerParms);
-            expect(responseErrText).toEqual("Recommended replacement: " +
+            expect(responseErrText).toContain("Recommended replacement: " +
                 handlerParms.definition.deprecatedReplacement);
         });
 
@@ -216,7 +216,7 @@ describe("CliUtils", () => {
             responseErrText = notSetYet;
             handlerParms.positionals = ["positional_one"];
             CliUtils.showMsgWhenDeprecated(handlerParms);
-            expect(responseErrText).toEqual("Recommended replacement: " +
+            expect(responseErrText).toContain("Recommended replacement: " +
                 handlerParms.definition.deprecatedReplacement);
         });
 
@@ -224,7 +224,7 @@ describe("CliUtils", () => {
             responseErrText = notSetYet;
             handlerParms.positionals = [];
             CliUtils.showMsgWhenDeprecated(handlerParms);
-            expect(responseErrText).toEqual("Recommended replacement: " +
+            expect(responseErrText).toContain("Recommended replacement: " +
                 handlerParms.definition.deprecatedReplacement);
             expect(responseErrText).not.toContain("Obsolete component. No replacement exists");
         });

--- a/packages/imperative/src/utilities/src/CliUtils.ts
+++ b/packages/imperative/src/utilities/src/CliUtils.ts
@@ -373,7 +373,7 @@ export class CliUtils {
         let message = "";
         if (deprecatedReplacement != null) {
             const noNewlineInText = deprecatedReplacement.replace(/\n/g, " ");
-            if(commandWarning) message += ("\n\nWarning: This " + commandType + " has been deprecated.\n");
+            if(commandWarning) message += "\n\nWarning: This " + commandType + " has been deprecated.\n";
             if (deprecatedReplacement === "") {
                 message += "Obsolete component. No replacement exists";
             } else {

--- a/packages/imperative/src/utilities/src/CliUtils.ts
+++ b/packages/imperative/src/utilities/src/CliUtils.ts
@@ -378,20 +378,20 @@ export class CliUtils {
      * @memberof CliUtils
      */
     public static showMsgWhenDeprecated(handlerParms: IHandlerParameters) {
-        if (handlerParms.definition.deprecatedReplacement) {
+        if (handlerParms.definition.deprecatedReplacement || handlerParms.definition.deprecatedReplacement === "") {
             // form the command that is deprecated
-            let oldCmd: string | number;
-            if (handlerParms.positionals.length >= 1) {
-                oldCmd = handlerParms.positionals[0];
-            }
-            if (handlerParms.positionals.length >= 2) {
-                oldCmd = oldCmd + " " + handlerParms.positionals[1];
-            }
-
+            const oldCmd = handlerParms.positionals.join(" ");
             // display the message
             handlerParms.response.console.error("\nWarning: The command '" + oldCmd + "' is deprecated.");
-            handlerParms.response.console.error("Recommended replacement: " +
-                handlerParms.definition.deprecatedReplacement);
+            if(handlerParms.definition.deprecatedReplacement === "")
+            {
+                handlerParms.response.console.error("Obsolete component. No replacement exists");
+            }
+            else
+            {
+                handlerParms.response.console.error("Recommended replacement: " +
+                    handlerParms.definition.deprecatedReplacement);
+            }
         }
     }
 

--- a/packages/imperative/src/utilities/src/CliUtils.ts
+++ b/packages/imperative/src/utilities/src/CliUtils.ts
@@ -21,7 +21,7 @@ import { ICommandArguments } from "../../cmd/src/doc/args/ICommandArguments";
 import { IProfile } from "../../profiles";
 import { IPromptOptions } from "../../cmd/src/doc/response/api/handler/IPromptOptions";
 import { read } from "read";
-
+import { ICommandDefinition } from "../../cmd";
 /**
  * Cli Utils contains a set of static methods/helpers that are CLI related (forming options, censoring args, etc.)
  * @export
@@ -369,12 +369,13 @@ export class CliUtils {
         return TextUtils.chalk[color](headerText);
     }
 
-    public static generateDeprecatedMessage(deprecatedReplacement: string | null, commandType: string, commandWarning?: boolean): string {
+    public static generateDeprecatedMessage(cmdDefinition: ICommandDefinition, showWarning?: boolean): string {
+
         let message = "";
-        if (deprecatedReplacement != null) {
-            const noNewlineInText = deprecatedReplacement.replace(/\n/g, " ");
-            if(commandWarning) message += "\n\nWarning: This " + commandType + " has been deprecated.\n";
-            if (deprecatedReplacement === "") {
+        if (cmdDefinition.deprecatedReplacement != null) {
+            const noNewlineInText = cmdDefinition.deprecatedReplacement.replace(/\n/g, " ");
+            if(showWarning) message += "\n\nWarning: This " + cmdDefinition.type + " has been deprecated.\n";
+            if (cmdDefinition.deprecatedReplacement === "") {
                 message += "Obsolete component. No replacement exists";
             } else {
                 message += "Recommended replacement: " + noNewlineInText;
@@ -397,7 +398,7 @@ export class CliUtils {
             // display the message
             handlerParms.response.console.error("\nWarning: The command '" + oldCmd + "' is deprecated.");
             // Use consolidated deprecated message logic
-            const deprecatedMessage = CliUtils.generateDeprecatedMessage(handlerParms.definition.deprecatedReplacement, handlerParms.definition.type);
+            const deprecatedMessage = CliUtils.generateDeprecatedMessage(handlerParms.definition);
             handlerParms.response.console.error(deprecatedMessage);
         }
     }

--- a/packages/imperative/src/utilities/src/CliUtils.ts
+++ b/packages/imperative/src/utilities/src/CliUtils.ts
@@ -22,7 +22,6 @@ import { IProfile } from "../../profiles";
 import { IPromptOptions } from "../../cmd/src/doc/response/api/handler/IPromptOptions";
 import { read } from "read";
 
-
 /**
  * Cli Utils contains a set of static methods/helpers that are CLI related (forming options, censoring args, etc.)
  * @export
@@ -370,6 +369,20 @@ export class CliUtils {
         return TextUtils.chalk[color](headerText);
     }
 
+    public static generateDeprecatedMessage(deprecatedReplacement: string | null, commandType: string, commandWarning?: boolean): string {
+        let message = "";
+        if (deprecatedReplacement != null) {
+            const noNewlineInText = deprecatedReplacement.replace(/\n/g, " ");
+            if(commandWarning) message += ("\n\nWarning: This " + commandType + " has been deprecated.\n");
+            if (deprecatedReplacement === "") {
+                message += "Obsolete component. No replacement exists";
+            } else {
+                message += "Recommended replacement: " + noNewlineInText;
+            }
+        }
+        return message;
+    }
+
     /**
      * Display a message when the command is deprecated.
      * @static
@@ -383,15 +396,9 @@ export class CliUtils {
             const oldCmd = handlerParms.positionals.join(" ");
             // display the message
             handlerParms.response.console.error("\nWarning: The command '" + oldCmd + "' is deprecated.");
-            if(handlerParms.definition.deprecatedReplacement === "")
-            {
-                handlerParms.response.console.error("Obsolete component. No replacement exists");
-            }
-            else
-            {
-                handlerParms.response.console.error("Recommended replacement: " +
-                    handlerParms.definition.deprecatedReplacement);
-            }
+            // Use consolidated deprecated message logic
+            const deprecatedMessage = CliUtils.generateDeprecatedMessage(handlerParms.definition.deprecatedReplacement, handlerParms.definition.type);
+            handlerParms.response.console.error(deprecatedMessage);
         }
     }
 

--- a/packages/imperative/web-help/dist/css/main.css
+++ b/packages/imperative/web-help/dist/css/main.css
@@ -85,6 +85,10 @@ body {
     width: calc(100% - 10px);
 }
 
+#tree-search::placeholder {
+    color: var(--bs-secondary);
+}
+
 #tree-tabs {
     margin: 0 5px 5px 5px;
     width: calc(100% - 10px);

--- a/packages/imperative/web-help/docs.ts
+++ b/packages/imperative/web-help/docs.ts
@@ -25,6 +25,7 @@ function arrayFrom(items: any): any[] {
 
 const isInIframe: boolean = window.location !== window.parent.location;
 const links: any = arrayFrom(document.getElementsByTagName("a"));
+const sameOrigin: string = window.location.protocol !== "file:" ? window.location.origin : "*";
 
 // Process all <a> tags on page
 links.forEach((link: any) => {
@@ -36,7 +37,10 @@ links.forEach((link: any) => {
         link.setAttribute("target", "_blank");
     } else if (isInIframe) {
         // If link is relative and page is inside an iframe, then send signal to command tree when link is clicked to make it update selected node
-        link.setAttribute("onclick", "window.parent.postMessage(this.href, '*'); return true;");
+        link.onclick = (e: any) => {
+            window.parent.postMessage(e.target.href, sameOrigin);
+            return true;
+        };
     }
 });
 
@@ -89,9 +93,9 @@ function findCurrentCmdAnchor() {
 if (isInIframe && window.location.href.indexOf("/all.html") !== -1) {
     let currentCmdName: string;
     window.onscroll = (_: any) => {
-        const cmdName = findCurrentCmdAnchor().getAttribute("name");
+        const cmdName = findCurrentCmdAnchor()?.getAttribute("name");
         if (cmdName != null && cmdName !== currentCmdName) {
-            window.parent.postMessage(cmdName + ".html", window.location.origin);
+            window.parent.postMessage(cmdName + ".html", sameOrigin);
             currentCmdName = cmdName;
         }
     };

--- a/packages/imperative/web-help/package.json
+++ b/packages/imperative/web-help/package.json
@@ -5,26 +5,27 @@
   "main": "index.js",
   "scripts": {
     "build": "tsc --build ./tsconfig.json",
-    "watch": "tsc --build ./tsconfig.json -w"
+    "watch": "tsc --build ./tsconfig.json -w",
+    "deps:lockfile": "node ../../../scripts/rewriteShrinkwrap.js package-lock.json"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "balloon-css": "^1.0.4",
-    "bootstrap": "^4.4.1",
-    "clipboard": "^2.0.4",
-    "github-markdown-css": "^5.1.0",
-    "jquery": "^3.4.1",
-    "jstree": "^3.3.8",
-    "scroll-into-view-if-needed": "2.2.22",
-    "split.js": "^1.5.11",
-    "url-search-params-polyfill": "^8.0.0"
+    "balloon-css": "^1.2.0",
+    "bootstrap": "^5.3.3",
+    "clipboard": "^2.0.11",
+    "github-markdown-css": "^5.6.1",
+    "jquery": "^3.7.1",
+    "jstree": "^3.3.16",
+    "scroll-into-view-if-needed": "2.2.29",
+    "split.js": "^1.6.5",
+    "url-search-params-polyfill": "^8.2.5"
   },
   "devDependencies": {
-    "@types/jquery": "^3.3.31",
-    "@types/jstree": "^3.3.39",
-    "postcss": "^8.3.6",
+    "@types/jquery": "^3.5.30",
+    "@types/jstree": "^3.3.46",
+    "postcss": "^8.4.41",
     "postcss-url": "^10.1.3"
   }
 }

--- a/packages/imperative/web-help/tree.ts
+++ b/packages/imperative/web-help/tree.ts
@@ -259,7 +259,7 @@ function onSearchTextChanged(noDelay: boolean = false) {
  * @param e - Event object sent by postMessage
  */
 function onDocsPageChanged(e: any) {
-    if (e.origin !== window.location.origin || typeof e.data !== "string") return;
+    if ((e.origin !== window.location.origin && e.origin !== "null") || typeof e.data !== "string") return;
     const tempNodeId = e.data.slice(e.data.lastIndexOf("/") + 1);
     updateCurrentNode(tempNodeId, false, false);
 }

--- a/scripts/rewriteShrinkwrap.js
+++ b/scripts/rewriteShrinkwrap.js
@@ -14,7 +14,7 @@ const chalk = require("chalk");
 const getLockfile = require("npm-lockfile/getLockfile");
 
 const rootShrinkwrapFile = __dirname + "/../npm-shrinkwrap.json";
-const cliShrinkwrapFile = __dirname + "/../packages/cli/npm-shrinkwrap.json";
+const newShrinkwrapFile = process.cwd() + "/" + (process.argv[2] ?? "npm-shrinkwrap.json");
 
 // Remove "file:" links from shrinkwrap
 const shrinkwrap = JSON.parse(fs.readFileSync(rootShrinkwrapFile, "utf-8"));
@@ -23,11 +23,11 @@ for (const [k, v] of Object.entries(shrinkwrap.packages)) {
         delete shrinkwrap.packages[k];
     }
 }
-fs.writeFileSync(cliShrinkwrapFile, JSON.stringify(shrinkwrap, null, 2));
+fs.writeFileSync(newShrinkwrapFile, JSON.stringify(shrinkwrap, null, 2));
 
-// Build deduped shrinkwrap for @zowe/cli
+// Build deduped shrinkwrap for subpackage (@zowe/cli or web-help)
 const zoweRegistry = require("../lerna.json").command.publish.registry;
-getLockfile(cliShrinkwrapFile, undefined, { "@zowe:registry": zoweRegistry })
-    .then((lockfile) => fs.writeFileSync(cliShrinkwrapFile, lockfile))
+getLockfile(newShrinkwrapFile, undefined, { "@zowe:registry": zoweRegistry })
+    .then((lockfile) => fs.writeFileSync(newShrinkwrapFile, lockfile))
     .then(() => console.log(chalk.green("Lockfile contents written!")))
     .catch((err) => { console.error(err); process.exit(1); });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,7 @@
     "target": "es2015",
     "module": "commonjs",
     "declaration": true,
+    "declarationMap": true,
     "moduleResolution": "node",
     "noImplicitAny": true,
     "preserveConstEnums": true,


### PR DESCRIPTION
**What It Does**
Modified showMsgWhenDeprecated() to allow an empty string as a parameter when no replacement is available for deprecated command to print an alternative message.

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [x] added/updated automated tests
- [x] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)
