### PR TITLE
Handle Proxy during System Tests [v2]

### DIFF
--- a/packages/cli/__tests__/zosmf/__system__/check/status/zosmf.check.status.system.test.ts
+++ b/packages/cli/__tests__/zosmf/__system__/check/status/zosmf.check.status.system.test.ts
@@ -103,7 +103,7 @@ describe("zosmf check status", () => {
 
     describe("Expected failures", () => {
 
-        it("should fail due to invalid port", async () => {
+        (!process.env.HTTP_PROXY && !process.env.HTTPS_PROXY ? it : it.skip)("should fail due to invalid port", async () => {
             // update temporary zowe profile with an invalid port
             const scriptPath = testEnvironment.workingDir + "_create_profile_invalid_port";
             const bogusPort = 12345;

--- a/packages/cli/__tests__/zosmf/__system__/list/systems/zosmf.list.systems.system.test.ts
+++ b/packages/cli/__tests__/zosmf/__system__/list/systems/zosmf.list.systems.system.test.ts
@@ -121,7 +121,7 @@ describe("zosmf list systems", () => {
 
     describe("Expected failures", () => {
 
-        it("should fail due to invalid port", async () => {
+        (!process.env.HTTP_PROXY && !process.env.HTTPS_PROXY ? it : it.skip)("should fail due to invalid port", async () => {
             // update temporary zowe profile with an invalid port
             const scriptPath = testEnvironment.workingDir + "_create_profile_invalid_port";
             const bogusPort = 12345;

--- a/packages/zosmf/__tests__/__system__/methods/CheckStatus.system.test.ts
+++ b/packages/zosmf/__tests__/__system__/methods/CheckStatus.system.test.ts
@@ -69,7 +69,7 @@ describe("Check Status Api", () => {
             expect(error.message).toContain(ZosmfMessages.missingSession.message);
         });
 
-        it("should return with proper message for invalid hostname", async () => {
+        (!process.env.HTTP_PROXY && !process.env.HTTPS_PROXY ? it : it.skip)("should return with proper message for invalid hostname", async () => {
             const badHostName = "badHost";
             const badSession = new Session({
                 user: defaultSystem.zosmf.user,
@@ -95,7 +95,7 @@ describe("Check Status Api", () => {
             expect(error.message).toMatch(/(Error: getaddrinfo).*(badHost)/);
         });
 
-        it("should return with proper message for invalid port", async () => {
+        (!process.env.HTTP_PROXY && !process.env.HTTPS_PROXY ? it : it.skip)("should return with proper message for invalid port", async () => {
             const badPort = 51342;
             const badSession = new Session({
                 user: defaultSystem.zosmf.user,

--- a/packages/zosmf/__tests__/__system__/methods/ListDefinedSystems.system.test.ts
+++ b/packages/zosmf/__tests__/__system__/methods/ListDefinedSystems.system.test.ts
@@ -69,7 +69,7 @@ describe("List Defined Systems Api", () => {
             expect(error.message).toContain(ZosmfMessages.missingSession.message);
         });
 
-        it("should return with proper message for invalid hostname", async () => {
+        (!process.env.HTTP_PROXY && !process.env.HTTPS_PROXY ? it : it.skip)("should return with proper message for invalid hostname", async () => {
             const badHostName = "badHost";
             const badSession = new Session({
                 user: defaultSystem.zosmf.user,
@@ -95,7 +95,7 @@ describe("List Defined Systems Api", () => {
             expect(error.message).toMatch(/(Error: getaddrinfo).*(badHost)/);
         });
 
-        it("should return with proper message for invalid port", async () => {
+        (!process.env.HTTP_PROXY && !process.env.HTTPS_PROXY ? it : it.skip)("should return with proper message for invalid port", async () => {
             const badPort = 9999;
             const badSession = new Session({
                 user: defaultSystem.zosmf.user,


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->
Skips invalid hostname and invalid port tests when a proxy is set.

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
