### PR TITLE
fix: require.main.filename check in `DefaultCredentialManager`

### DIFF
--- a/packages/imperative/CHANGELOG.md
+++ b/packages/imperative/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to the Imperative package will be documented in this file.
 ## Recent Changes
 
 - BugFix: Fixed issues flagged by Coverity [#2291](https://github.com/zowe/zowe-cli/pull/2291)
-- BugFix: Fixed an issue where the default credential manager failed to load if the `main` property of the `require` object was `undefined`.
+- BugFix: Fixed an issue where the default credential manager failed to load when using ESM or the Node.js REPL environment. [#2297](https://github.com/zowe/zowe-cli/pull/2297)
 
 ## `8.1.0`
 

--- a/packages/imperative/CHANGELOG.md
+++ b/packages/imperative/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to the Imperative package will be documented in this file.
 ## Recent Changes
 
 - BugFix: Fixed issues flagged by Coverity [#2291](https://github.com/zowe/zowe-cli/pull/2291)
+- BugFix: Fixed an issue where the default credential manager failed to load if the `main` property of the `require` object was `undefined`.
 
 ## `8.1.0`
 

--- a/packages/imperative/src/security/src/DefaultCredentialManager.ts
+++ b/packages/imperative/src/security/src/DefaultCredentialManager.ts
@@ -120,7 +120,9 @@ export class DefaultCredentialManager extends AbstractCredentialManager {
             // our calling CLI. Since our caller must supply keytar, we search for keytar
             // within our caller's path.
             const requireOpts: any = {};
-            requireOpts.paths = [require.main?.filename, ...require.resolve.paths("@zowe/secrets-for-zowe-sdk")].filter(Boolean);
+            if (require.main?.filename != null) {
+                requireOpts.paths = [require.main.filename, ...require.resolve.paths("@zowe/secrets-for-zowe-sdk")];
+            }
             // use helper function for require.resolve so it can be mocked in jest tests
             const keytarPath = require.resolve("@zowe/secrets-for-zowe-sdk", requireOpts);
             Logger.getImperativeLogger().debug("Loading Keytar module from", keytarPath);

--- a/packages/imperative/src/security/src/DefaultCredentialManager.ts
+++ b/packages/imperative/src/security/src/DefaultCredentialManager.ts
@@ -120,9 +120,7 @@ export class DefaultCredentialManager extends AbstractCredentialManager {
             // our calling CLI. Since our caller must supply keytar, we search for keytar
             // within our caller's path.
             const requireOpts: any = {};
-            if (require.main?.filename != null) {
-                requireOpts.paths = [require.main.filename, ...require.resolve.paths("@zowe/secrets-for-zowe-sdk")];
-            }
+            requireOpts.paths = [require.main?.filename, ...require.resolve.paths("@zowe/secrets-for-zowe-sdk")].filter(Boolean);
             // use helper function for require.resolve so it can be mocked in jest tests
             const keytarPath = require.resolve("@zowe/secrets-for-zowe-sdk", requireOpts);
             Logger.getImperativeLogger().debug("Loading Keytar module from", keytarPath);

--- a/packages/imperative/src/security/src/DefaultCredentialManager.ts
+++ b/packages/imperative/src/security/src/DefaultCredentialManager.ts
@@ -120,7 +120,7 @@ export class DefaultCredentialManager extends AbstractCredentialManager {
             // our calling CLI. Since our caller must supply keytar, we search for keytar
             // within our caller's path.
             const requireOpts: any = {};
-            if (require.main.filename != null) {
+            if (require.main?.filename != null) {
                 requireOpts.paths = [require.main.filename, ...require.resolve.paths("@zowe/secrets-for-zowe-sdk")];
             }
             // use helper function for require.resolve so it can be mocked in jest tests


### PR DESCRIPTION
**What It Does**

In some environments (namely ESM and the Node.js REPL), the `main` property is not always available within the `require` object, so the `if` check for `require.main.filename != null` results in a TypeError.

**How to Test**

This one is a bit difficult to test, but this should work as an example:

- Make an empty folder and set up a basic NPM project using `npm init`
- Build a TGZ for `@zowe/imperative` using `npm install && npm run build && npm pack` in the `packages/imperative` folder. Install the generated tarball in this new NPM project alongside `@zowe/secrets-for-zowe-sdk` as normal dependencies:
  - `npm install zowe-imperative-8.1.0.tgz @zowe/secrets-for-zowe-sdk`
- Open the Node.js REPL within this folder: `node -i`
- Import `DefaultCredentialManager` within the REPL and create a new instance of it. Then attempt to initialize it. Initialization should be successful with no errors thrown:

  ```javascript
  > const { DefaultCredentialManager } = await import("@zowe/imperative")
  > const credMgr = new DefaultCredentialManager()
  > await credMgr.initialize()
   ```

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [ ] added/updated automated tests
- [x] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)
