### PR TITLE
chore: Allow a latest update from v2-lts in the interim

### DIFF
--- a/release.config.js
+++ b/release.config.js
@@ -1,12 +1,13 @@
 module.exports = {
     branches: [
         {
-            name: "master",
-            level: "minor"
-        },
-        {
+            // This is a temporary change, in case we need to release a critical fix to the V2-lts line.
             name: "zowe-v?-lts",
             level: "patch"
+        },
+        {
+            name: "master",
+            level: "none"
         }
         // {
         //     name: "next",


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->

This enables `@latest` releases from the zowe-v2-lts branch.

Ideally this PR is closed without being merged. :yum:

