### PR TITLE
fix(jobs): Binary spool files corrupted by newline normalization

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "audit:public": "npm audit --registry https://registry.npmjs.org/",
     "bundle:webHelp": "cd packages/imperative/web-help && node build.js",
     "prepare": "husky && npm run bundle:webHelp",
-    "package": "node scripts/bundleCliTgz.js"
+    "package": "lerna run prepublishOnly && node scripts/bundleCliTgz.js"
   },
   "devDependencies": {
     "@lerna-lite/changed": "^3.6.0",

--- a/packages/cli/src/zostso/issue/command/Command.handler.ts
+++ b/packages/cli/src/zostso/issue/command/Command.handler.ts
@@ -1,13 +1,13 @@
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Eclipse Public License v2.0 which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
- *
- * SPDX-License-Identifier: EPL-2.0
- *
- * Copyright Contributors to the Zowe Project.
- *
- */
+* This program and the accompanying materials are made available under the terms of the
+* Eclipse Public License v2.0 which accompanies this distribution, and is available at
+* https://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Copyright Contributors to the Zowe Project.
+*
+*/
 
 import { IHandlerParameters } from "@zowe/imperative";
 import {

--- a/packages/imperative/src/imperative/src/config/cmd/secure/secure.handler.ts
+++ b/packages/imperative/src/imperative/src/config/cmd/secure/secure.handler.ts
@@ -1,13 +1,13 @@
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Eclipse Public License v2.0 which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
- *
- * SPDX-License-Identifier: EPL-2.0
- *
- * Copyright Contributors to the Zowe Project.
- *
- */
+* This program and the accompanying materials are made available under the terms of the
+* Eclipse Public License v2.0 which accompanies this distribution, and is available at
+* https://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Copyright Contributors to the Zowe Project.
+*
+*/
 
 import {
     ICommandArguments,

--- a/packages/zosjobs/CHANGELOG.md
+++ b/packages/zosjobs/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Zowe z/OS jobs SDK package will be documented in this file.
 
+## Recent Changes
+
+- BugFix: Fixed error in `DownloadJobs.downloadSpoolContentCommon` causing binary spool files to be corrupted by newline normalization. [#2282](https://github.com/zowe/zowe-cli/issues/2282)
+
 ## `8.0.0`
 
 - MAJOR: v8.0.0 Release

--- a/packages/zosjobs/CHANGELOG.md
+++ b/packages/zosjobs/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the Zowe z/OS jobs SDK package will be documented in this
 
 ## Recent Changes
 
-- BugFix: Fixed error in `DownloadJobs.downloadSpoolContentCommon` causing binary spool files to be corrupted by newline normalization. [#2282](https://github.com/zowe/zowe-cli/issues/2282)
+- BugFix: Fixed error in `DownloadJobs.downloadSpoolContentCommon` method causing binary spool files to be corrupted by newline normalization. [#2282](https://github.com/zowe/zowe-cli/issues/2282)
 
 ## `8.0.0`
 

--- a/packages/zosjobs/src/DownloadJobs.ts
+++ b/packages/zosjobs/src/DownloadJobs.ts
@@ -128,8 +128,9 @@ export class DownloadJobs {
         }
 
         const writeStream = parms.stream ?? IO.createWriteStream(file);
+        const normalizeResponseNewLines = !(parms.binary || parms.record);
         await ZosmfRestClient.getStreamed(session, JobsConstants.RESOURCE + parameters, [Headers.TEXT_PLAIN_UTF8], writeStream,
-            true);
+            normalizeResponseNewLines);
     }
 
     /**

--- a/packages/zostso/__tests__/__unit__/IssueTso.unit.test.ts
+++ b/packages/zostso/__tests__/__unit__/IssueTso.unit.test.ts
@@ -1,13 +1,13 @@
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Eclipse Public License v2.0 which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
- *
- * SPDX-License-Identifier: EPL-2.0
- *
- * Copyright Contributors to the Zowe Project.
- *
- */
+* This program and the accompanying materials are made available under the terms of the
+* Eclipse Public License v2.0 which accompanies this distribution, and is available at
+* https://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Copyright Contributors to the Zowe Project.
+*
+*/
 
 /* eslint-disable deprecation/deprecation */
 import { ImperativeConfig, ImperativeError, Session } from "@zowe/imperative";

--- a/packages/zostso/src/IssueTso.ts
+++ b/packages/zostso/src/IssueTso.ts
@@ -1,13 +1,13 @@
 /*
- * This program and the accompanying materials are made available under the terms of the
- * Eclipse Public License v2.0 which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
- *
- * SPDX-License-Identifier: EPL-2.0
- *
- * Copyright Contributors to the Zowe Project.
- *
- */
+* This program and the accompanying materials are made available under the terms of the
+* Eclipse Public License v2.0 which accompanies this distribution, and is available at
+* https://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Copyright Contributors to the Zowe Project.
+*
+*/
 
 import { AbstractSession, Headers, ImperativeError } from "@zowe/imperative";
 import { IStartTsoParms } from "./doc/input/IStartTsoParms";


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->
Fixes #2282 

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->
Reproduce the issue with the following steps (only on Windows):
1. Run a JCL job that outputs a spool file containing the `0A` (`\n`) character. For example:
    ```
    //CATFILE  EXEC PGM=BPXBATCH,REGION=0M
    //STDPARM  DD   *
    SH cat "//'IBMUSER.BINARY.DS'"
    /*
    //STDERR   DD   SYSOUT=*
    //STDOUT   DD   SYSOUT=*
    ```
2. Download spool in binary mode with `zowe jobs download output <jobId> --binary>`
3. Verify that `0A` (`\n` = LF) characters do not have `0D` (`\r` = CR) prepended.

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [x] added/updated automated tests
- [x] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
