### PR TITLE
Major: Update release config and changelog files

### DIFF
--- a/__tests__/__packages__/cli-test-utils/CHANGELOG.md
+++ b/__tests__/__packages__/cli-test-utils/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Zowe CLI test utils package will be documented in this file.
 
+## Recent Changes
+
+- MAJOR: v8.0.0 Release
+
 ## `8.0.0-next.202409191615`
 
 - Update: Final prerelease

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Zowe CLI package will be documented in this file.
 
+## Recent Changes
+
+- MAJOR: v8.0.0 Release
+
 ## `8.0.0-next.202409191615`
 
 - Update: Final prerelease

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Zowe core SDK package will be documented in this file.
 
+## Recent Changes
+
+- MAJOR: v8.0.0 Release
+
 ## `8.0.0-next.202409191615`
 
 - Update: Final prerelease

--- a/packages/imperative/CHANGELOG.md
+++ b/packages/imperative/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Imperative package will be documented in this file.
 
+## Recent Changes
+
+- MAJOR: v8.0.0 Release
+
 ## `8.0.0-next.202409191615`
 
 - Update: Final prerelease

--- a/packages/provisioning/CHANGELOG.md
+++ b/packages/provisioning/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Zowe provisioning SDK package will be documented in this file.
 
+## Recent Changes
+
+- MAJOR: v8.0.0 Release
+
 ## `8.0.0-next.202409191615`
 
 - Update: Final prerelease

--- a/packages/secrets/CHANGELOG.md
+++ b/packages/secrets/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Zowe Secrets SDK package will be documented in this file.
 
+## Recent Changes
+
+- MAJOR: v8.0.0 Release
+
 ## `8.0.0-next.202409191615`
 
 - Update: Final prerelease

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Zowe z/OS workflows SDK package will be documented in this file.
 
+## Recent Changes
+
+- MAJOR: v8.0.0 Release
+
 ## `8.0.0-next.202409191615`
 
 - Update: Final prerelease

--- a/packages/zosconsole/CHANGELOG.md
+++ b/packages/zosconsole/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Zowe z/OS console SDK package will be documented in this file.
 
+## Recent Changes
+
+- MAJOR: v8.0.0 Release
+
 ## `8.0.0-next.202409191615`
 
 - Update: Final prerelease

--- a/packages/zosfiles/CHANGELOG.md
+++ b/packages/zosfiles/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Zowe z/OS files SDK package will be documented in this file.
 
+## Recent Changes
+
+- MAJOR: v8.0.0 Release
+
 ## `8.0.0-next.202409191615`
 
 - Update: Final prerelease

--- a/packages/zosjobs/CHANGELOG.md
+++ b/packages/zosjobs/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Zowe z/OS jobs SDK package will be documented in this file.
 
+## Recent Changes
+
+- MAJOR: v8.0.0 Release
+
 ## `8.0.0-next.202409191615`
 
 - Update: Final prerelease

--- a/packages/zoslogs/CHANGELOG.md
+++ b/packages/zoslogs/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Zowe z/OS logs SDK package will be documented in this file.
 
+## Recent Changes
+
+- MAJOR: v8.0.0 Release
+
 ## `8.0.0-next.202409191615`
 
 - Update: Final prerelease

--- a/packages/zosmf/CHANGELOG.md
+++ b/packages/zosmf/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Zowe z/OSMF SDK package will be documented in this file.
 
+## Recent Changes
+
+- MAJOR: v8.0.0 Release
+
 ## `8.0.0-next.202409191615`
 
 - Update: Final prerelease

--- a/packages/zostso/CHANGELOG.md
+++ b/packages/zostso/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Zowe z/OS TSO SDK package will be documented in this file.
 
+## Recent Changes
+
+- MAJOR: v8.0.0 Release
+
 ## `8.0.0-next.202409191615`
 
 - Update: Final prerelease

--- a/packages/zosuss/CHANGELOG.md
+++ b/packages/zosuss/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Zowe z/OS USS SDK package will be documented in this file.
 
+## Recent Changes
+
+- MAJOR: v8.0.0 Release
+
 ## `8.0.0-next.202409191615`
 
 - Update: Final prerelease

--- a/release.config.js
+++ b/release.config.js
@@ -6,13 +6,10 @@ module.exports = {
             name: "zowe-v?-lts",
             level: "patch"
         },
-        // Temporarily publish master branch as @next prerelease.
-        // When V3 goes live, remember to update alias tags below.
         {
             name: "master",
             level: "none",
-            prerelease: true,
-            channel: "next"
+            channel: "zowe-v3-lts"
         }
     ],
     plugins: [
@@ -36,8 +33,7 @@ module.exports = {
         }],
         ["@octorelease/lerna", {
             aliasTags: {
-                "latest": ["zowe-v2-lts"],
-                "next": ["zowe-v3-lts"]
+                "latest": ["zowe-v2-lts"]
             },
             pruneShrinkwrap: ["@zowe/cli"],
             smokeTest: true


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->

Publish the v8.0.0 version to zowe.jfrog.io

This one will only update the `zowe-v3-lts` tag on the registry.