### PR TITLE
Fix Yargs parsing strings as numbers

### DIFF
--- a/packages/imperative/CHANGELOG.md
+++ b/packages/imperative/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Imperative package will be documented in this file.
 
+## Recent Changes
+
+- LTS Breaking: Fixed command parsing error where `string` typed options would be converted into `number`s if the value provided by the user consists only of numeric characters. [#1881](https://github.com/zowe/zowe-cli/issues/1881)  
+
 ## `8.0.0-next.202408191401`
 
 - Update: See `5.26.3` and `5.27.0` for details

--- a/packages/imperative/__tests__/src/packages/cmd/ValidationTestCommand.ts
+++ b/packages/imperative/__tests__/src/packages/cmd/ValidationTestCommand.ts
@@ -68,6 +68,7 @@ export const ValidationTestCommand: ICommandDefinition = {
                 name: "should-be-number",
                 description: "should be a numerical value",
                 type: "number",
+                aliases: ["sbn"]
             },
             {
                 name: "dog-type",

--- a/packages/imperative/src/cmd/src/syntax/SyntaxValidator.ts
+++ b/packages/imperative/src/cmd/src/syntax/SyntaxValidator.ts
@@ -235,7 +235,13 @@ export class SyntaxValidator {
                     if (positional.type === "number") {
                         valid = this.validateNumeric(commandArguments[positional.name], positional, responseObject, true) && valid;
                         // Convert to number for backwards compatability
-                        if (valid) { commandArguments[positional.name] = parseFloat(commandArguments[positional.name]); }
+                        if (valid) {
+                            const changedOptions: ICommandArguments = CliUtils.setOptionValue(positional.name,
+                                [], parseFloat(commandArguments[positional.name]));
+                            for (const [k, v] of Object.entries(changedOptions)) {
+                                commandArguments[k] = v;
+                            }
+                        }
                     }
 
                     if (!(positional.stringLengthRange == null) &&
@@ -378,8 +384,14 @@ export class SyntaxValidator {
                     valid = this.validateBoolean(commandArguments[optionDef.name], optionDef, responseObject) && valid;
                 } else if (optionDef.type === "number") {
                     valid = this.validateNumeric(commandArguments[optionDef.name], optionDef, responseObject) && valid;
-                    // Convert to numbers for backwards compatibility
-                    if (valid) { commandArguments[optionDef.name] = parseFloat(commandArguments[optionDef.name]); }
+                    // Convert to numbers for backwards compatibility - sets all possible values
+                    if (valid) {
+                        const changedOptions: ICommandArguments = CliUtils.setOptionValue(optionDef.name,
+                            optionDef.aliases ?? [], parseFloat(commandArguments[optionDef.name]));
+                        for (const [k, v] of Object.entries(changedOptions)) {
+                            commandArguments[k] = v;
+                        }
+                    }
                 }
                 /**
                  * Validate that the option's value is valid json.

--- a/packages/imperative/src/cmd/src/syntax/SyntaxValidator.ts
+++ b/packages/imperative/src/cmd/src/syntax/SyntaxValidator.ts
@@ -235,7 +235,7 @@ export class SyntaxValidator {
                     if (positional.type === "number") {
                         valid = this.validateNumeric(commandArguments[positional.name], positional, responseObject, true) && valid;
                         // Convert to number for backwards compatability
-                        if (valid) { commandArguments[positional.name] = parseInt(commandArguments[positional.name]); }
+                        if (valid) { commandArguments[positional.name] = parseFloat(commandArguments[positional.name]); }
                     }
 
                     if (!(positional.stringLengthRange == null) &&
@@ -379,7 +379,7 @@ export class SyntaxValidator {
                 } else if (optionDef.type === "number") {
                     valid = this.validateNumeric(commandArguments[optionDef.name], optionDef, responseObject) && valid;
                     // Convert to numbers for backwards compatibility
-                    if (valid) { commandArguments[optionDef.name] = parseInt(commandArguments[optionDef.name]); }
+                    if (valid) { commandArguments[optionDef.name] = parseFloat(commandArguments[optionDef.name]); }
                 }
                 /**
                  * Validate that the option's value is valid json.

--- a/packages/imperative/src/cmd/src/syntax/SyntaxValidator.ts
+++ b/packages/imperative/src/cmd/src/syntax/SyntaxValidator.ts
@@ -234,6 +234,8 @@ export class SyntaxValidator {
                     }
                     if (positional.type === "number") {
                         valid = this.validateNumeric(commandArguments[positional.name], positional, responseObject, true) && valid;
+                        // Convert to number for backwards compatability
+                        if (valid) { commandArguments[positional.name] = parseInt(commandArguments[positional.name]); }
                     }
 
                     if (!(positional.stringLengthRange == null) &&
@@ -373,11 +375,11 @@ export class SyntaxValidator {
                             commandArguments[optionDef.name]);
                     }
                 } else if (optionDef.type === "boolean") {
-                    valid = this.validateBoolean(commandArguments[optionDef.name], optionDef,
-                        responseObject) && valid;
+                    valid = this.validateBoolean(commandArguments[optionDef.name], optionDef, responseObject) && valid;
                 } else if (optionDef.type === "number") {
-                    valid = this.validateNumeric(commandArguments[optionDef.name], optionDef,
-                        responseObject) && valid;
+                    valid = this.validateNumeric(commandArguments[optionDef.name], optionDef, responseObject) && valid;
+                    // Convert to numbers for backwards compatibility
+                    if (valid) { commandArguments[optionDef.name] = parseInt(commandArguments[optionDef.name]); }
                 }
                 /**
                  * Validate that the option's value is valid json.

--- a/packages/imperative/src/cmd/src/syntax/__tests__/SyntaxValidator.unit.test.ts
+++ b/packages/imperative/src/cmd/src/syntax/__tests__/SyntaxValidator.unit.test.ts
@@ -27,7 +27,7 @@ describe("Imperative should provide advanced syntax validation rules", () => {
     const logger = TestLogger.getTestLogger();
     const aliases: Record<string, string[]> = {};
     // We define ValidationTestCommand. Options is always defined.
-    for (const option of ValidationTestCommand.options) {
+    for (const option of ValidationTestCommand.options!) {
         if (option.aliases) {
             aliases[option.name] = option.aliases;
         }

--- a/packages/imperative/src/cmd/src/syntax/__tests__/SyntaxValidator.unit.test.ts
+++ b/packages/imperative/src/cmd/src/syntax/__tests__/SyntaxValidator.unit.test.ts
@@ -25,8 +25,16 @@ import { YargsConfigurer } from "../../yargs/YargsConfigurer";
 
 describe("Imperative should provide advanced syntax validation rules", () => {
     const logger = TestLogger.getTestLogger();
+    const aliases: Record<string, string[]> = {};
+    // We define ValidationTestCommand. Options is always defined.
+    for (const option of ValidationTestCommand.options) {
+        if (option.aliases) {
+            aliases[option.name] = option.aliases;
+        }
+    }
     const configuration = {
-        configuration: YargsConfigurer.yargsConfiguration
+        configuration: YargsConfigurer.yargsConfiguration,
+        alias: aliases
     };
 
     describe("Advanced syntax validation for commands using a test command", () => {
@@ -37,7 +45,7 @@ describe("Imperative should provide advanced syntax validation rules", () => {
 
         function tryOptions(optionString: string, shouldSucceed: boolean, expectedText?: string[]) {
 
-            const options = yargsParser(optionString, configuration);
+            const options = yargsParser.detailed(optionString, configuration).argv;
             options._ = ["test", "validation-test"].concat(options._ || []); // fake out command structure
             options[Constants.JSON_OPTION] = true;
             delete options["--"]; // delete extra yargs parse field
@@ -367,8 +375,8 @@ describe("Imperative should provide advanced syntax validation rules", () => {
                 false, ["multiple", "--always-required-string"])();
         });
 
-        it("should validate that typed numbers are numbers, and convert strings that are numbers", async () => {
-            const options = yargsParser(minValidOptions + " --should-be-number 4", configuration);
+        it("should validate that typed numbers are numbers, and convert strings that are numbers 1", async () => {
+            const options = yargsParser.detailed(minValidOptions + " --should-be-number 4", configuration).argv;
             options._ = ["test", "validation-test"].concat(options._ || []); // fake out command structure
             options[Constants.JSON_OPTION] = true;
             delete options["--"]; // delete extra yargs parse field
@@ -381,12 +389,60 @@ describe("Imperative should provide advanced syntax validation rules", () => {
             };
             const svResponse = await new SyntaxValidator(ValidationTestCommand, fakeParent).validate(response, options);
             expect(options["should-be-number"]).toBe(4);
+            expect(options["shouldBeNumber"]).toBe(4);
+            expect(options["sbn"]).toBe(4);
             expect(options["should-be-number"]).not.toBe("4");
+            expect(options["shouldBeNumber"]).not.toBe("4");
+            expect(options["sbn"]).not.toBe("4");
             expect(svResponse.valid).toEqual(true);
         });
 
-        it("should validate that typed numbers are numbers, and convert strings that are numbers that are floats", async () => {
-            const options = yargsParser(minValidOptions + " --should-be-number 3.1415926", configuration);
+        it("should validate that typed numbers are numbers, and convert strings that are numbers 2", async () => {
+            const options = yargsParser.detailed(minValidOptions + " --shouldBeNumber 4", configuration).argv;
+            options._ = ["test", "validation-test"].concat(options._ || []); // fake out command structure
+            options[Constants.JSON_OPTION] = true;
+            delete options["--"]; // delete extra yargs parse field
+            logger.debug("Executing test syntax command with arguments: " + inspect(options));
+            const response = new CommandResponse({responseFormat: "json"});
+            const fakeParent: ICommandDefinition = {
+                name: undefined,
+                description: "", type: "group",
+                children: [ValidationTestCommand]
+            };
+            const svResponse = await new SyntaxValidator(ValidationTestCommand, fakeParent).validate(response, options);
+            expect(options["should-be-number"]).toBe(4);
+            expect(options["shouldBeNumber"]).toBe(4);
+            expect(options["sbn"]).toBe(4);
+            expect(options["should-be-number"]).not.toBe("4");
+            expect(options["shouldBeNumber"]).not.toBe("4");
+            expect(options["sbn"]).not.toBe("4");
+            expect(svResponse.valid).toEqual(true);
+        });
+
+        it("should validate that typed numbers are numbers, and convert strings that are numbers 3", async () => {
+            const options = yargsParser.detailed(minValidOptions + " --sbn 4", configuration).argv;
+            options._ = ["test", "validation-test"].concat(options._ || []); // fake out command structure
+            options[Constants.JSON_OPTION] = true;
+            delete options["--"]; // delete extra yargs parse field
+            logger.debug("Executing test syntax command with arguments: " + inspect(options));
+            const response = new CommandResponse({responseFormat: "json"});
+            const fakeParent: ICommandDefinition = {
+                name: undefined,
+                description: "", type: "group",
+                children: [ValidationTestCommand]
+            };
+            const svResponse = await new SyntaxValidator(ValidationTestCommand, fakeParent).validate(response, options);
+            expect(options["should-be-number"]).toBe(4);
+            expect(options["shouldBeNumber"]).toBe(4);
+            expect(options["sbn"]).toBe(4);
+            expect(options["should-be-number"]).not.toBe("4");
+            expect(options["shouldBeNumber"]).not.toBe("4");
+            expect(options["sbn"]).not.toBe("4");
+            expect(svResponse.valid).toEqual(true);
+        });
+
+        it("should validate that typed numbers are numbers, and convert strings that are numbers that are floats 1", async () => {
+            const options = yargsParser.detailed(minValidOptions + " --should-be-number 3.1415926", configuration).argv;
             options._ = ["test", "validation-test"].concat(options._ || []); // fake out command structure
             options[Constants.JSON_OPTION] = true;
             delete options["--"]; // delete extra yargs parse field
@@ -399,12 +455,60 @@ describe("Imperative should provide advanced syntax validation rules", () => {
             };
             const svResponse = await new SyntaxValidator(ValidationTestCommand, fakeParent).validate(response, options);
             expect(options["should-be-number"]).toBe(3.1415926);
+            expect(options["shouldBeNumber"]).toBe(3.1415926);
+            expect(options["sbn"]).toBe(3.1415926);
             expect(options["should-be-number"]).not.toBe("3.1415926");
+            expect(options["shouldBeNumber"]).not.toBe("3.1415926");
+            expect(options["sbn"]).not.toBe("3.1415926");
+            expect(svResponse.valid).toEqual(true);
+        });
+
+        it("should validate that typed numbers are numbers, and convert strings that are numbers that are floats 2", async () => {
+            const options = yargsParser.detailed(minValidOptions + " --shouldBeNumber 3.1415926", configuration).argv;
+            options._ = ["test", "validation-test"].concat(options._ || []); // fake out command structure
+            options[Constants.JSON_OPTION] = true;
+            delete options["--"]; // delete extra yargs parse field
+            logger.debug("Executing test syntax command with arguments: " + inspect(options));
+            const response = new CommandResponse({responseFormat: "json"});
+            const fakeParent: ICommandDefinition = {
+                name: undefined,
+                description: "", type: "group",
+                children: [ValidationTestCommand]
+            };
+            const svResponse = await new SyntaxValidator(ValidationTestCommand, fakeParent).validate(response, options);
+            expect(options["should-be-number"]).toBe(3.1415926);
+            expect(options["shouldBeNumber"]).toBe(3.1415926);
+            expect(options["sbn"]).toBe(3.1415926);
+            expect(options["should-be-number"]).not.toBe("3.1415926");
+            expect(options["shouldBeNumber"]).not.toBe("3.1415926");
+            expect(options["sbn"]).not.toBe("3.1415926");
+            expect(svResponse.valid).toEqual(true);
+        });
+
+        it("should validate that typed numbers are numbers, and convert strings that are numbers that are floats 3", async () => {
+            const options = yargsParser.detailed(minValidOptions + " --sbn 3.1415926", configuration).argv;
+            options._ = ["test", "validation-test"].concat(options._ || []); // fake out command structure
+            options[Constants.JSON_OPTION] = true;
+            delete options["--"]; // delete extra yargs parse field
+            logger.debug("Executing test syntax command with arguments: " + inspect(options));
+            const response = new CommandResponse({responseFormat: "json"});
+            const fakeParent: ICommandDefinition = {
+                name: undefined,
+                description: "", type: "group",
+                children: [ValidationTestCommand]
+            };
+            const svResponse = await new SyntaxValidator(ValidationTestCommand, fakeParent).validate(response, options);
+            expect(options["should-be-number"]).toBe(3.1415926);
+            expect(options["shouldBeNumber"]).toBe(3.1415926);
+            expect(options["sbn"]).toBe(3.1415926);
+            expect(options["should-be-number"]).not.toBe("3.1415926");
+            expect(options["shouldBeNumber"]).not.toBe("3.1415926");
+            expect(options["sbn"]).not.toBe("3.1415926");
             expect(svResponse.valid).toEqual(true);
         });
 
         it("should validate that typed strings are strings and not numbers", async () => {
-            const options = yargsParser(minValidOptions + " --fluffy 9001", configuration);
+            const options = yargsParser.detailed(minValidOptions + " --fluffy 9001", configuration).argv;
             options._ = ["test", "validation-test"].concat(options._ || []); // fake out command structure
             options[Constants.JSON_OPTION] = true;
             delete options["--"]; // delete extra yargs parse field

--- a/packages/imperative/src/cmd/src/syntax/__tests__/SyntaxValidator.unit.test.ts
+++ b/packages/imperative/src/cmd/src/syntax/__tests__/SyntaxValidator.unit.test.ts
@@ -385,6 +385,24 @@ describe("Imperative should provide advanced syntax validation rules", () => {
             expect(svResponse.valid).toEqual(true);
         });
 
+        it("should validate that typed numbers are numbers, and convert strings that are numbers that are floats", async () => {
+            const options = yargsParser(minValidOptions + " --should-be-number 3.1415926", configuration);
+            options._ = ["test", "validation-test"].concat(options._ || []); // fake out command structure
+            options[Constants.JSON_OPTION] = true;
+            delete options["--"]; // delete extra yargs parse field
+            logger.debug("Executing test syntax command with arguments: " + inspect(options));
+            const response = new CommandResponse({responseFormat: "json"});
+            const fakeParent: ICommandDefinition = {
+                name: undefined,
+                description: "", type: "group",
+                children: [ValidationTestCommand]
+            };
+            const svResponse = await new SyntaxValidator(ValidationTestCommand, fakeParent).validate(response, options);
+            expect(options["should-be-number"]).toBe(3.1415926);
+            expect(options["should-be-number"]).not.toBe("3.1415926");
+            expect(svResponse.valid).toEqual(true);
+        });
+
         it("should validate that typed strings are strings and not numbers", async () => {
             const options = yargsParser(minValidOptions + " --fluffy 9001", configuration);
             options._ = ["test", "validation-test"].concat(options._ || []); // fake out command structure

--- a/packages/imperative/src/cmd/src/yargs/CommandYargs.ts
+++ b/packages/imperative/src/cmd/src/yargs/CommandYargs.ts
@@ -41,11 +41,10 @@ export class CommandYargs extends AbstractCommandYargs {
                 if (!(option.type == null)) {
                     // don't let yargs handle any types that we are validating ourselves
                     // and don't use custom types as the yargs type since yargs won't understand
-                    if (option.type !== "number" &&
-                        option.type !== "json") {
-                        definition.type = option.type as any;
-                    } else if (option.type === "json") {
+                    if (option.type === "json" || option.type === "number") {
                         definition.type = "string";
+                    } else {
+                        definition.type = option.type as any;
                     }
                 }
                 // If this is a boolean type option, default it to undefined so that we can distinguish

--- a/packages/imperative/src/cmd/src/yargs/YargsConfigurer.ts
+++ b/packages/imperative/src/cmd/src/yargs/YargsConfigurer.ts
@@ -40,6 +40,11 @@ export class YargsConfigurer {
     ) {
     }
 
+    public static yargsConfiguration: Record<string, boolean> = {
+        "parse-numbers": false,
+        "parse-positional-numbers": false
+    };
+
     public configure() {
 
         /**
@@ -50,6 +55,7 @@ export class YargsConfigurer {
         this.yargs.help(false);
         this.yargs.version(false);
         this.yargs.showHelpOnFail(false);
+        this.yargs.parserConfiguration(YargsConfigurer.yargsConfiguration);
         // finally, catch any undefined commands
         this.yargs.command({
             command: "*",

--- a/packages/imperative/src/cmd/src/yargs/YargsConfigurer.ts
+++ b/packages/imperative/src/cmd/src/yargs/YargsConfigurer.ts
@@ -40,7 +40,7 @@ export class YargsConfigurer {
     ) {
     }
 
-    public static readonly yargsConfiguration: Record<string, boolean> = {
+    public static readonly yargsConfiguration: Readonly<Record<string, boolean>> = {
         "parse-numbers": false,
         "parse-positional-numbers": false
     };

--- a/packages/imperative/src/cmd/src/yargs/YargsConfigurer.ts
+++ b/packages/imperative/src/cmd/src/yargs/YargsConfigurer.ts
@@ -40,7 +40,7 @@ export class YargsConfigurer {
     ) {
     }
 
-    public static yargsConfiguration: Record<string, boolean> = {
+    public static readonly yargsConfiguration: Record<string, boolean> = {
         "parse-numbers": false,
         "parse-positional-numbers": false
     };


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->
Prevents parsing string arguments as numbers if the value provided only consists of numerics.
Resolves #1881

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->
Run the `zowe files download ds "FAKE.DS" --rto 50 --encoding 1047 --show-inputs-only` command and observe the response timeout is blue (number) and encoding is white (string).

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [x] added/updated automated tests
- [x] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
