### PR TITLE
Add search callbacks to files SDK

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -16637,6 +16637,7 @@
       "version": "8.1.1",
       "license": "EPL-2.0",
       "dependencies": {
+        "lodash": "^4.17.21",
         "minimatch": "^9.0.5"
       },
       "devDependencies": {

--- a/packages/zosfiles/CHANGELOG.md
+++ b/packages/zosfiles/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the Zowe z/OS files SDK package will be documented in thi
 
 ## Recent Changes
 
-- Enhancement: Added an optional `continueSearch` function to `ISearchOptions` to allow for user prompting and data set search cancellation after the list of data sets to be searched is retrieved. [#2300](https://github.com/zowe/zowe-cli/pull/2300)
+- Enhancement: Added an optional `continueSearch` function to the `ISearchOptions` interface. After a data set listing is completed, the new function is called with the list of data sets about to be searched. This allows the extender or end users to continue with the search or cancel it. [#2300](https://github.com/zowe/zowe-cli/pull/2300)
 
 ## `8.1.1`
 

--- a/packages/zosfiles/CHANGELOG.md
+++ b/packages/zosfiles/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Zowe z/OS files SDK package will be documented in this file.
 
+## Recent Changes
+
+- Enhancement: Added an optional `continueSearch` function to `ISearchOptions` to allow for user prompting and data set search cancellation after the list of data sets to be searched is retrieved. []()
+
 ## `8.1.1`
 
 - BugFix: Updated peer dependencies to `^8.0.0`, dropping support for versions tagged `next`. [#2287](https://github.com/zowe/zowe-cli/pull/2287)

--- a/packages/zosfiles/CHANGELOG.md
+++ b/packages/zosfiles/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the Zowe z/OS files SDK package will be documented in thi
 
 ## Recent Changes
 
-- Enhancement: Added an optional `continueSearch` function to `ISearchOptions` to allow for user prompting and data set search cancellation after the list of data sets to be searched is retrieved. []()
+- Enhancement: Added an optional `continueSearch` function to `ISearchOptions` to allow for user prompting and data set search cancellation after the list of data sets to be searched is retrieved. [#2300](https://github.com/zowe/zowe-cli/pull/2300)
 
 ## `8.1.1`
 

--- a/packages/zosfiles/__tests__/__unit__/methods/search/Search.unit.test.ts
+++ b/packages/zosfiles/__tests__/__unit__/methods/search/Search.unit.test.ts
@@ -10,7 +10,7 @@
 */
 
 import { ImperativeError, Session, TaskStage } from "@zowe/imperative";
-import { Get, ISearchItem, ISearchOptions, IZosFilesResponse, List, Search } from "../../../../src";
+import { Get, IDataSet, ISearchItem, ISearchOptions, IZosFilesResponse, List, Search } from "../../../../src";
 
 describe("Search", () => {
 
@@ -45,6 +45,13 @@ describe("Search", () => {
         {dsn: "TEST3.PDS", member: "MEMBER1", matchList: undefined},
         {dsn: "TEST3.PDS", member: "MEMBER2", matchList: undefined},
         {dsn: "TEST3.PDS", member: "MEMBER3", matchList: undefined}
+    ];
+    const searchDataSets: IDataSet[] = [
+        {dsn: "TEST1.DS", member: undefined},
+        {dsn: "TEST2.DS", member: undefined},
+        {dsn: "TEST3.PDS", member: "MEMBER1"},
+        {dsn: "TEST3.PDS", member: "MEMBER2"},
+        {dsn: "TEST3.PDS", member: "MEMBER3"}
     ];
     let oldForceColor: string;
 
@@ -88,6 +95,7 @@ describe("Search", () => {
             progressTask: undefined,
             maxConcurrentRequests: 1,
             timeout: undefined,
+            continueSearch: undefined
         };
 
         searchItems = [
@@ -300,6 +308,282 @@ describe("Search", () => {
                 expectedLine + ", Column: " + expectedCol + ", Contents: " + testDataString);
             expect(response.commandResponse).toContain("Data Set \"TEST3.PDS\" | Member \"MEMBER3\":\nLine: " +
                 expectedLine + ", Column: " + expectedCol + ", Contents: " + testDataString);
+        });
+
+        it("Should handle a callback that returns true (sync)", async () => {
+            testDataString = "TESTDATA IS AT THE BEGINNING OF THE STRING";
+            expectedCol = 1;
+            expectedLine = 1;
+            regenerateMockImplementations();
+            let suppliedDataSets: IDataSet[];
+            searchOptions.continueSearch = function fakePrompt(dataSets: IDataSet[]) {
+                suppliedDataSets = dataSets;
+                return true;
+            };
+
+            const response = await Search.dataSets(dummySession, searchOptions);
+
+            expect(listDataSetsMatchingPatternSpy).toHaveBeenCalledTimes(1);
+            expect(listDataSetsMatchingPatternSpy).toHaveBeenCalledWith(dummySession, ["TEST*"], {maxConcurrentRequests: 1});
+            expect(listAllMembersSpy).toHaveBeenCalledTimes(1);
+            expect(listAllMembersSpy).toHaveBeenCalledWith(dummySession, "TEST3.PDS", {});
+            expect(searchOnMainframeSpy).toHaveBeenCalledTimes(1);
+            expect(searchLocalSpy).toHaveBeenCalledTimes(1);
+
+            expect(suppliedDataSets).toEqual(searchDataSets);
+
+            expect(response.errorMessage).not.toBeDefined();
+            expect(response.success).toEqual(true);
+            expect(response.apiResponse).toEqual([
+                {dsn: "TEST1.DS", member: undefined, matchList: [{column: expectedCol, line: expectedLine, contents: testDataString}]},
+                {dsn: "TEST2.DS", member: undefined, matchList: [{column: expectedCol, line: expectedLine, contents: testDataString}]},
+                {dsn: "TEST3.PDS", member: "MEMBER1", matchList: [{column: expectedCol, line: expectedLine, contents: testDataString}]},
+                {dsn: "TEST3.PDS", member: "MEMBER2", matchList: [{column: expectedCol, line: expectedLine, contents: testDataString}]},
+                {dsn: "TEST3.PDS", member: "MEMBER3", matchList: [{column: expectedCol, line: expectedLine, contents: testDataString}]}
+            ]);
+            expect(response.commandResponse).toContain("Found \"TESTDATA\" in 5 data sets and PDS members");
+            expect(response.commandResponse).toContain("Data Set \"TEST1.DS\":\nLine: " +
+                expectedLine + ", Column: " + expectedCol + ", Contents: " + testDataString);
+            expect(response.commandResponse).toContain("Data Set \"TEST2.DS\":\nLine: " +
+                expectedLine + ", Column: " + expectedCol + ", Contents: " + testDataString);
+            expect(response.commandResponse).toContain("Data Set \"TEST3.PDS\" | Member \"MEMBER1\":\nLine: " +
+                expectedLine + ", Column: " + expectedCol + ", Contents: " + testDataString);
+            expect(response.commandResponse).toContain("Data Set \"TEST3.PDS\" | Member \"MEMBER2\":\nLine: " +
+                expectedLine + ", Column: " + expectedCol + ", Contents: " + testDataString);
+            expect(response.commandResponse).toContain("Data Set \"TEST3.PDS\" | Member \"MEMBER3\":\nLine: " +
+                expectedLine + ", Column: " + expectedCol + ", Contents: " + testDataString);
+        });
+
+        it("Should handle a callback that returns false (sync)", async () => {
+            testDataString = "TESTDATA IS AT THE BEGINNING OF THE STRING";
+            expectedCol = 1;
+            expectedLine = 1;
+            regenerateMockImplementations();
+            let suppliedDataSets: IDataSet[];
+            searchOptions.continueSearch = function fakePrompt(dataSets: IDataSet[]) {
+                suppliedDataSets = dataSets;
+                return false;
+            };
+
+            const response = await Search.dataSets(dummySession, searchOptions);
+
+            expect(listDataSetsMatchingPatternSpy).toHaveBeenCalledTimes(1);
+            expect(listDataSetsMatchingPatternSpy).toHaveBeenCalledWith(dummySession, ["TEST*"], {maxConcurrentRequests: 1});
+            expect(listAllMembersSpy).toHaveBeenCalledTimes(1);
+            expect(listAllMembersSpy).toHaveBeenCalledWith(dummySession, "TEST3.PDS", {});
+            expect(searchOnMainframeSpy).toHaveBeenCalledTimes(0);
+            expect(searchLocalSpy).toHaveBeenCalledTimes(0);
+
+            expect(suppliedDataSets).toEqual(searchDataSets);
+
+            expect(response.errorMessage).not.toBeDefined();
+            expect(response.success).toEqual(false);
+            expect(response.apiResponse).toEqual(undefined);
+            expect(response.commandResponse).toContain("The search was cancelled.");
+        });
+
+        it("Should handle a callback that returns undefined (sync)", async () => {
+            testDataString = "TESTDATA IS AT THE BEGINNING OF THE STRING";
+            expectedCol = 1;
+            expectedLine = 1;
+            regenerateMockImplementations();
+            let suppliedDataSets: IDataSet[];
+            searchOptions.continueSearch = function fakePrompt(dataSets: IDataSet[]) {
+                suppliedDataSets = dataSets;
+                return undefined;
+            };
+
+            const response = await Search.dataSets(dummySession, searchOptions);
+
+            expect(listDataSetsMatchingPatternSpy).toHaveBeenCalledTimes(1);
+            expect(listDataSetsMatchingPatternSpy).toHaveBeenCalledWith(dummySession, ["TEST*"], {maxConcurrentRequests: 1});
+            expect(listAllMembersSpy).toHaveBeenCalledTimes(1);
+            expect(listAllMembersSpy).toHaveBeenCalledWith(dummySession, "TEST3.PDS", {});
+            expect(searchOnMainframeSpy).toHaveBeenCalledTimes(0);
+            expect(searchLocalSpy).toHaveBeenCalledTimes(0);
+
+            expect(suppliedDataSets).toEqual(searchDataSets);
+
+            expect(response.errorMessage).not.toBeDefined();
+            expect(response.success).toEqual(false);
+            expect(response.apiResponse).toEqual(undefined);
+            expect(response.commandResponse).toContain("The search was cancelled.");
+        });
+
+        it("Should handle a callback that returns null (sync)", async () => {
+            testDataString = "TESTDATA IS AT THE BEGINNING OF THE STRING";
+            expectedCol = 1;
+            expectedLine = 1;
+            regenerateMockImplementations();
+            let suppliedDataSets: IDataSet[];
+            searchOptions.continueSearch = function fakePrompt(dataSets: IDataSet[]) {
+                suppliedDataSets = dataSets;
+                return null;
+            };
+
+            const response = await Search.dataSets(dummySession, searchOptions);
+
+            expect(listDataSetsMatchingPatternSpy).toHaveBeenCalledTimes(1);
+            expect(listDataSetsMatchingPatternSpy).toHaveBeenCalledWith(dummySession, ["TEST*"], {maxConcurrentRequests: 1});
+            expect(listAllMembersSpy).toHaveBeenCalledTimes(1);
+            expect(listAllMembersSpy).toHaveBeenCalledWith(dummySession, "TEST3.PDS", {});
+            expect(searchOnMainframeSpy).toHaveBeenCalledTimes(0);
+            expect(searchLocalSpy).toHaveBeenCalledTimes(0);
+
+            expect(suppliedDataSets).toEqual(searchDataSets);
+
+            expect(response.errorMessage).not.toBeDefined();
+            expect(response.success).toEqual(false);
+            expect(response.apiResponse).toEqual(undefined);
+            expect(response.commandResponse).toContain("The search was cancelled.");
+        });
+
+        it("Should handle a callback that returns true (async)", async () => {
+            testDataString = "TESTDATA IS AT THE BEGINNING OF THE STRING";
+            expectedCol = 1;
+            expectedLine = 1;
+            regenerateMockImplementations();
+            let suppliedDataSets: IDataSet[];
+            searchOptions.continueSearch = async function fakePrompt(dataSets: IDataSet[]) {
+                return new Promise((resolve) => {
+                    setTimeout(() => {
+                        resolve(true);
+                    }, 1);
+                    suppliedDataSets = dataSets;
+                    delay(1);
+                });
+            };
+
+            const response = await Search.dataSets(dummySession, searchOptions);
+
+            expect(listDataSetsMatchingPatternSpy).toHaveBeenCalledTimes(1);
+            expect(listDataSetsMatchingPatternSpy).toHaveBeenCalledWith(dummySession, ["TEST*"], {maxConcurrentRequests: 1});
+            expect(listAllMembersSpy).toHaveBeenCalledTimes(1);
+            expect(listAllMembersSpy).toHaveBeenCalledWith(dummySession, "TEST3.PDS", {});
+            expect(searchOnMainframeSpy).toHaveBeenCalledTimes(1);
+            expect(searchLocalSpy).toHaveBeenCalledTimes(1);
+
+            expect(suppliedDataSets).toEqual(searchDataSets);
+
+            expect(response.errorMessage).not.toBeDefined();
+            expect(response.success).toEqual(true);
+            expect(response.apiResponse).toEqual([
+                {dsn: "TEST1.DS", member: undefined, matchList: [{column: expectedCol, line: expectedLine, contents: testDataString}]},
+                {dsn: "TEST2.DS", member: undefined, matchList: [{column: expectedCol, line: expectedLine, contents: testDataString}]},
+                {dsn: "TEST3.PDS", member: "MEMBER1", matchList: [{column: expectedCol, line: expectedLine, contents: testDataString}]},
+                {dsn: "TEST3.PDS", member: "MEMBER2", matchList: [{column: expectedCol, line: expectedLine, contents: testDataString}]},
+                {dsn: "TEST3.PDS", member: "MEMBER3", matchList: [{column: expectedCol, line: expectedLine, contents: testDataString}]}
+            ]);
+            expect(response.commandResponse).toContain("Found \"TESTDATA\" in 5 data sets and PDS members");
+            expect(response.commandResponse).toContain("Data Set \"TEST1.DS\":\nLine: " +
+                expectedLine + ", Column: " + expectedCol + ", Contents: " + testDataString);
+            expect(response.commandResponse).toContain("Data Set \"TEST2.DS\":\nLine: " +
+                expectedLine + ", Column: " + expectedCol + ", Contents: " + testDataString);
+            expect(response.commandResponse).toContain("Data Set \"TEST3.PDS\" | Member \"MEMBER1\":\nLine: " +
+                expectedLine + ", Column: " + expectedCol + ", Contents: " + testDataString);
+            expect(response.commandResponse).toContain("Data Set \"TEST3.PDS\" | Member \"MEMBER2\":\nLine: " +
+                expectedLine + ", Column: " + expectedCol + ", Contents: " + testDataString);
+            expect(response.commandResponse).toContain("Data Set \"TEST3.PDS\" | Member \"MEMBER3\":\nLine: " +
+                expectedLine + ", Column: " + expectedCol + ", Contents: " + testDataString);
+        });
+
+        it("Should handle a callback that returns false (async)", async () => {
+            testDataString = "TESTDATA IS AT THE BEGINNING OF THE STRING";
+            expectedCol = 1;
+            expectedLine = 1;
+            regenerateMockImplementations();
+            let suppliedDataSets: IDataSet[];
+            searchOptions.continueSearch = async function fakePrompt(dataSets: IDataSet[]) {
+                return new Promise((resolve) => {
+                    setTimeout(() => {
+                        resolve(false);
+                    }, 1);
+                    suppliedDataSets = dataSets;
+                    delay(1);
+                });
+            };
+
+            const response = await Search.dataSets(dummySession, searchOptions);
+
+            expect(listDataSetsMatchingPatternSpy).toHaveBeenCalledTimes(1);
+            expect(listDataSetsMatchingPatternSpy).toHaveBeenCalledWith(dummySession, ["TEST*"], {maxConcurrentRequests: 1});
+            expect(listAllMembersSpy).toHaveBeenCalledTimes(1);
+            expect(listAllMembersSpy).toHaveBeenCalledWith(dummySession, "TEST3.PDS", {});
+            expect(searchOnMainframeSpy).toHaveBeenCalledTimes(0);
+            expect(searchLocalSpy).toHaveBeenCalledTimes(0);
+
+            expect(suppliedDataSets).toEqual(searchDataSets);
+
+            expect(response.errorMessage).not.toBeDefined();
+            expect(response.success).toEqual(false);
+            expect(response.apiResponse).toEqual(undefined);
+            expect(response.commandResponse).toContain("The search was cancelled.");
+        });
+
+        it("Should handle a callback that returns undefined (async)", async () => {
+            testDataString = "TESTDATA IS AT THE BEGINNING OF THE STRING";
+            expectedCol = 1;
+            expectedLine = 1;
+            regenerateMockImplementations();
+            let suppliedDataSets: IDataSet[];
+            searchOptions.continueSearch = async function fakePrompt(dataSets: IDataSet[]) {
+                return new Promise((resolve) => {
+                    setTimeout(() => {
+                        resolve(undefined);
+                    }, 1);
+                    suppliedDataSets = dataSets;
+                    delay(1);
+                });
+            };
+
+            const response = await Search.dataSets(dummySession, searchOptions);
+
+            expect(listDataSetsMatchingPatternSpy).toHaveBeenCalledTimes(1);
+            expect(listDataSetsMatchingPatternSpy).toHaveBeenCalledWith(dummySession, ["TEST*"], {maxConcurrentRequests: 1});
+            expect(listAllMembersSpy).toHaveBeenCalledTimes(1);
+            expect(listAllMembersSpy).toHaveBeenCalledWith(dummySession, "TEST3.PDS", {});
+            expect(searchOnMainframeSpy).toHaveBeenCalledTimes(0);
+            expect(searchLocalSpy).toHaveBeenCalledTimes(0);
+
+            expect(suppliedDataSets).toEqual(searchDataSets);
+
+            expect(response.errorMessage).not.toBeDefined();
+            expect(response.success).toEqual(false);
+            expect(response.apiResponse).toEqual(undefined);
+            expect(response.commandResponse).toContain("The search was cancelled.");
+        });
+
+        it("Should handle a callback that returns null (async)", async () => {
+            testDataString = "TESTDATA IS AT THE BEGINNING OF THE STRING";
+            expectedCol = 1;
+            expectedLine = 1;
+            regenerateMockImplementations();
+            let suppliedDataSets: IDataSet[];
+            searchOptions.continueSearch = async function fakePrompt(dataSets: IDataSet[]) {
+                return new Promise((resolve) => {
+                    setTimeout(() => {
+                        resolve(null);
+                    }, 1);
+                    suppliedDataSets = dataSets;
+                    delay(1);
+                });
+            };
+
+            const response = await Search.dataSets(dummySession, searchOptions);
+
+            expect(listDataSetsMatchingPatternSpy).toHaveBeenCalledTimes(1);
+            expect(listDataSetsMatchingPatternSpy).toHaveBeenCalledWith(dummySession, ["TEST*"], {maxConcurrentRequests: 1});
+            expect(listAllMembersSpy).toHaveBeenCalledTimes(1);
+            expect(listAllMembersSpy).toHaveBeenCalledWith(dummySession, "TEST3.PDS", {});
+            expect(searchOnMainframeSpy).toHaveBeenCalledTimes(0);
+            expect(searchLocalSpy).toHaveBeenCalledTimes(0);
+
+            expect(suppliedDataSets).toEqual(searchDataSets);
+
+            expect(response.errorMessage).not.toBeDefined();
+            expect(response.success).toEqual(false);
+            expect(response.apiResponse).toEqual(undefined);
+            expect(response.commandResponse).toContain("The search was cancelled.");
         });
 
         it("Should handle a migrated data set", async () => {

--- a/packages/zosfiles/package.json
+++ b/packages/zosfiles/package.json
@@ -46,7 +46,8 @@
     "prepack": "node ../../scripts/prepareLicenses.js"
   },
   "dependencies": {
-    "minimatch": "^9.0.5"
+    "minimatch": "^9.0.5",
+    "lodash": "^4.17.21"
   },
   "devDependencies": {
     "@zowe/cli-test-utils": "8.1.1",

--- a/packages/zosfiles/src/methods/search/Search.ts
+++ b/packages/zosfiles/src/methods/search/Search.ts
@@ -117,15 +117,16 @@ export class Search {
             resp = await searchOptions.continueSearch(cloneDeep(searchItemsQueue));
         }
 
-        // Return if either of the callbacks set response to false, null, or undefined
-        if (resp != true) {
+        // Return if the callback set response to false, null, undefined, or anything that is not boolean true
+        if (resp !== true) {
             return {
                 success: false,
                 commandResponse: "The search was cancelled."
             };
         }
 
-        // Cast the search items queue to ISearchItem. Clone so the original search items are not being modified.
+        // Cast the search items queue to ISearchItem. Clone so the original search items are not being modified and type errors aren't thrown
+        // when/if we reference the original list again.
         let searchItems: ISearchItem[] = cloneDeep(searchItemsQueue);
 
         // Start searching on the mainframe if applicable

--- a/packages/zosfiles/src/methods/search/Search.ts
+++ b/packages/zosfiles/src/methods/search/Search.ts
@@ -113,7 +113,7 @@ export class Search {
         // Call the callback if it exists.
         let resp: boolean = true;
         if (searchOptions.continueSearch) {
-            // Do not pass along the real search items queue. Extenders should not be modifying it.
+            // Call with a clone of the search items queue. Extenders should not be modifying the original.
             resp = await searchOptions.continueSearch(cloneDeep(searchItemsQueue));
         }
 
@@ -125,8 +125,8 @@ export class Search {
             };
         }
 
-        // Cast the search items queue to ISearchItem. Spread to make brand new items instead of a reference.
-        let searchItems: ISearchItem[] = searchItemsQueue;
+        // Cast the search items queue to ISearchItem. Clone so the original search items are not being modified.
+        let searchItems: ISearchItem[] = cloneDeep(searchItemsQueue);
 
         // Start searching on the mainframe if applicable
         if (searchOptions.mainframeSearch) {

--- a/packages/zosfiles/src/methods/search/Search.ts
+++ b/packages/zosfiles/src/methods/search/Search.ts
@@ -18,6 +18,8 @@ import { ISearchMatchLocation } from "./doc/ISearchMatchLocation";
 import { asyncPool } from "@zowe/core-for-zowe-sdk";
 import { ISearchOptions } from "./doc/ISearchOptions";
 import { IZosFilesResponse } from "../../doc/IZosFilesResponse";
+import { IDataSet } from "../../doc/IDataSet";
+import { cloneDeep } from "lodash";
 
 // This interface isn't used outside of the private functions, so just keeping it here.
 interface ISearchResponse {
@@ -71,7 +73,7 @@ export class Search {
         }
 
         // List all data sets that match the search term
-        let searchItems: ISearchItem[] = [];
+        const searchItemsQueue: IDataSet[] = [];
         const partitionedDataSets: string[] = [];
 
         // We are in trouble if list fails - exit if it does
@@ -84,7 +86,7 @@ export class Search {
                 // Skip anything that doesn't have a DSORG or is migrated
                 if (resp.dsorg && !(resp.migr && resp.migr.toLowerCase() === "yes")) {
                     if (resp.dsorg === "PS") {                                      // Sequential
-                        searchItems.push({dsn: resp.dsname});
+                        searchItemsQueue.push({dsn: resp.dsname});
                     } else if (resp.dsorg === "PO" || resp.dsorg === "PO-E") {      // Partitioned
                         partitionedDataSets.push(resp.dsname);
                     }
@@ -100,13 +102,31 @@ export class Search {
                 const response = await List.allMembers(session, pds, searchOptions.listOptions);
                 if (response.apiResponse.items.length > 0) {
                     for (const item of response.apiResponse.items) {
-                        if (item.member != undefined) { searchItems.push({dsn: pds, member: item.member}); }
+                        if (item.member != undefined) { searchItemsQueue.push({dsn: pds, member: item.member}); }
                     }
                 }
             } catch (err) {
                 failedDatasets.push(pds);
             }
         }
+
+        // Call the callback if it exists.
+        let resp: boolean = true;
+        if (searchOptions.continueSearch) {
+            // Do not pass along the real search items queue. Extenders should not be modifying it.
+            resp = await searchOptions.continueSearch(cloneDeep(searchItemsQueue));
+        }
+
+        // Return if either of the callbacks set response to false, null, or undefined
+        if (resp != true) {
+            return {
+                success: false,
+                commandResponse: "The search was cancelled."
+            };
+        }
+
+        // Cast the search items queue to ISearchItem. Spread to make brand new items instead of a reference.
+        let searchItems: ISearchItem[] = searchItemsQueue;
 
         // Start searching on the mainframe if applicable
         if (searchOptions.mainframeSearch) {

--- a/packages/zosfiles/src/methods/search/doc/ISearchOptions.ts
+++ b/packages/zosfiles/src/methods/search/doc/ISearchOptions.ts
@@ -12,6 +12,7 @@
 import { ITaskWithStatus } from "@zowe/imperative";
 import { IGetOptions } from "../../get";
 import { IListOptions } from "../../list";
+import { IDataSet } from "../../../doc/IDataSet";
 
 export interface ISearchOptions {
     /* The pattern matching the data set(s) that should be searched */
@@ -40,4 +41,8 @@ export interface ISearchOptions {
 
     /* The search should be case sensitive */
     caseSensitive?: boolean;
+
+    /* A function that, if provided, is called with a list of data sets and members that are about to be searched. */
+    /* If true, continue search. If false, terminate search. */
+    continueSearch?: (dataSets: IDataSet[]) => Promise<boolean> | boolean;
 }


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->
Adds the ability to provide a function to the Data Sets search function, which is called if present and provided a list of data sets that are about to be searched. This allows extenders to prompt users asking if they want to continue a search, or automatically cancel a search if too many items are about to be searched. If not supplied, the search SDK keeps current behavior.

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [x] added/updated automated tests
- [x] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
