### PR TITLE
fix(ds): Fix invalid response from DS list API for archived data sets

### DIFF
--- a/packages/zosfiles/CHANGELOG.md
+++ b/packages/zosfiles/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the Zowe z/OS files SDK package will be documented in thi
 
 ## Recent Changes
 
-- BugFix: Fixed an issue with `List.dataSetsMatchingPattern` method where migrated data sets could break fetching attributes for other data sets. [#2285](https://github.com/zowe/zowe-cli/issues/2285)
+- BugFix: Fixed an issue with the `List.dataSetsMatchingPattern` method where migrated data sets could break fetching attributes for other data sets. [#2285](https://github.com/zowe/zowe-cli/issues/2285)
 
 ## `8.0.0`
 

--- a/packages/zosfiles/CHANGELOG.md
+++ b/packages/zosfiles/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Zowe z/OS files SDK package will be documented in this file.
 
+## Recent Changes
+
+- BugFix: Fixed an issue with `List.dataSetsMatchingPattern` method where migrated data sets could break fetching attributes for other data sets. [#2285](https://github.com/zowe/zowe-cli/issues/2285)
+
 ## `8.0.0`
 
 - MAJOR: v8.0.0 Release

--- a/packages/zosfiles/__tests__/__unit__/methods/list/List.unit.test.ts
+++ b/packages/zosfiles/__tests__/__unit__/methods/list/List.unit.test.ts
@@ -1498,7 +1498,7 @@ describe("z/OS Files - List", () => {
             });
 
             expect(listDataSetSpy).toHaveBeenCalledTimes(3);
-            expect(listDataSetSpy).toHaveBeenCalledWith(dummySession, dataSetPS.dsname, {attributes: true});
+            expect(listDataSetSpy).toHaveBeenLastCalledWith(dummySession, dataSetPS.dsname, {attributes: true, maxLength: 1});
         });
 
         it("should handle an error when the exclude pattern is specified", async () => {

--- a/packages/zosfiles/src/methods/list/List.ts
+++ b/packages/zosfiles/src/methods/list/List.ts
@@ -389,7 +389,7 @@ export class List {
                         listsInitiated++;
                     }
 
-                    return List.dataSet(session, dataSetObj.dsname, { attributes: true }).then(
+                    return List.dataSet(session, dataSetObj.dsname, { attributes: true, maxLength: 1 }).then(
                         (tempResponse) => {
                             Object.assign(dataSetObj, tempResponse.apiResponse.items[0]);
                         },


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->
Fixes #2285 

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->
Find a ds pattern whose results include data sets with volume=ARCIVE but the first ds in the list is not migrated.

Notice that listing with attributes fails:
`zowe zos-files list data-set <dsPattern> --attributes`

After adding `maxLength=1`, it succeeds:
`zowe zos-files list data-set <dsPattern> --attributes --max-length 1`

**Review Checklist**
I certify that I have:
- [ ] tested my changes
- [x] added/updated automated tests
- [x] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
