### PR TITLE
Attempt to fix workflow permissions to publish GH releases

### DIFF
--- a/.github/workflows/update-project.yml
+++ b/.github/workflows/update-project.yml
@@ -12,10 +12,10 @@ env:
   PR_STATUS_DRAFT: 'In Progress'
   PR_STATUS_READY: 'Review/QA'
 
-permissions: write-all
-
 jobs:
   update-project:
+    permissions: 
+      id-token: write
     name: Move project item
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/update-project.yml
+++ b/.github/workflows/update-project.yml
@@ -14,6 +14,7 @@ env:
 
 permissions:
   issues: write
+  pull-requests: write
 
 jobs:
   update-project:

--- a/.github/workflows/update-project.yml
+++ b/.github/workflows/update-project.yml
@@ -12,12 +12,7 @@ env:
   PR_STATUS_DRAFT: 'In Progress'
   PR_STATUS_READY: 'Review/QA'
 
-permissions:
-  contents: write
-  issues: write
-  pull-requests: write
-  repository-projects: write
-  statuses: write
+permissions: write-all
 
 jobs:
   update-project:

--- a/.github/workflows/update-project.yml
+++ b/.github/workflows/update-project.yml
@@ -13,9 +13,11 @@ env:
   PR_STATUS_READY: 'Review/QA'
 
 permissions:
+  contents: write
   issues: write
   pull-requests: write
   repository-projects: write
+  statuses: write
 
 jobs:
   update-project:

--- a/.github/workflows/update-project.yml
+++ b/.github/workflows/update-project.yml
@@ -15,8 +15,14 @@ env:
 jobs:
   update-project:
     permissions: 
-      contents: read
+      contents: write
       metadata: read
+      project: read
+      repository-projects: read
+      packages: write
+      pull-requests: read
+      statuses: read
+      checks: read
     name: Move project item
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/update-project.yml
+++ b/.github/workflows/update-project.yml
@@ -15,9 +15,7 @@ env:
 jobs:
   update-project:
     permissions: 
-      actions: read
       contents: read
-      id-token: write
       metadata: read
     name: Move project item
     runs-on: ubuntu-latest

--- a/.github/workflows/update-project.yml
+++ b/.github/workflows/update-project.yml
@@ -17,7 +17,7 @@ jobs:
     name: Move project item
     runs-on: ubuntu-latest
     steps:
-    - uses: zowe-actions/shared-actions/project-move-item@main
+    - uses: zowe-actions/shared-actions/project-move-item@fernando-fix-wf
       if: ${{ github.event.issue && fromJSON(env.ISSUE_STATUSES)[github.event.label.name] }}
       with:
         item-status: ${{ fromJSON(env.ISSUE_STATUSES)[github.event.label.name] }}

--- a/.github/workflows/update-project.yml
+++ b/.github/workflows/update-project.yml
@@ -14,8 +14,7 @@ env:
 
 jobs:
   update-project:
-    permissions: 
-      id-token: write
+    permissions: read-all
     name: Move project item
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/update-project.yml
+++ b/.github/workflows/update-project.yml
@@ -14,7 +14,11 @@ env:
 
 jobs:
   update-project:
-    permissions: read-all
+    permissions: 
+      actions: read
+      contents: read
+      id-token: write
+      metadata: read
     name: Move project item
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/update-project.yml
+++ b/.github/workflows/update-project.yml
@@ -15,6 +15,7 @@ env:
 permissions:
   issues: write
   pull-requests: write
+  repository-projects: write
 
 jobs:
   update-project:

--- a/.github/workflows/update-project.yml
+++ b/.github/workflows/update-project.yml
@@ -12,6 +12,9 @@ env:
   PR_STATUS_DRAFT: 'In Progress'
   PR_STATUS_READY: 'Review/QA'
 
+permissions:
+  issues: write
+
 jobs:
   update-project:
     name: Move project item

--- a/.github/workflows/update-project.yml
+++ b/.github/workflows/update-project.yml
@@ -16,13 +16,9 @@ jobs:
   update-project:
     permissions: 
       contents: write
-      metadata: read
-      project: read
-      repository-projects: read
-      packages: write
-      pull-requests: read
-      statuses: read
-      checks: read
+      issues: write
+      pull-requests: write
+      repository-projects: write
     name: Move project item
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/update-project.yml
+++ b/.github/workflows/update-project.yml
@@ -14,11 +14,6 @@ env:
 
 jobs:
   update-project:
-    permissions: 
-      contents: write
-      issues: write
-      pull-requests: write
-      repository-projects: write
     name: Move project item
     runs-on: ubuntu-latest
     steps:
@@ -29,7 +24,7 @@ jobs:
         project-number: ${{ env.PROJECT_NUMBER }}
         project-token: ${{ secrets.ZOWE_ROBOT_TOKEN }}
 
-    - uses: zowe-actions/shared-actions/project-move-item@main
+    - uses: zowe-actions/shared-actions/project-move-item@fernando-fix-wf
       if: ${{ github.event.pull_request }}
       with:
         assign-author: true

--- a/.github/workflows/zowe-cli.yml
+++ b/.github/workflows/zowe-cli.yml
@@ -161,6 +161,12 @@ jobs:
         token: ${{ secrets.CODECOV_TOKEN }}
 
   release:
+    permissions:
+      deployments: write
+      issues: write
+      pull-requests: write
+      statuses: write
+      
     if: github.event_name == 'push' && github.ref_protected
     needs: test
     runs-on: ubuntu-latest

--- a/.github/workflows/zowe-cli.yml
+++ b/.github/workflows/zowe-cli.yml
@@ -162,6 +162,7 @@ jobs:
 
   release:
     permissions:
+      contents: write
       deployments: write
       issues: write
       pull-requests: write


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->

Explicitly allow the GH Token to allow the octorelease action to to handle deployments and comments

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->

I'm afraid we have to merge to test 😓 

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [ ] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->

More details:
- https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idpermissions
