### PR TITLE
ci: use `ubuntu-22.04` for secrets-sdk and zowe-cli workflows

### DIFF
--- a/.github/workflows/secrets-sdk.yml
+++ b/.github/workflows/secrets-sdk.yml
@@ -38,27 +38,27 @@ jobs:
               npm run build -- --target i686-pc-windows-msvc
               npm run test
             target: i686-pc-windows-msvc
-          - host: ubuntu-latest
+          - host: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
             use-cross: true
             build: |
               set -e
               CARGO=cross npm run build -- --target x86_64-unknown-linux-gnu
-          - host: ubuntu-latest
+          - host: ubuntu-22.04
             target: i686-unknown-linux-gnu
             use-cross: true
             build: |
               set -e
               source scripts/configure-cross.sh i686-unknown-linux-gnu
               CARGO=cross npm run build -- --target i686-unknown-linux-gnu
-          - host: ubuntu-latest
+          - host: ubuntu-22.04
             target: armv7-unknown-linux-gnueabihf
             use-cross: true
             build: |
               set -e
               source scripts/configure-cross.sh armv7-unknown-linux-gnueabihf
               CARGO=cross npm run build -- --target armv7-unknown-linux-gnueabihf
-          - host: ubuntu-latest
+          - host: ubuntu-22.04
             target: x86_64-unknown-linux-musl
             use-cross: true
             build: |
@@ -67,14 +67,14 @@ jobs:
           - host: macos-latest
             target: aarch64-apple-darwin
             build: npm run build -- --target aarch64-apple-darwin
-          - host: ubuntu-latest
+          - host: ubuntu-22.04
             target: aarch64-unknown-linux-gnu
             use-cross: true
             build: |
               set -e
               source scripts/configure-cross.sh aarch64-unknown-linux-gnu
               CARGO=cross npm run build -- --target aarch64-unknown-linux-gnu
-          - host: ubuntu-latest
+          - host: ubuntu-22.04
             target: aarch64-unknown-linux-musl
             use-cross: true
             build: |
@@ -208,17 +208,17 @@ jobs:
           - host: macos-latest
             target: x86_64-apple-darwin
             architecture: x64
-          - host: ubuntu-latest
+          - host: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
-          - host: ubuntu-latest
+          - host: ubuntu-22.04
             target: x86_64-unknown-linux-musl
-          - host: ubuntu-latest
+          - host: ubuntu-22.04
             target: aarch64-unknown-linux-gnu
             platform: linux/arm64
-          - host: ubuntu-latest
+          - host: ubuntu-22.04
             target: aarch64-unknown-linux-musl
             platform: linux/arm64
-          - host: ubuntu-latest
+          - host: ubuntu-22.04
             target: armv7-unknown-linux-gnueabihf
             platform: linux/arm/v7
         node:
@@ -250,10 +250,10 @@ jobs:
         if: ${{ matrix.settings.platform }}
       - name: Test bindings
         run: npm run test
-        if: ${{ matrix.settings.host != 'ubuntu-latest' }}
+        if: ${{ matrix.settings.host != 'ubuntu-22.04' }}
       - name: Setup and run tests
         uses: addnab/docker-run-action@v3
-        if: ${{ matrix.settings.host == 'ubuntu-latest' && !endsWith(matrix.settings.target, 'musl') }}
+        if: ${{ matrix.settings.host == 'ubuntu-22.04' && !endsWith(matrix.settings.target, 'musl') }}
         with:
           image: ${{ format('node:{0}-slim', matrix.node) }}
           options: "-v ${{ github.workspace }}:/build -w /build --cap-add=IPC_LOCK ${{ matrix.settings.platform && format('--platform={0}', matrix.settings.platform) }}"
@@ -263,7 +263,7 @@ jobs:
             cd packages/secrets && dbus-run-session -- bash scripts/linux-test.sh
       - name: Setup and run tests (MUSL)
         uses: addnab/docker-run-action@v3
-        if: ${{ matrix.settings.host == 'ubuntu-latest' && endsWith(matrix.settings.target, 'musl') }}
+        if: ${{ matrix.settings.host == 'ubuntu-22.04' && endsWith(matrix.settings.target, 'musl') }}
         with:
           image: ${{ format('node:{0}-alpine', matrix.node) }}
           options: "-v ${{ github.workspace }}:/build -w /build --cap-add=IPC_LOCK ${{ matrix.settings.platform && format('--platform={0}', matrix.settings.platform) }}"

--- a/.github/workflows/zowe-cli.yml
+++ b/.github/workflows/zowe-cli.yml
@@ -37,7 +37,7 @@ jobs:
         node-version: [18.x, 20.x]
         os: 
           - windows-latest
-          - ubuntu-latest
+          - ubuntu-22.04
           - ${{ github.event.inputs.macos-type || 'macos-14'}}
 
     env:
@@ -130,7 +130,7 @@ jobs:
 
     - name: Unlock Keyring
       id: unlock-keyring
-      if: ${{ always() && steps.build.outcome == 'success' && matrix.os == 'ubuntu-latest' }}
+      if: ${{ always() && steps.build.outcome == 'success' && matrix.os == 'ubuntu-22.04' }}
       uses: t1m0thyj/unlock-keyring@v1
 
     - name: Start Daemon
@@ -163,7 +163,7 @@ jobs:
   release:
     if: github.event_name == 'push' && github.ref_protected
     needs: test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       issues: write
       contents: write


### PR DESCRIPTION
**What It Does**

`libsecret` was removed from the Ubuntu 24 runner image. Downgrading to `ubuntu-22.04` will allow us to import Secrets SDK and use it in tests without error.
