### PR TITLE
Remove invalid anchor link in MaintainerVersioning.md

### DIFF
--- a/docs/MaintainerVersioning.md
+++ b/docs/MaintainerVersioning.md
@@ -1,6 +1,6 @@
 # Versioning
 
-This article describes the versioning scheme used by Zowe CLI and Imperative CLI Framework, and provides [examples](#example-timeline) on how the scheme works.
+This article describes the versioning scheme used by Zowe CLI and Imperative CLI Framework, and provides examples on how the scheme works.
 
 We highly recommend that consumers adhere to the [requirements](#requirements), [tentative release schedule](#tentative-release-schedule), and [tag usage](#tag-usage) for versioning.
 

--- a/docs/MaintainerVersioning.md
+++ b/docs/MaintainerVersioning.md
@@ -78,8 +78,6 @@ We tag various releases of our product in an NPM registry. End users install the
 
    This tag is deprecated.
 
-See the [example timeline](#example-timeline) for examples that show how the above versions will be updated.
-
 ## Requirements
 
 Our versioning scheme has the following requirements:


### PR DESCRIPTION
**What It Does**
Removes anchor links to an example timeline that is no longer included in `MaintainerVersioning.md`

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->

**Review Checklist**
I certify that I have:
- [ ] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [ ] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
