### PR TITLE
chore: Update the latest tag on NPM

### DIFF
--- a/release.config.js
+++ b/release.config.js
@@ -1,15 +1,12 @@
 module.exports = {
     branches: [
-        // Temporarily put zowe-v2-lts branch first in the list.
-        // It should move down once latest becomes zowe-v3-lts.
+        {
+            name: "master",
+            level: "minor",
+        },
         {
             name: "zowe-v?-lts",
             level: "patch"
-        },
-        {
-            name: "master",
-            level: "none",
-            channel: "zowe-v3-lts"
         }
     ],
     plugins: [
@@ -33,7 +30,7 @@ module.exports = {
         }],
         ["@octorelease/lerna", {
             aliasTags: {
-                "latest": ["zowe-v2-lts"]
+                "latest": ["zowe-v3-lts"]
             },
             pruneShrinkwrap: ["@zowe/cli"],
             smokeTest: true


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->

This PR will update the latest tag to match the same version as `zowe-v3-lts` going forward.

This PR should be merged only after the Zowe v3.0 announcement 😋 

**Note:** This PR shall be merged with the `release-current` label.
