### PR TITLE
Fix handling of scoped registry on plugin install

### DIFF
--- a/packages/imperative/CHANGELOG.md
+++ b/packages/imperative/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Imperative package will be documented in this file.
 
+## Recent Changes
+
+- BugFix: Fixed an issue where `plugins install` command could fail when installing scoped package because scoped registry was used to fetch all dependencies. [#2317](https://github.com/zowe/zowe-cli/issues/2317)
+
 ## `8.2.0`
 
 - Enhancement: Use the new SDK method `ConfigUtils.hasTokenExpired` to check whether a given JSON web token has expired. [#2298](https://github.com/zowe/zowe-cli/pull/2298)

--- a/packages/imperative/CHANGELOG.md
+++ b/packages/imperative/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the Imperative package will be documented in this file.
 
 ## Recent Changes
 
-- BugFix: Fixed an issue where `plugins install` command could fail when installing scoped package because scoped registry was used to fetch all dependencies. [#2317](https://github.com/zowe/zowe-cli/issues/2317)
+- BugFix: Fixed an issue where the `plugins install` command could fail when installing a scoped package because scoped registry was used to fetch all dependencies. [#2317](https://github.com/zowe/zowe-cli/issues/2317)
 
 ## `8.2.0`
 

--- a/packages/imperative/__tests__/src/packages/imperative/plugins/suites/InstallingPlugins.ts
+++ b/packages/imperative/__tests__/src/packages/imperative/plugins/suites/InstallingPlugins.ts
@@ -83,7 +83,7 @@ describe("Installing Plugins", () => {
             name: "override-plugin",
             usage: "override-plugin"
         },
-        location: {
+        sample_registry: {
             location: "imperative-sample-plugin",
             name: "imperative-sample-plugin",
             usage: "sample-plugin"
@@ -667,7 +667,7 @@ describe("Installing Plugins", () => {
             const savedPluginJson = readFileSync(pluginJsonLocation);
             const expectedContent: IPluginJson = fileContent as IPluginJson;
 
-            expectedContent[plugins.normal.name].location = envNpmRegistry;
+            expectedContent[plugins.normal.name].location = plugins.normal.location;
 
             expect(savedPluginJson).toEqual(expectedContent);
         });
@@ -735,7 +735,7 @@ describe("Installing Plugins", () => {
             const actualJson = readFileSync(pluginJsonLocation);
 
             // Add missing registry to expected
-            expectedJson[plugins.normal.name].location = envNpmRegistry;
+            expectedJson[plugins.normal.name].location = plugins.normal.location;
 
             // Add missing normal2 plugin not present in before each
             expectedJson[plugins.normal3.name] = {
@@ -751,7 +751,7 @@ describe("Installing Plugins", () => {
         it("should error when a package and --file is specified", function () {
             expect(
                 T.stripNewLines(
-                    executeCommandString(this, `${pluginGroup} install ${plugins.location.location} --file ${testFile}`).stderr
+                    executeCommandString(this, `${pluginGroup} install ${plugins.sample_registry.location} --file ${testFile}`).stderr
                 )
             ).toContain("Option --file can not be specified if positional package... is as well. They are mutually exclusive.");
         });
@@ -760,7 +760,7 @@ describe("Installing Plugins", () => {
             expect(
                 T.stripNewLines(
                     executeCommandString(this,
-                        `${pluginGroup} install ${plugins.location.location} --file ${testFile} --registry ${TEST_REGISTRY}`).stderr
+                        `${pluginGroup} install ${plugins.sample_registry.location} --file ${testFile} --registry ${TEST_REGISTRY}`).stderr
                 )
             ).toContain("The following options conflict (mutually exclusive)");
         });

--- a/packages/imperative/src/imperative/__tests__/plugins/cmd/install/install.handler.unit.test.ts
+++ b/packages/imperative/src/imperative/__tests__/plugins/cmd/install/install.handler.unit.test.ts
@@ -53,7 +53,6 @@ import { PMFConstants } from "../../../../src/plugins/utilities/PMFConstants";
 import { TextUtils } from "../../../../../utilities";
 import { getRegistry, getScopeRegistry, npmLogin } from "../../../../src/plugins/utilities/NpmFunctions";
 import * as spawn from "cross-spawn";
-import { IO } from "../../../../../io";
 
 describe("Plugin Management Facility install handler", () => {
 
@@ -381,28 +380,27 @@ describe("Plugin Management Facility install handler", () => {
         expect(expectedError.additionalDetails).toContain("Command failed");
         expect(expectedError.additionalDetails).toContain("npm");
     });
-    it("should handle installed plugins via public scope", async () => {
-        const handler = new InstallHandler();
+    // it("should handle installed plugins via public scope", async () => {
+    //     const handler = new InstallHandler();
 
-        const params = getIHandlerParametersObject();
-        params.arguments.plugin = ["@public/sample1"];
+    //     const params = getIHandlerParametersObject();
+    //     params.arguments.plugin = ["@public/sample1"];
 
-        mocks.getScopeRegistry.mockReturnValueOnce("publicRegistryUrl" as any);
+    //     mocks.getScopeRegistry.mockReturnValueOnce("publicRegistryUrl" as any);
 
-        try {
-            await handler.process(params);
-        } catch (e) {
-            expect(e).toBeUndefined();
-        }
+    //     try {
+    //         await handler.process(params);
+    //     } catch (e) {
+    //         expect(e).toBeUndefined();
+    //     }
 
-        expect(mocks.install).toHaveBeenCalledWith("@public/sample1","publicRegistryUrl");
-    });
+    //     expect(mocks.install).toHaveBeenCalledWith("@public/sample1","publicRegistryUrl");
+    // });
     it("should handle installed plugins via project/directory", async () => {
         const handler = new InstallHandler();
 
         const params = getIHandlerParametersObject();
         params.arguments.plugin = ["path/to/dir"];
-        jest.spyOn(IO, 'isDir').mockReturnValue(true);
 
         try{
             await handler.process(params);
@@ -411,7 +409,7 @@ describe("Plugin Management Facility install handler", () => {
             expect(e).toBeUndefined();
         }
 
-        expect(mocks.install).toHaveBeenCalledWith("path/to/dir","path/to/dir");
+        expect(mocks.install).toHaveBeenCalledWith("path/to/dir", packageRegistry);
     });
     it("should handle installed plugins via tarball file", async () => {
         const handler = new InstallHandler();
@@ -426,16 +424,14 @@ describe("Plugin Management Facility install handler", () => {
             expect(e).toBeUndefined();
         }
 
-        expect(mocks.install).toHaveBeenCalledWith("path/to/dir/file.tgz","path/to/dir/file.tgz");
+        expect(mocks.install).toHaveBeenCalledWith("path/to/dir/file.tgz", packageRegistry);
     });
-    it("should handle multiple installed plugins via tarball, director, public registry, and private registry", async () => {
+    it("should handle multiple installed plugins via tarball, directory, and registry", async () => {
         const handler = new InstallHandler();
 
         const params = getIHandlerParametersObject();
-        params.arguments.plugin = ["@public/sample1","@private/sample1","path/to/dir","path/to/dir/file.tgz"];
-        mocks.getScopeRegistry.mockReturnValueOnce("publicRegistryUrl" as any);
-        mocks.getScopeRegistry.mockReturnValueOnce("privateRegistryUrl" as any);
-        jest.spyOn(IO, 'isDir').mockReturnValue(true);
+        params.arguments.plugin = ["@public/sample1", "@private/sample1", "path/to/dir", "path/to/dir/file.tgz"];
+        mocks.getRegistry.mockReturnValueOnce(packageRegistry2 as any);
 
         try{
             await handler.process(params);
@@ -444,10 +440,10 @@ describe("Plugin Management Facility install handler", () => {
             expect(e).toBeUndefined();
         }
 
-        expect(mocks.install).toHaveBeenCalledWith("@public/sample1","publicRegistryUrl");
-        expect(mocks.install).toHaveBeenCalledWith("@private/sample1","privateRegistryUrl");
-        expect(mocks.install).toHaveBeenCalledWith("path/to/dir","path/to/dir");
-        expect(mocks.install).toHaveBeenCalledWith("path/to/dir/file.tgz","path/to/dir/file.tgz");
+        expect(mocks.install).toHaveBeenCalledWith("@public/sample1", packageRegistry2);
+        expect(mocks.install).toHaveBeenCalledWith("@private/sample1", packageRegistry2);
+        expect(mocks.install).toHaveBeenCalledWith("path/to/dir", packageRegistry2);
+        expect(mocks.install).toHaveBeenCalledWith("path/to/dir/file.tgz", packageRegistry2);
     });
 });
 

--- a/packages/imperative/src/imperative/__tests__/plugins/cmd/install/install.handler.unit.test.ts
+++ b/packages/imperative/src/imperative/__tests__/plugins/cmd/install/install.handler.unit.test.ts
@@ -207,7 +207,10 @@ describe("Plugin Management Facility install handler", () => {
         wasGetRegistryCalled();
 
         expect(mocks.install).toHaveBeenCalledTimes(2);
-        wasInstallCallValid(`${fileJson.a.package}@${fileJson.a.version}`, { location: packageRegistry, npmArgs: {} }, true);
+        wasInstallCallValid(`${fileJson.a.package}@${fileJson.a.version}`, {
+            location: packageRegistry,
+            npmArgs: { registry: packageRegistry }
+        }, true);
         wasInstallCallValid(fileJson.plugin2.package, {
             location: packageRegistry2,
             npmArgs: { registry: packageRegistry2 }
@@ -258,7 +261,10 @@ describe("Plugin Management Facility install handler", () => {
         wasGetRegistryCalled();
 
         // Check that install worked as expected
-        wasInstallCallValid(params.arguments.plugin[0], { location: packageRegistry, npmArgs: {} });
+        wasInstallCallValid(params.arguments.plugin[0], {
+            location: packageRegistry,
+            npmArgs: { registry: packageRegistry }
+        });
 
         // Check that success is output
         wasInstallSuccessful(params);
@@ -319,9 +325,13 @@ describe("Plugin Management Facility install handler", () => {
 
         // Validate that install was called with each of these values
         expect(mocks.install).toHaveBeenCalledTimes(params.arguments.plugin.length);
-        wasInstallCallValid(params.arguments.plugin[0], { location: packageRegistry, npmArgs: {} });
-        wasInstallCallValid(params.arguments.plugin[1], { location: packageRegistry, npmArgs: {} });
-        wasInstallCallValid(params.arguments.plugin[2], { location: packageRegistry, npmArgs: {} });
+        const registryInfo: INpmRegistryInfo = {
+            location: packageRegistry,
+            npmArgs: { registry: packageRegistry }
+        };
+        wasInstallCallValid(params.arguments.plugin[0], registryInfo);
+        wasInstallCallValid(params.arguments.plugin[1], registryInfo);
+        wasInstallCallValid(params.arguments.plugin[2], registryInfo);
 
         wasInstallSuccessful(params);
     });
@@ -407,7 +417,10 @@ describe("Plugin Management Facility install handler", () => {
             expect(e).toBeUndefined();
         }
 
-        wasInstallCallValid("@public/sample1", { location: "publicRegistryUrl", npmArgs: {} });
+        wasInstallCallValid("@public/sample1", {
+            location: packageRegistry,
+            npmArgs: { registry: packageRegistry, "@public:registry": "publicRegistryUrl" }
+        });
     });
     it("should handle installed plugins via project/directory", async () => {
         const handler = new InstallHandler();
@@ -422,7 +435,10 @@ describe("Plugin Management Facility install handler", () => {
             expect(e).toBeUndefined();
         }
 
-        wasInstallCallValid("path/to/dir", { location: "path/to/dir", npmArgs: {} });
+        wasInstallCallValid("path/to/dir", {
+            location: "path/to/dir",
+            npmArgs: { registry: packageRegistry }
+        });
     });
     it("should handle installed plugins via tarball file", async () => {
         const handler = new InstallHandler();
@@ -437,7 +453,10 @@ describe("Plugin Management Facility install handler", () => {
             expect(e).toBeUndefined();
         }
 
-        wasInstallCallValid("path/to/dir/file.tgz", { location: "path/to/dir/file.tgz", npmArgs: {} });
+        wasInstallCallValid("path/to/dir/file.tgz", {
+            location: "path/to/dir/file.tgz",
+            npmArgs: { registry: packageRegistry }
+        });
     });
     it("should handle multiple installed plugins via tarball, directory, and registry", async () => {
         const handler = new InstallHandler();
@@ -455,9 +474,21 @@ describe("Plugin Management Facility install handler", () => {
         }
 
         expect(mocks.install).toHaveBeenCalledTimes(params.arguments.plugin.length);
-        wasInstallCallValid("@public/sample1", { location: "publicRegistryUrl", npmArgs: {} });
-        wasInstallCallValid("@private/sample1", { location: "privateRegistryUrl", npmArgs: {} });
-        wasInstallCallValid("path/to/dir", { location: "path/to/dir", npmArgs: {} });
-        wasInstallCallValid("path/to/dir/file.tgz", { location: "path/to/dir/file.tgz", npmArgs: {} });
+        wasInstallCallValid("@public/sample1", {
+            location: packageRegistry,
+            npmArgs: { registry: packageRegistry, "@public:registry": "publicRegistryUrl" }
+        });
+        wasInstallCallValid("@private/sample1", {
+            location: packageRegistry,
+            npmArgs: { registry: packageRegistry, "@private:registry": "privateRegistryUrl" }
+        });
+        wasInstallCallValid("path/to/dir", {
+            location: "path/to/dir",
+            npmArgs: { registry: packageRegistry }
+        });
+        wasInstallCallValid("path/to/dir/file.tgz", {
+            location: "path/to/dir/file.tgz",
+            npmArgs: { registry: packageRegistry }
+        });
     });
 });

--- a/packages/imperative/src/imperative/__tests__/plugins/cmd/install/install.handler.unit.test.ts
+++ b/packages/imperative/src/imperative/__tests__/plugins/cmd/install/install.handler.unit.test.ts
@@ -10,31 +10,22 @@
 */
 
 /* eslint-disable jest/expect-expect */
-import Mock = jest.Mock;
-
 let expectedVal: unknown;
 let returnedVal: unknown;
 
 jest.mock("cross-spawn");
 jest.mock("jsonfile");
-jest.mock("../../../../src/plugins/utilities/npm-interface/install");
-jest.mock("../../../../src/plugins/utilities/runValidatePlugin");
 jest.mock("../../../../src/plugins/utilities/PMFConstants");
-jest.mock("../../../../../cmd/src/response/CommandResponse");
 jest.mock("../../../../../cmd/src/response/HandlerResponse");
-jest.mock("../../../../../cmd/src/doc/handler/IHandlerParameters");
-jest.mock("../../../../../logger");
-jest.mock("../../../../src/Imperative");
-jest.mock("../../../../src/plugins/utilities/NpmFunctions");
 jest.doMock("path", () => {
     const originalPath = jest.requireActual("path");
     return {
         ...originalPath,
-        resolve: (...path: string[]) => {
-            if (path[0] == expectedVal) {
+        resolve: (...paths: string[]) => {
+            if (paths[0] === expectedVal) {
                 return returnedVal ? returnedVal : expectedVal;
             } else {
-                return originalPath.resolve(...path);
+                return originalPath.resolve(...paths);
             }
         }
     };
@@ -43,28 +34,30 @@ jest.doMock("path", () => {
 import { HandlerResponse, IHandlerParameters } from "../../../../../cmd";
 import { Console } from "../../../../../console";
 import { ImperativeError } from "../../../../../error";
-import { install } from "../../../../src/plugins/utilities/npm-interface";
-import { runValidatePlugin } from "../../../../src/plugins/utilities/runValidatePlugin";
+import * as npmInterface from "../../../../src/plugins/utilities/npm-interface";
+import * as validatePlugin from "../../../../src/plugins/utilities/runValidatePlugin";
 import InstallHandler from "../../../../src/plugins/cmd/install/install.handler";
 import { IPluginJson } from "../../../../src/plugins/doc/IPluginJson";
 import { Logger } from "../../../../../logger";
-import { readFileSync, writeFileSync } from "jsonfile";
+import * as jsonfile from "jsonfile";
 import { PMFConstants } from "../../../../src/plugins/utilities/PMFConstants";
 import { TextUtils } from "../../../../../utilities";
-import { getRegistry, getScopeRegistry, npmLogin } from "../../../../src/plugins/utilities/NpmFunctions";
+import { NpmRegistryUtils } from "../../../../src/plugins/utilities/NpmFunctions";
 import * as spawn from "cross-spawn";
+import { INpmRegistryInfo } from "../../../../src/plugins/doc/INpmRegistryInfo";
 
 describe("Plugin Management Facility install handler", () => {
 
     // Objects created so types are correct.
+    const origGetRegistry = jest.requireActual("../../../../src/plugins/utilities/NpmFunctions").NpmRegistryUtils.getRegistry;
     const mocks = {
-        npmLogin: npmLogin as Mock<typeof npmLogin>,
-        getRegistry: getRegistry as unknown as Mock<typeof getRegistry>,
-        getScopeRegistry: getScopeRegistry as unknown as Mock<typeof getScopeRegistry>,
-        readFileSync: readFileSync as Mock<typeof readFileSync>,
-        writeFileSync: writeFileSync as Mock<typeof writeFileSync>,
-        install: install as unknown as Mock<typeof install>,
-        runValidatePlugin: runValidatePlugin as unknown as Mock<typeof runValidatePlugin>,
+        npmLogin: jest.spyOn(NpmRegistryUtils, "npmLogin"),
+        getRegistry: jest.spyOn(NpmRegistryUtils, "getRegistry"),
+        getScopeRegistry: jest.spyOn(NpmRegistryUtils as any, "getScopeRegistry"),
+        readFileSync: jest.spyOn(jsonfile, "readFileSync"),
+        writeFileSync: jest.spyOn(jsonfile, "writeFileSync"),
+        install: jest.spyOn(npmInterface, "install"),
+        runValidatePlugin: jest.spyOn(validatePlugin, "runValidatePlugin"),
     };
 
     // two plugin set of values
@@ -83,11 +76,11 @@ describe("Plugin Management Facility install handler", () => {
         jest.clearAllMocks();
 
         // This needs to be mocked before running process function of uninstall handler
-        (Logger.getImperativeLogger as unknown as Mock<typeof Logger.getImperativeLogger>).mockReturnValue(new Logger(new Console()) as any);
-        mocks.getRegistry.mockReturnValue(packageRegistry as any);
-        mocks.readFileSync.mockReturnValue({} as any);
-        npmLogin(packageRegistry);
-        mocks.runValidatePlugin.mockReturnValue(finalValidationMsg as any);
+        jest.spyOn(Logger, "getImperativeLogger").mockReturnValue(new Logger(new Console()));
+        mocks.getRegistry.mockReturnValue(packageRegistry);
+        mocks.readFileSync.mockReturnValue({});
+        mocks.runValidatePlugin.mockReturnValue(finalValidationMsg);
+        mocks.install.mockImplementation();
         expectedVal = undefined;
         returnedVal = undefined;
     });
@@ -139,7 +132,7 @@ describe("Plugin Management Facility install handler", () => {
      */
     const wasInstallCallValid = (
         packageLocation: string,
-        registry: string,
+        registry: INpmRegistryInfo,
         installFromFile = false
     ) => {
         if (installFromFile) {
@@ -161,8 +154,9 @@ describe("Plugin Management Facility install handler", () => {
      */
     const wasInstallSuccessful = (params: IHandlerParameters) => {
         // get the text of the last message that was displayed
-        const outputMsg = (params.response.console.log as Mock).mock.calls[(params.response.console.log as Mock).mock.calls.length - 1][0];
-        expect(outputMsg).toContain(finalValidationMsg);
+        expect(params.response.console.log).toHaveBeenLastCalledWith(
+            expect.stringContaining(finalValidationMsg)
+        );
     };
 
     /**
@@ -192,10 +186,10 @@ describe("Plugin Management Facility install handler", () => {
         };
 
         // Override the return value for this test only
-        mocks.readFileSync.mockReturnValueOnce(fileJson as any);
+        mocks.readFileSync.mockReturnValueOnce(fileJson);
         mocks.install
-            .mockReturnValueOnce("a" as any)
-            .mockReturnValueOnce("plugin2" as any);
+            .mockResolvedValueOnce("a")
+            .mockResolvedValueOnce("plugin2");
 
         const handler = new InstallHandler();
 
@@ -212,17 +206,16 @@ describe("Plugin Management Facility install handler", () => {
         // Validate the call to get the registry value
         wasGetRegistryCalled();
 
-        // Validate the call to login
-        wasNpmLoginCallValid(packageRegistry);
-
         expect(mocks.install).toHaveBeenCalledTimes(2);
-        wasInstallCallValid(`${fileJson.a.package}@${fileJson.a.version}`, packageRegistry, true);
-        wasInstallCallValid(fileJson.plugin2.package, packageRegistry2, true);
+        wasInstallCallValid(`${fileJson.a.package}@${fileJson.a.version}`, { location: packageRegistry, npmArgs: {} }, true);
+        wasInstallCallValid(fileJson.plugin2.package, {
+            location: packageRegistry2,
+            npmArgs: { registry: packageRegistry2 }
+        }, true);
 
         expect(mocks.runValidatePlugin).toHaveBeenCalledTimes(2);
         expect(mocks.runValidatePlugin).toHaveBeenCalledWith("a");
         expect(mocks.runValidatePlugin).toHaveBeenCalledWith("plugin2");
-
 
         // Validate that the read was correct
         wasReadFileSyncCallValid(resolveVal);
@@ -264,11 +257,8 @@ describe("Plugin Management Facility install handler", () => {
         // Validate the call to get the registry value
         wasGetRegistryCalled();
 
-        // Validate the call to login
-        wasNpmLoginCallValid(packageRegistry);
-
         // Check that install worked as expected
-        wasInstallCallValid(params.arguments.plugin[0], packageRegistry);
+        wasInstallCallValid(params.arguments.plugin[0], { location: packageRegistry, npmArgs: {} });
 
         // Check that success is output
         wasInstallSuccessful(params);
@@ -284,8 +274,35 @@ describe("Plugin Management Facility install handler", () => {
         await handler.process(params as IHandlerParameters);
 
         // Validate the call to install with specified plugin and registry
-        wasInstallCallValid(params.arguments.plugin[0], params.arguments.registry);
+        wasInstallCallValid(params.arguments.plugin[0], {
+            location: params.arguments.registry,
+            npmArgs: { registry: params.arguments.registry }
+        });
 
+        wasInstallSuccessful(params);
+    });
+
+    it("should install single package with registry and login specified", async () => {
+        mocks.npmLogin.mockReturnValueOnce();
+        const handler = new InstallHandler();
+
+        const params = getIHandlerParametersObject();
+        params.arguments.plugin = ["sample1"];
+        params.arguments.registry = "http://localhost:4873/";
+        params.arguments.login = true;
+
+        await handler.process(params as IHandlerParameters);
+
+        // Validate the call to login
+        wasNpmLoginCallValid(packageRegistry);
+
+        // Check that install worked as expected
+        wasInstallCallValid(params.arguments.plugin[0], {
+            location: params.arguments.registry,
+            npmArgs: { registry: params.arguments.registry }
+        });
+
+        // Check that success is output
         wasInstallSuccessful(params);
     });
 
@@ -300,14 +317,11 @@ describe("Plugin Management Facility install handler", () => {
         // Validate the install
         wasGetRegistryCalled();
 
-        // Validate the call to login
-        wasNpmLoginCallValid(packageRegistry);
-
         // Validate that install was called with each of these values
         expect(mocks.install).toHaveBeenCalledTimes(params.arguments.plugin.length);
-        wasInstallCallValid(params.arguments.plugin[0], packageRegistry);
-        wasInstallCallValid(params.arguments.plugin[1], packageRegistry);
-        wasInstallCallValid(params.arguments.plugin[2], packageRegistry);
+        wasInstallCallValid(params.arguments.plugin[0], { location: packageRegistry, npmArgs: {} });
+        wasInstallCallValid(params.arguments.plugin[1], { location: packageRegistry, npmArgs: {} });
+        wasInstallCallValid(params.arguments.plugin[2], { location: packageRegistry, npmArgs: {} });
 
         wasInstallSuccessful(params);
     });
@@ -323,8 +337,7 @@ describe("Plugin Management Facility install handler", () => {
         // Validate the call to get the registry value
         wasGetRegistryCalled();
 
-        // Validate the call to login
-        wasNpmLoginCallValid(packageRegistry);
+        // Validate that the read was correct
         wasReadFileSyncCallValid(PMFConstants.instance.PLUGIN_JSON);
 
         expect(params.response.console.log).toHaveBeenCalledWith("No packages were found in " +
@@ -368,7 +381,7 @@ describe("Plugin Management Facility install handler", () => {
         });
 
         jest.spyOn(spawn, "sync").mockReturnValueOnce({ status: 1 } as any);
-        mocks.getRegistry.mockImplementationOnce(jest.requireActual("../../../../src/plugins/utilities/NpmFunctions").getRegistry);
+        mocks.getRegistry.mockImplementationOnce(origGetRegistry);
 
         try {
             await handler.process(params);
@@ -380,22 +393,22 @@ describe("Plugin Management Facility install handler", () => {
         expect(expectedError.additionalDetails).toContain("Command failed");
         expect(expectedError.additionalDetails).toContain("npm");
     });
-    // it("should handle installed plugins via public scope", async () => {
-    //     const handler = new InstallHandler();
+    it("should handle installed plugins via package name", async () => {
+        const handler = new InstallHandler();
 
-    //     const params = getIHandlerParametersObject();
-    //     params.arguments.plugin = ["@public/sample1"];
+        const params = getIHandlerParametersObject();
+        params.arguments.plugin = ["@public/sample1"];
 
-    //     mocks.getScopeRegistry.mockReturnValueOnce("publicRegistryUrl" as any);
+        mocks.getScopeRegistry.mockReturnValueOnce("publicRegistryUrl");
 
-    //     try {
-    //         await handler.process(params);
-    //     } catch (e) {
-    //         expect(e).toBeUndefined();
-    //     }
+        try {
+            await handler.process(params);
+        } catch (e) {
+            expect(e).toBeUndefined();
+        }
 
-    //     expect(mocks.install).toHaveBeenCalledWith("@public/sample1","publicRegistryUrl");
-    // });
+        wasInstallCallValid("@public/sample1", { location: "publicRegistryUrl", npmArgs: {} });
+    });
     it("should handle installed plugins via project/directory", async () => {
         const handler = new InstallHandler();
 
@@ -409,7 +422,7 @@ describe("Plugin Management Facility install handler", () => {
             expect(e).toBeUndefined();
         }
 
-        expect(mocks.install).toHaveBeenCalledWith("path/to/dir", packageRegistry);
+        wasInstallCallValid("path/to/dir", { location: "path/to/dir", npmArgs: {} });
     });
     it("should handle installed plugins via tarball file", async () => {
         const handler = new InstallHandler();
@@ -424,14 +437,15 @@ describe("Plugin Management Facility install handler", () => {
             expect(e).toBeUndefined();
         }
 
-        expect(mocks.install).toHaveBeenCalledWith("path/to/dir/file.tgz", packageRegistry);
+        wasInstallCallValid("path/to/dir/file.tgz", { location: "path/to/dir/file.tgz", npmArgs: {} });
     });
     it("should handle multiple installed plugins via tarball, directory, and registry", async () => {
         const handler = new InstallHandler();
 
         const params = getIHandlerParametersObject();
         params.arguments.plugin = ["@public/sample1", "@private/sample1", "path/to/dir", "path/to/dir/file.tgz"];
-        mocks.getRegistry.mockReturnValueOnce(packageRegistry2 as any);
+        mocks.getScopeRegistry.mockReturnValueOnce("publicRegistryUrl");
+        mocks.getScopeRegistry.mockReturnValueOnce("privateRegistryUrl");
 
         try{
             await handler.process(params);
@@ -440,10 +454,10 @@ describe("Plugin Management Facility install handler", () => {
             expect(e).toBeUndefined();
         }
 
-        expect(mocks.install).toHaveBeenCalledWith("@public/sample1", packageRegistry2);
-        expect(mocks.install).toHaveBeenCalledWith("@private/sample1", packageRegistry2);
-        expect(mocks.install).toHaveBeenCalledWith("path/to/dir", packageRegistry2);
-        expect(mocks.install).toHaveBeenCalledWith("path/to/dir/file.tgz", packageRegistry2);
+        expect(mocks.install).toHaveBeenCalledTimes(params.arguments.plugin.length);
+        wasInstallCallValid("@public/sample1", { location: "publicRegistryUrl", npmArgs: {} });
+        wasInstallCallValid("@private/sample1", { location: "privateRegistryUrl", npmArgs: {} });
+        wasInstallCallValid("path/to/dir", { location: "path/to/dir", npmArgs: {} });
+        wasInstallCallValid("path/to/dir/file.tgz", { location: "path/to/dir/file.tgz", npmArgs: {} });
     });
 });
-

--- a/packages/imperative/src/imperative/__tests__/plugins/cmd/list/list.handler.unit.test.ts
+++ b/packages/imperative/src/imperative/__tests__/plugins/cmd/list/list.handler.unit.test.ts
@@ -84,7 +84,7 @@ describe("Plugin Management Facility list handler", () => {
         mocks.readFileSync.mockReturnValue({} as any);
     });
 
-    test("list packages", async () => {
+    it("list packages", async () => {
 
         // plugin definitions mocking unsorted file contents
         const fileJson: IPluginJson = {
@@ -113,7 +113,7 @@ describe("Plugin Management Facility list handler", () => {
 
     });
 
-    test("list packages short", async () => {
+    it("list packages short", async () => {
 
         // plugin definitions mocking unsorted file contents
         const fileJson: IPluginJson = {
@@ -143,4 +143,3 @@ describe("Plugin Management Facility list handler", () => {
 
     });
 });
-

--- a/packages/imperative/src/imperative/__tests__/plugins/cmd/uninstall/uninstall.handler.unit.test.ts
+++ b/packages/imperative/src/imperative/__tests__/plugins/cmd/uninstall/uninstall.handler.unit.test.ts
@@ -109,7 +109,7 @@ describe("Plugin Management Facility uninstall handler", () => {
         expect(params.response.console.log).toHaveBeenCalledWith("Removal of the npm package(s) was successful.\n");
     };
 
-    test("uninstall specified package", async () => {
+    it("uninstall specified package", async () => {
         // plugin definitions mocking file contents
         const fileJson: IPluginJson = {
             a: {

--- a/packages/imperative/src/imperative/__tests__/plugins/cmd/update/update.handler.unit.test.ts
+++ b/packages/imperative/src/imperative/__tests__/plugins/cmd/update/update.handler.unit.test.ts
@@ -9,6 +9,7 @@
 *
 */
 
+/* eslint-disable jest/expect-expect */
 jest.mock("child_process");
 jest.mock("jsonfile");
 jest.mock("../../../../src/plugins/utilities/PMFConstants");
@@ -157,7 +158,7 @@ describe("Plugin Management Facility update handler", () => {
         wasNpmLoginCallValid(packageRegistry);
         wasWriteFileSyncValid(PMFConstants.instance.PLUGIN_JSON, fileJson);
         wasUpdateCallValid(packageName, {
-            location: resolveVal,
+            location: packageRegistry,
             npmArgs: { registry: packageRegistry }
         });
         wasUpdateSuccessful(params);

--- a/packages/imperative/src/imperative/__tests__/plugins/cmd/update/update.handler.unit.test.ts
+++ b/packages/imperative/src/imperative/__tests__/plugins/cmd/update/update.handler.unit.test.ts
@@ -25,7 +25,6 @@ import { NpmRegistryUtils } from "../../../../src/plugins/utilities/NpmFunctions
 import * as childProcess from "child_process";
 import * as jsonfile from "jsonfile";
 import * as npmInterface from "../../../../src/plugins/utilities/npm-interface";
-import { INpmRegistryInfo } from "../../../../src/plugins/doc/INpmRegistryInfo";
 
 describe("Plugin Management Facility update handler", () => {
 
@@ -58,7 +57,6 @@ describe("Plugin Management Facility update handler", () => {
         jest.spyOn(Logger, "getImperativeLogger").mockReturnValue(new Logger(new Console()));
         mocks.execSyncSpy.mockReturnValue(packageRegistry);
         mocks.readFileSyncSpy.mockReturnValue({});
-        NpmRegistryUtils.npmLogin(packageRegistry);
     });
 
     /**
@@ -88,10 +86,10 @@ describe("Plugin Management Facility update handler", () => {
      */
     const wasUpdateCallValid = (
         packageNameParm: string,
-        registry: INpmRegistryInfo
+        registry: string
     ) => {
         expect(mocks.updateSpy).toHaveBeenCalledWith(
-            packageNameParm, registry
+            packageNameParm, { location: registry, npmArgs: { registry } }
         );
     };
 
@@ -151,16 +149,14 @@ describe("Plugin Management Facility update handler", () => {
         const params = getIHandlerParametersObject();
         params.arguments.plugin = pluginName;
         params.arguments.registry = packageRegistry;
+        params.arguments.login = true;
 
         await handler.process(params as IHandlerParameters);
 
         // Validate the call to login
         wasNpmLoginCallValid(packageRegistry);
         wasWriteFileSyncValid(PMFConstants.instance.PLUGIN_JSON, fileJson);
-        wasUpdateCallValid(packageName, {
-            location: packageRegistry,
-            npmArgs: { registry: packageRegistry }
-        });
+        wasUpdateCallValid(packageName, packageRegistry);
         wasUpdateSuccessful(params);
     });
 
@@ -186,12 +182,8 @@ describe("Plugin Management Facility update handler", () => {
         await handler.process(params as IHandlerParameters);
 
         // Validate the call to login
-        wasNpmLoginCallValid(packageRegistry);
         wasWriteFileSyncValid(PMFConstants.instance.PLUGIN_JSON, fileJson);
-        wasUpdateCallValid(resolveVal, {
-            location: packageRegistry,
-            npmArgs: { registry: packageRegistry }
-        });
+        wasUpdateCallValid(resolveVal, packageRegistry);
         wasUpdateSuccessful(params);
     });
 });

--- a/packages/imperative/src/imperative/__tests__/plugins/cmd/update/update.handler.unit.test.ts
+++ b/packages/imperative/src/imperative/__tests__/plugins/cmd/update/update.handler.unit.test.ts
@@ -9,17 +9,10 @@
 *
 */
 
-import Mock = jest.Mock;
-
 jest.mock("child_process");
 jest.mock("jsonfile");
-jest.mock("../../../../src/plugins/utilities/npm-interface/update");
 jest.mock("../../../../src/plugins/utilities/PMFConstants");
-jest.mock("../../../../../cmd/src/doc/handler/IHandlerParameters");
-jest.mock("../../../../../cmd/src/response/CommandResponse");
 jest.mock("../../../../../cmd/src/response/HandlerResponse");
-jest.mock("../../../../../logger");
-jest.mock("../../../../src/plugins/utilities/NpmFunctions");
 
 import { HandlerResponse, IHandlerParameters } from "../../../../../cmd";
 import { Console } from "../../../../../console";
@@ -27,21 +20,22 @@ import { IPluginJson } from "../../../../src/plugins/doc/IPluginJson";
 import { Logger } from "../../../../../logger";
 import { PMFConstants } from "../../../../src/plugins/utilities/PMFConstants";
 import UpdateHandler from "../../../../src/plugins/cmd/update/update.handler";
-import * as NpmFunctions from "../../../../src/plugins/utilities/NpmFunctions";
-import * as ChildProcesses from "child_process";
-import * as JsonFile from "jsonfile";
-import * as NpmInterface from "../../../../src/plugins/utilities/npm-interface";
+import { NpmRegistryUtils } from "../../../../src/plugins/utilities/NpmFunctions";
+import * as childProcess from "child_process";
+import * as jsonfile from "jsonfile";
+import * as npmInterface from "../../../../src/plugins/utilities/npm-interface";
+import { INpmRegistryInfo } from "../../../../src/plugins/doc/INpmRegistryInfo";
 
 describe("Plugin Management Facility update handler", () => {
 
     const resolveVal = "test/imperative-plugins";
 
     const mocks = {
-        npmLoginSpy: jest.spyOn(NpmFunctions, 'npmLogin') as jest.SpyInstance,
-        execSyncSpy: jest.spyOn(ChildProcesses, 'execSync') as jest.SpyInstance,
-        readFileSyncSpy: jest.spyOn(JsonFile, 'readFileSync') as jest.SpyInstance,
-        writeFileSyncSpy: jest.spyOn(JsonFile, 'writeFileSync') as jest.SpyInstance,
-        updateSpy: jest.spyOn(NpmInterface, 'update') as jest.SpyInstance,
+        npmLoginSpy: jest.spyOn(NpmRegistryUtils, "npmLogin"),
+        execSyncSpy: jest.spyOn(childProcess, "execSync"),
+        readFileSyncSpy: jest.spyOn(jsonfile, "readFileSync"),
+        writeFileSyncSpy: jest.spyOn(jsonfile, "writeFileSync"),
+        updateSpy: jest.spyOn(npmInterface, "update"),
     };
 
     // two plugin set of values
@@ -56,14 +50,14 @@ describe("Plugin Management Facility update handler", () => {
     const pluginName = "imperative-sample-plugin";
 
     beforeEach(() => {
-    // Mocks need cleared after every test for clean test runs
+        // Mocks need cleared after every test for clean test runs
         jest.resetAllMocks();
 
         // This needs to be mocked before running process function of update handler
-        (Logger.getImperativeLogger as unknown as Mock<typeof Logger.getImperativeLogger>).mockReturnValue(new Logger(new Console()) as any);
-        mocks.execSyncSpy.mockReturnValue(packageRegistry as any);
-        mocks.readFileSyncSpy.mockReturnValue({} as any);
-        NpmFunctions.npmLogin(packageRegistry);
+        jest.spyOn(Logger, "getImperativeLogger").mockReturnValue(new Logger(new Console()));
+        mocks.execSyncSpy.mockReturnValue(packageRegistry);
+        mocks.readFileSyncSpy.mockReturnValue({});
+        NpmRegistryUtils.npmLogin(packageRegistry);
     });
 
     /**
@@ -93,7 +87,7 @@ describe("Plugin Management Facility update handler", () => {
      */
     const wasUpdateCallValid = (
         packageNameParm: string,
-        registry: string
+        registry: INpmRegistryInfo
     ) => {
         expect(mocks.updateSpy).toHaveBeenCalledWith(
             packageNameParm, registry
@@ -107,7 +101,8 @@ describe("Plugin Management Facility update handler", () => {
      *                                    process function.
      */
     const wasUpdateSuccessful = (params: IHandlerParameters) => {
-        expect(params.response.console.log).toHaveBeenCalledWith(`Update of the npm package(${params.arguments.plugin}) was successful.\n`);
+        expect(params.response.console.log).toHaveBeenCalledWith(
+            `Update of the npm package(${resolveVal}) was successful.\n`);
     };
 
     /**
@@ -131,7 +126,7 @@ describe("Plugin Management Facility update handler", () => {
         );
     };
 
-    test("update specified plugin", async () => {
+    it("update specified plugin", async () => {
 
         // plugin definitions mocking file contents
         const fileJson: IPluginJson = {
@@ -148,7 +143,7 @@ describe("Plugin Management Facility update handler", () => {
         };
 
         // Override the return value for this test only
-        mocks.readFileSyncSpy.mockReturnValueOnce(fileJson as any);
+        mocks.readFileSyncSpy.mockReturnValueOnce(fileJson);
 
         const handler = new UpdateHandler();
 
@@ -161,13 +156,14 @@ describe("Plugin Management Facility update handler", () => {
         // Validate the call to login
         wasNpmLoginCallValid(packageRegistry);
         wasWriteFileSyncValid(PMFConstants.instance.PLUGIN_JSON, fileJson);
-        wasUpdateCallValid(packageName, packageRegistry);
-
-        expect(params.response.console.log).toHaveBeenCalledWith(
-            `Update of the npm package(${resolveVal}) was successful.\n`);
+        wasUpdateCallValid(packageName, {
+            location: resolveVal,
+            npmArgs: { registry: packageRegistry }
+        });
+        wasUpdateSuccessful(params);
     });
 
-    test("update imperative-sample-plugin", async () => {
+    it("update imperative-sample-plugin", async () => {
 
         // plugin definitions mocking file contents
         const fileJson: IPluginJson = {
@@ -179,7 +175,7 @@ describe("Plugin Management Facility update handler", () => {
         };
 
         // Override the return value for this test only
-        mocks.readFileSyncSpy.mockReturnValueOnce(fileJson as any);
+        mocks.readFileSyncSpy.mockReturnValueOnce(fileJson);
 
         const handler = new UpdateHandler();
 
@@ -191,9 +187,10 @@ describe("Plugin Management Facility update handler", () => {
         // Validate the call to login
         wasNpmLoginCallValid(packageRegistry);
         wasWriteFileSyncValid(PMFConstants.instance.PLUGIN_JSON, fileJson);
-        wasUpdateCallValid(resolveVal, packageRegistry);
-        expect(params.response.console.log).toHaveBeenCalledWith(
-            `Update of the npm package(${resolveVal}) was successful.\n`);
+        wasUpdateCallValid(resolveVal, {
+            location: packageRegistry,
+            npmArgs: { registry: packageRegistry }
+        });
+        wasUpdateSuccessful(params);
     });
 });
-

--- a/packages/imperative/src/imperative/__tests__/plugins/utilities/NpmFunctions.unit.test.ts
+++ b/packages/imperative/src/imperative/__tests__/plugins/utilities/NpmFunctions.unit.test.ts
@@ -54,7 +54,7 @@ describe("NpmFunctions", () => {
             status: 0,
             stdout: stdoutBuffer
         } as any);
-        const result = npmFunctions.getRegistry();
+        const result = npmFunctions.NpmRegistryUtils.getRegistry();
         expect(spawnSyncSpy.mock.calls[0][0]).toBe(npmCmd);
         expect(spawnSyncSpy.mock.calls[0][1]).toEqual(["config", "get", "registry"]);
         expect(result).toBe(stdoutBuffer.toString());
@@ -62,7 +62,7 @@ describe("NpmFunctions", () => {
 
     it("npmLogin should run npm login command", () => {
         const spawnSyncSpy = jest.spyOn(spawn, "sync").mockReturnValueOnce({ status: 0 } as any);
-        npmFunctions.npmLogin(fakeRegistry);
+        npmFunctions.NpmRegistryUtils.npmLogin(fakeRegistry);
         expect(spawnSyncSpy.mock.calls[0][0]).toBe(npmCmd);
         expect(spawnSyncSpy.mock.calls[0][1]).toContain("login");
         expect(spawnSyncSpy.mock.calls[0][1]).toEqual(expect.arrayContaining(["--registry", fakeRegistry]));
@@ -136,10 +136,10 @@ describe("NpmFunctions", () => {
             expect(pacote.manifest).toHaveBeenCalledTimes(1);
         });
 
-        it("getScopeRegistry() should return registry for 'test' scope", async () => {
+        it("getScopeRegistry() should return registry for 'test' scope", () => {
             const spawnSpy = jest.spyOn(ExecUtils, "spawnAndGetOutput");
             spawnSpy.mockReturnValueOnce("https://test123.com");
-            const result = await npmFunctions.getScopeRegistry("test");
+            const result = (npmFunctions.NpmRegistryUtils as any).getScopeRegistry("test");
             expect(result).toBe("https://test123.com");
             expect(spawnSpy).toHaveBeenCalledTimes(1);
         });

--- a/packages/imperative/src/imperative/__tests__/plugins/utilities/NpmFunctions.unit.test.ts
+++ b/packages/imperative/src/imperative/__tests__/plugins/utilities/NpmFunctions.unit.test.ts
@@ -40,7 +40,7 @@ describe("NpmFunctions", () => {
             status: 0,
             stdout: stdoutBuffer
         } as any);
-        const result = npmFunctions.installPackages("fakePrefix", fakeRegistry, "samplePlugin");
+        const result = npmFunctions.installPackages("samplePlugin", { prefix: "fakePrefix", registry: fakeRegistry });
         expect(spawnSyncSpy.mock.calls[0][0]).toBe(npmCmd);
         expect(spawnSyncSpy.mock.calls[0][1]).toEqual(expect.arrayContaining(["install", "samplePlugin"]));
         expect(spawnSyncSpy.mock.calls[0][1]).toEqual(expect.arrayContaining(["--prefix", "fakePrefix"]));

--- a/packages/imperative/src/imperative/__tests__/plugins/utilities/npm-interface/install.unit.test.ts
+++ b/packages/imperative/src/imperative/__tests__/plugins/utilities/npm-interface/install.unit.test.ts
@@ -133,8 +133,8 @@ describe("PMF: Install Interface", () => {
      * @param {string} expectedRegistry The registry that should be sent to npm install
      */
     const wasNpmInstallCallValid = (expectedPackage: string, expectedRegistry: string, updateSchema?: boolean) => {
-        expect(mocks.installPackages).toHaveBeenCalledWith(PMFConstants.instance.PLUGIN_INSTALL_LOCATION,
-            expectedRegistry, expectedPackage);
+        expect(mocks.installPackages).toHaveBeenCalledWith(expectedPackage,
+            { prefix: PMFConstants.instance.PLUGIN_INSTALL_LOCATION, registry: expectedRegistry });
         shouldUpdateSchema(updateSchema ?? true);
     };
 

--- a/packages/imperative/src/imperative/__tests__/plugins/utilities/npm-interface/uninstall.unit.test.ts
+++ b/packages/imperative/src/imperative/__tests__/plugins/utilities/npm-interface/uninstall.unit.test.ts
@@ -17,7 +17,7 @@ jest.mock("../../../../src/plugins/utilities/PMFConstants");
 import * as fs from "fs";
 import * as jsonfile from "jsonfile";
 import { Console } from "../../../../../console";
-import * as crossSpawn from "cross-spawn";
+import * as spawn from "cross-spawn";
 import { ImperativeError } from "../../../../../error";
 import { IPluginJson } from "../../../../src/plugins/doc/IPluginJson";
 import { Logger } from "../../../../../logger";
@@ -33,7 +33,7 @@ import { updateAndGetRemovedTypes } from "../../../../src/plugins/utilities/npm-
 describe("PMF: Uninstall Interface", () => {
     // Objects created so types are correct.
     const mocks = {
-        spawnSync: jest.spyOn(crossSpawn, "sync"),
+        spawnSync: jest.spyOn(spawn, "sync"),
         readFileSync: jest.spyOn(jsonfile, "readFileSync"),
         writeFileSync: jest.spyOn(jsonfile, "writeFileSync")
     };

--- a/packages/imperative/src/imperative/__tests__/plugins/utilities/npm-interface/uninstall.unit.test.ts
+++ b/packages/imperative/src/imperative/__tests__/plugins/utilities/npm-interface/uninstall.unit.test.ts
@@ -10,24 +10,18 @@
 */
 
 /* eslint-disable jest/expect-expect */
-import Mock = jest.Mock;
-
 jest.mock("cross-spawn");
 jest.mock("jsonfile");
 jest.mock("../../../../src/plugins/utilities/PMFConstants");
-jest.mock("../../../../../logger");
-jest.mock("../../../../../cmd/src/response/CommandResponse");
-jest.mock("../../../../../cmd/src/response/HandlerResponse");
 
 import * as fs from "fs";
 import * as jsonfile from "jsonfile";
 import { Console } from "../../../../../console";
-import { sync } from "cross-spawn";
+import * as crossSpawn from "cross-spawn";
 import { ImperativeError } from "../../../../../error";
 import { IPluginJson } from "../../../../src/plugins/doc/IPluginJson";
 import { Logger } from "../../../../../logger";
 import { PMFConstants } from "../../../../src/plugins/utilities/PMFConstants";
-import { readFileSync, writeFileSync } from "jsonfile";
 import { findNpmOnPath } from "../../../../src/plugins/utilities/NpmFunctions";
 import { uninstall } from "../../../../src/plugins/utilities/npm-interface";
 import { ConfigSchema, ConfigUtils } from "../../../../../config";
@@ -39,9 +33,9 @@ import { updateAndGetRemovedTypes } from "../../../../src/plugins/utilities/npm-
 describe("PMF: Uninstall Interface", () => {
     // Objects created so types are correct.
     const mocks = {
-        spawnSync: sync as unknown as Mock<typeof sync>,
-        readFileSync: readFileSync as Mock<typeof readFileSync>,
-        writeFileSync: writeFileSync as Mock<typeof writeFileSync>
+        spawnSync: jest.spyOn(crossSpawn, "sync"),
+        readFileSync: jest.spyOn(jsonfile, "readFileSync"),
+        writeFileSync: jest.spyOn(jsonfile, "writeFileSync")
     };
 
     const samplePackageName = "imperative-sample-plugin";
@@ -54,7 +48,7 @@ describe("PMF: Uninstall Interface", () => {
         jest.resetAllMocks();
 
         // This needs to be mocked before running uninstall
-        (Logger.getImperativeLogger as unknown as Mock<typeof Logger.getImperativeLogger>).mockReturnValue(new Logger(new Console()) as any);
+        jest.spyOn(Logger, "getImperativeLogger").mockReturnValue(new Logger(new Console()));
     });
 
     afterAll(() => {
@@ -127,7 +121,7 @@ describe("PMF: Uninstall Interface", () => {
                 }
             };
 
-            mocks.readFileSync.mockReturnValue(pluginJsonFile as any);
+            mocks.readFileSync.mockReturnValue(pluginJsonFile);
 
             uninstall(packageName);
 
@@ -151,7 +145,7 @@ describe("PMF: Uninstall Interface", () => {
                 }
             };
 
-            mocks.readFileSync.mockReturnValue(pluginJsonFile as any);
+            mocks.readFileSync.mockReturnValue(pluginJsonFile);
 
             uninstall(samplePackageName);
 
@@ -192,7 +186,7 @@ describe("PMF: Uninstall Interface", () => {
                 }
             };
 
-            mocks.readFileSync.mockReturnValue(pluginJsonFile as any);
+            mocks.readFileSync.mockReturnValue(pluginJsonFile);
             jest.spyOn(fs, "existsSync").mockReturnValueOnce(true);
             let caughtError;
 
@@ -244,7 +238,7 @@ describe("PMF: Uninstall Interface", () => {
                 }
             };
 
-            mocks.readFileSync.mockReturnValue(pluginJsonFile as any);
+            mocks.readFileSync.mockReturnValue(pluginJsonFile);
             const blockMocks = getBlockMocks();
             if (opts.schemaUpdated) {
                 blockMocks.fs.existsSync.mockReturnValueOnce(true);

--- a/packages/imperative/src/imperative/__tests__/plugins/utilities/npm-interface/update.unit.test.ts
+++ b/packages/imperative/src/imperative/__tests__/plugins/utilities/npm-interface/update.unit.test.ts
@@ -9,30 +9,24 @@
 *
 */
 
-import Mock = jest.Mock;
-
 jest.mock("cross-spawn");
 jest.mock("jsonfile");
 jest.mock("../../../../src/plugins/utilities/PMFConstants");
-jest.mock("../../../../../logger");
-jest.mock("../../../../../cmd/src/response/CommandResponse");
-jest.mock("../../../../../cmd/src/response/HandlerResponse");
-jest.mock("../../../../src/plugins/utilities/NpmFunctions");
 
 import { Console } from "../../../../../console";
 import { IPluginJson } from "../../../../src/plugins/doc/IPluginJson";
 import { Logger } from "../../../../../logger";
 import { PMFConstants } from "../../../../src/plugins/utilities/PMFConstants";
-import { readFileSync } from "jsonfile";
+import * as jsonfile from "jsonfile";
 import { update } from "../../../../src/plugins/utilities/npm-interface";
-import { getPackageInfo, installPackages } from "../../../../src/plugins/utilities/NpmFunctions";
+import * as npmFns from "../../../../src/plugins/utilities/NpmFunctions";
 
 describe("PMF: update Interface", () => {
     // Objects created so types are correct.
     const mocks = {
-        installPackages: installPackages as unknown as Mock<typeof installPackages>,
-        readFileSync: readFileSync as Mock<typeof readFileSync>,
-        getPackageInfo: getPackageInfo as unknown as Mock<typeof getPackageInfo>
+        installPackages: jest.spyOn(npmFns, "installPackages"),
+        readFileSync: jest.spyOn(jsonfile, "readFileSync"),
+        getPackageInfo: jest.spyOn(npmFns, "getPackageInfo")
     };
 
     const packageName = "pretty-format";
@@ -44,12 +38,12 @@ describe("PMF: update Interface", () => {
         jest.resetAllMocks();
 
         // This needs to be mocked before running update
-        (Logger.getImperativeLogger as unknown as Mock<typeof Logger.getImperativeLogger>).mockReturnValue(new Logger(new Console()) as any);
+        jest.spyOn(Logger, "getImperativeLogger").mockReturnValue(new Logger(new Console()));
 
         /* Since update() adds new plugins into the value returned from
-        * readFileSyc(plugins.json), we must reset readFileSync to return an empty set before each test.
+        * readFileSync(plugins.json), we must reset readFileSync to return an empty set before each test.
         */
-        mocks.readFileSync.mockReturnValue({} as any);
+        mocks.readFileSync.mockReturnValue({});
     });
 
     afterAll(() => {
@@ -64,33 +58,11 @@ describe("PMF: update Interface", () => {
    * @param {boolean} [updateFromFile=false] was the update from a file. This affects
    *                                          the pipe sent to spawnSync stdio option.
    */
-    const wasNpmInstallCallValid = (expectedPackage: string, expectedRegistry: string) => {
+    const wasNpmInstallCallValid = (expectedPackage: string, expectedRegistry: Record<string, string>) => {
         expect(mocks.installPackages).toHaveBeenCalledWith(expectedPackage,
-            { prefix: PMFConstants.instance.PLUGIN_INSTALL_LOCATION, registry: expectedRegistry });
+            { prefix: PMFConstants.instance.PLUGIN_INSTALL_LOCATION, ...expectedRegistry });
     };
 
-    describe("Basic update", () => {
-        it("should update from the npm registry", async () => {
-
-            // value for our plugins.json
-            const oneOldPlugin: IPluginJson = {
-                plugin1: {
-                    package: packageName,
-                    location: packageRegistry,
-                    version: packageVersion
-                }
-            };
-
-            mocks.getPackageInfo.mockResolvedValue({ name: packageName, version: packageVersion } as never);
-            mocks.readFileSync.mockReturnValue(oneOldPlugin as any);
-
-            const data = await update(packageName, packageRegistry);
-            expect(data).toEqual(packageVersion);
-
-            // Validate the update
-            wasNpmInstallCallValid(packageName, packageRegistry);
-        });
-    });
     it("should update from the npm registry", async () => {
 
         // value for our plugins.json
@@ -102,13 +74,39 @@ describe("PMF: update Interface", () => {
             }
         };
 
-        mocks.getPackageInfo.mockResolvedValue({ name: packageName, version: packageVersion } as never);
-        mocks.readFileSync.mockReturnValue(oneOldPlugin as any);
+        mocks.getPackageInfo.mockResolvedValue({ name: packageName, version: packageVersion });
+        mocks.readFileSync.mockReturnValue(oneOldPlugin);
 
-        const data = await update(packageName, packageRegistry);
+        const registryInfo = new npmFns.NpmRegistryInfo(packageRegistry);
+        registryInfo.setPackage(oneOldPlugin.plugin1);
+        const data = await update(packageName, registryInfo);
         expect(data).toEqual(packageVersion);
 
         // Validate the update
-        wasNpmInstallCallValid(packageName, packageRegistry);
+        wasNpmInstallCallValid(packageName, { registry: packageRegistry });
+    });
+
+    it("should update from scoped npm registry", async () => {
+
+        // value for our plugins.json
+        const scopedPackageName = `@org/${packageName}`;
+        const oneOldPlugin: IPluginJson = {
+            plugin1: {
+                package: scopedPackageName,
+                location: packageRegistry,
+                version: packageVersion
+            }
+        };
+
+        mocks.getPackageInfo.mockResolvedValue({ name: scopedPackageName, version: packageVersion });
+        mocks.readFileSync.mockReturnValue(oneOldPlugin);
+
+        const registryInfo = new npmFns.NpmRegistryInfo(packageRegistry);
+        registryInfo.setPackage(oneOldPlugin.plugin1);
+        const data = await update(scopedPackageName, registryInfo);
+        expect(data).toEqual(packageVersion);
+
+        // Validate the update
+        wasNpmInstallCallValid(scopedPackageName, { "@org:registry": packageRegistry });
     });
 });

--- a/packages/imperative/src/imperative/__tests__/plugins/utilities/npm-interface/update.unit.test.ts
+++ b/packages/imperative/src/imperative/__tests__/plugins/utilities/npm-interface/update.unit.test.ts
@@ -26,7 +26,8 @@ describe("PMF: update Interface", () => {
     const mocks = {
         installPackages: jest.spyOn(npmFns, "installPackages"),
         readFileSync: jest.spyOn(jsonfile, "readFileSync"),
-        getPackageInfo: jest.spyOn(npmFns, "getPackageInfo")
+        getPackageInfo: jest.spyOn(npmFns, "getPackageInfo"),
+        getScopeRegistry: jest.spyOn(npmFns.NpmRegistryUtils as any, "getScopeRegistry")
     };
 
     const packageName = "pretty-format";
@@ -44,6 +45,7 @@ describe("PMF: update Interface", () => {
         * readFileSync(plugins.json), we must reset readFileSync to return an empty set before each test.
         */
         mocks.readFileSync.mockReturnValue({});
+        mocks.getScopeRegistry.mockReturnValue(packageRegistry);
     });
 
     afterAll(() => {
@@ -105,6 +107,6 @@ describe("PMF: update Interface", () => {
         expect(data).toEqual(packageVersion);
 
         // Validate the update
-        wasNpmInstallCallValid(scopedPackageName, { "@org:registry": packageRegistry });
+        wasNpmInstallCallValid(scopedPackageName, { registry: packageRegistry, "@org:registry": packageRegistry });
     });
 });

--- a/packages/imperative/src/imperative/__tests__/plugins/utilities/npm-interface/update.unit.test.ts
+++ b/packages/imperative/src/imperative/__tests__/plugins/utilities/npm-interface/update.unit.test.ts
@@ -65,8 +65,8 @@ describe("PMF: update Interface", () => {
    *                                          the pipe sent to spawnSync stdio option.
    */
     const wasNpmInstallCallValid = (expectedPackage: string, expectedRegistry: string) => {
-        expect(mocks.installPackages).toHaveBeenCalledWith(PMFConstants.instance.PLUGIN_INSTALL_LOCATION,
-            expectedRegistry, expectedPackage);
+        expect(mocks.installPackages).toHaveBeenCalledWith(expectedPackage,
+            { prefix: PMFConstants.instance.PLUGIN_INSTALL_LOCATION, registry: expectedRegistry });
     };
 
     describe("Basic update", () => {

--- a/packages/imperative/src/imperative/__tests__/plugins/utilities/npm-interface/update.unit.test.ts
+++ b/packages/imperative/src/imperative/__tests__/plugins/utilities/npm-interface/update.unit.test.ts
@@ -77,8 +77,7 @@ describe("PMF: update Interface", () => {
         mocks.getPackageInfo.mockResolvedValue({ name: packageName, version: packageVersion });
         mocks.readFileSync.mockReturnValue(oneOldPlugin);
 
-        const registryInfo = new npmFns.NpmRegistryInfo(packageRegistry);
-        registryInfo.setPackage(oneOldPlugin.plugin1);
+        const registryInfo = npmFns.NpmRegistryUtils.buildRegistryInfo(oneOldPlugin.plugin1);
         const data = await update(packageName, registryInfo);
         expect(data).toEqual(packageVersion);
 
@@ -101,8 +100,7 @@ describe("PMF: update Interface", () => {
         mocks.getPackageInfo.mockResolvedValue({ name: scopedPackageName, version: packageVersion });
         mocks.readFileSync.mockReturnValue(oneOldPlugin);
 
-        const registryInfo = new npmFns.NpmRegistryInfo(packageRegistry);
-        registryInfo.setPackage(oneOldPlugin.plugin1);
+        const registryInfo = npmFns.NpmRegistryUtils.buildRegistryInfo(oneOldPlugin.plugin1);
         const data = await update(scopedPackageName, registryInfo);
         expect(data).toEqual(packageVersion);
 

--- a/packages/imperative/src/imperative/src/plugins/cmd/install/install.handler.ts
+++ b/packages/imperative/src/imperative/src/plugins/cmd/install/install.handler.ts
@@ -20,7 +20,7 @@ import { readFileSync } from "jsonfile";
 import { ImperativeConfig, TextUtils } from "../../../../../utilities";
 import { ImperativeError } from "../../../../../error";
 import { runValidatePlugin } from "../../utilities/runValidatePlugin";
-import { NpmRegistryInfo } from "../../utilities/NpmFunctions";
+import { NpmRegistryUtils } from "../../utilities/NpmFunctions";
 
 /**
  * The install command handler for cli plugin install.
@@ -80,11 +80,11 @@ export default class InstallHandler implements ICommandHandler {
             });
         } else {
             try {
-                const registryInfo = new NpmRegistryInfo(params.arguments.registry);
+                const installRegistry = NpmRegistryUtils.getRegistry(params.arguments.registry);
 
                 // Get the registry to install to
                 if (params.arguments.registry != null && params.arguments.login) {
-                    registryInfo.npmLogin();
+                    NpmRegistryUtils.npmLogin(installRegistry);
                 }
 
                 params.response.console.log(
@@ -94,7 +94,7 @@ export default class InstallHandler implements ICommandHandler {
                     "Install 3rd party plug-ins at your own risk.\n"
                 );
 
-                params.response.console.log("Location = " + registryInfo.location);
+                params.response.console.log("Location = " + installRegistry);
 
                 // This section determines which npm logic needs to take place
                 if (params.arguments.plugin == null || params.arguments.plugin.length === 0) {
@@ -118,7 +118,7 @@ export default class InstallHandler implements ICommandHandler {
 
                             // Registry is typed as optional in the doc but the function expects it
                             // to be passed. So we'll always set it if it hasn't been done yet.
-                            registryInfo.setPackage(packageInfo);
+                            const registryInfo = NpmRegistryUtils.buildRegistryInfo(packageInfo, params.arguments.registry);
                             packageInfo.location ??= registryInfo.location;
 
                             this.console.debug(`Installing plugin: ${packageName}`);
@@ -144,7 +144,7 @@ export default class InstallHandler implements ICommandHandler {
                 } else {
                     for (const packageString of params.arguments.plugin) {
                         params.response.console.log("\n_______________________________________________________________");
-                        registryInfo.setPackage(packageString);
+                        const registryInfo = NpmRegistryUtils.buildRegistryInfo(packageString, params.arguments.registry);
                         const pluginName = await install(packageString, registryInfo);
                         params.response.console.log("Installed plugin name = '" + pluginName + "'");
                         params.response.console.log(runValidatePlugin(pluginName));

--- a/packages/imperative/src/imperative/src/plugins/cmd/install/install.handler.ts
+++ b/packages/imperative/src/imperative/src/plugins/cmd/install/install.handler.ts
@@ -135,7 +135,7 @@ export default class InstallHandler implements ICommandHandler {
                             this.console.debug(`Package: ${packageArgument}`);
 
                             params.response.console.log("\n_______________________________________________________________");
-                            params.response.console.log("Location = " + packageInfo.location);
+                            params.response.console.log("Location = " + packageInfo.location + "\n");
                             const pluginName = await install(packageArgument, registryInfo, true);
                             params.response.console.log("Installed plugin name = '" + pluginName + "'");
                             params.response.console.log(runValidatePlugin(pluginName));
@@ -147,7 +147,7 @@ export default class InstallHandler implements ICommandHandler {
                     for (const packageString of params.arguments.plugin) {
                         params.response.console.log("\n_______________________________________________________________");
                         const registryInfo = NpmRegistryUtils.buildRegistryInfo(packageString, params.arguments.registry);
-                        params.response.console.log("Location = " + registryInfo.location);
+                        params.response.console.log("Location = " + registryInfo.location + "\n");
                         const pluginName = await install(packageString, registryInfo);
                         params.response.console.log("Installed plugin name = '" + pluginName + "'");
                         params.response.console.log(runValidatePlugin(pluginName));

--- a/packages/imperative/src/imperative/src/plugins/cmd/install/install.handler.ts
+++ b/packages/imperative/src/imperative/src/plugins/cmd/install/install.handler.ts
@@ -20,17 +20,14 @@ import { readFileSync } from "jsonfile";
 import { ImperativeConfig, TextUtils } from "../../../../../utilities";
 import { ImperativeError } from "../../../../../error";
 import { runValidatePlugin } from "../../utilities/runValidatePlugin";
-import {
-    getRegistry,
-    getScopeRegistry,
-    npmLogin,
-} from "../../utilities/NpmFunctions";
-import { IO } from "../../../../../io";
+import { getRegistry, npmLogin } from "../../utilities/NpmFunctions";
+
 /**
  * The install command handler for cli plugin install.
  *
  * @see {installDefinition}
- */ export default class InstallHandler implements ICommandHandler {
+ */
+export default class InstallHandler implements ICommandHandler {
     /**
      * A logger for this class
      *
@@ -72,90 +69,57 @@ import { IO } from "../../../../../io";
      *
      * @throws {ImperativeError}
      */
-
-    private locationTypeTest(plugin: string){
-        let isDirTest: boolean;
-        let installRegistry = getRegistry();
-        try {
-            isDirTest = IO.isDir(plugin);
-        } catch (e) {
-            isDirTest = false;
-        }
-
-        if (plugin.startsWith("@")) {
-            installRegistry = getScopeRegistry(
-                plugin.split("/")[0].substring(1)
-            ).replace("\n", "");
-        } else if (
-            plugin.substring(plugin.lastIndexOf(".") + 1) === "tgz" ||
-            isDirTest
-        ) {
-            installRegistry = plugin;
-        }
-        return installRegistry;
-    }
-
     public async process(params: IHandlerParameters): Promise<void> {
         const chalk = TextUtils.chalk;
-        this.console.debug(
-            `Root Directory: ${PMFConstants.instance.PLUGIN_INSTALL_LOCATION}`
-        );
+        this.console.debug(`Root Directory: ${PMFConstants.instance.PLUGIN_INSTALL_LOCATION}`);
 
-        if (
-            params.arguments.plugin != null &&
-            params.arguments.plugin.length > 0 &&
-            typeof params.arguments.file !== "undefined"
-        ) {
+        if (params.arguments.plugin != null && params.arguments.plugin.length > 0 && typeof params.arguments.file !== "undefined") {
             throw new ImperativeError({
-                msg:
-                    `Option ${chalk.yellow.bold(
-                        "--file"
-                    )} can not be specified if positional ${chalk.yellow.bold(
-                        "package..."
-                    )} is as well. ` + `They are mutually exclusive.`,
+                msg: `Option ${chalk.yellow.bold("--file")} can not be specified if positional ${chalk.yellow.bold("package...")} is as well. ` +
+                    `They are mutually exclusive.`,
             });
         } else {
             try {
-                let installRegistry =
-                    params.arguments.registry ??
-                    getRegistry().replace("\n", "");
+                let installRegistry: any;
+
+                // Get the registry to install to
+                if (typeof params.arguments.registry === "undefined") {
+                    installRegistry = getRegistry().replace("\n",  "");
+                } else {
+                    installRegistry = params.arguments.registry;
+                    if (params.arguments.login) {
+                        npmLogin(installRegistry);
+                    }
+                }
+
+                params.response.console.log(
+                    "Plug-ins within the Imperative CLI Framework can legitimately gain\n" +
+                    `control of the ${ImperativeConfig.instance.rootCommandName} CLI application ` +
+                    "during the execution of every command.\n" +
+                    "Install 3rd party plug-ins at your own risk.\n"
+                );
+
+                params.response.console.log("Location = " + installRegistry);
 
                 // This section determines which npm logic needs to take place
-                if (
-                    params.arguments.plugin == null ||
-                    params.arguments.plugin.length === 0
-                ) {
-                    const configFile =
-                        typeof params.arguments.file === "undefined"
-                            ? PMFConstants.instance.PLUGIN_JSON
-                            : resolve(params.arguments.file);
+                if (params.arguments.plugin == null || params.arguments.plugin.length === 0) {
+                    const configFile = typeof params.arguments.file === "undefined" ?
+                        PMFConstants.instance.PLUGIN_JSON : resolve(params.arguments.file);
 
-                    this.console.debug(
-                        "Need to install using plugins.json file"
-                    );
+                    this.console.debug("Need to install using plugins.json file");
                     this.console.debug(`Using config file: ${configFile}`);
 
                     // Attempt to load that file and formulate the corresponding package
                     const packageJson: IPluginJson = readFileSync(configFile);
 
                     if (Object.keys(packageJson).length === 0) {
-                        params.response.console.log(
-                            "No packages were found in " +
-                                configFile +
-                                ", so no plugins were installed."
-                        );
+                        params.response.console.log("No packages were found in " + configFile + ", so no plugins were installed.");
                         return;
                     }
 
                     for (const packageName in packageJson) {
-                        if (
-                            Object.prototype.hasOwnProperty.call(
-                                packageJson,
-                                packageName
-                            )
-                        ) {
-                            const packageInfo: IPluginJsonObject =
-                                packageJson[packageName];
+                        if (Object.prototype.hasOwnProperty.call(packageJson, packageName)) {
+                            const packageInfo: IPluginJsonObject = packageJson[packageName];
 
                             // Registry is typed as optional in the doc but the function expects it
                             // to be passed. So we'll always set it if it hasn't been done yet.
@@ -163,89 +127,33 @@ import { IO } from "../../../../../io";
                                 packageInfo.location = installRegistry;
                             }
 
-                            installRegistry = this.locationTypeTest(packageInfo.location);
-
-                            this.console.debug(
-                                `Installing plugin: ${packageName}`
-                            );
-                            this.console.debug(
-                                `Package: ${packageInfo.package}`
-                            );
-                            this.console.debug(
-                                `Location: ${packageInfo.location}`
-                            );
-                            this.console.debug(
-                                `Version : ${packageInfo.version}`
-                            );
+                            this.console.debug(`Installing plugin: ${packageName}`);
+                            this.console.debug(`Package: ${packageInfo.package}`);
+                            this.console.debug(`Location: ${packageInfo.location}`);
+                            this.console.debug(`Version : ${packageInfo.version}`);
 
                             // Get the argument to the install command
                             // For simplicity a / or \ indicates that we are not dealing with an npm package
-                            const packageArgument =
-                                packageInfo.package === packageName
-                                    ? `${packageInfo.package}@${packageInfo.version}`
-                                    : packageInfo.package;
+                            const packageArgument = packageInfo.package === packageName ?
+                                `${packageInfo.package}@${packageInfo.version}` : packageInfo.package;
 
                             this.console.debug(`Package: ${packageArgument}`);
 
-                            params.response.console.log(
-                                "Plug-ins within the Imperative CLI Framework can legitimately gain\n" +
-                                    `control of the ${ImperativeConfig.instance.rootCommandName} CLI application ` +
-                                    "during the execution of every command.\n" +
-                                    "Install 3rd party plug-ins at your own risk.\n"
-                            );
-                            params.response.console.log(
-                                "Location = " + installRegistry
-                            );
-
-                            params.response.console.log(
-                                "\n_______________________________________________________________"
-                            );
-                            const pluginName = await install(
-                                packageArgument,
-                                packageInfo.location,
-                                true
-                            );
-                            params.response.console.log(
-                                "Installed plugin name = '" + pluginName + "'"
-                            );
-                            params.response.console.log(
-                                runValidatePlugin(pluginName)
-                            );
+                            params.response.console.log("\n_______________________________________________________________");
+                            const pluginName = await install(packageArgument, packageInfo.location, true);
+                            params.response.console.log("Installed plugin name = '" + pluginName + "'");
+                            params.response.console.log(runValidatePlugin(pluginName));
                         }
                     }
-                }
 
-                for (const plugin of params.arguments.plugin ?? []) {
-                    // Get the registry to install to
-                    if (typeof params.arguments.registry === "undefined") {
-                        installRegistry = this.locationTypeTest(plugin);
-                    } else {
-                        installRegistry = params.arguments.registry;
-                        if (params.arguments.login) {
-                            npmLogin(installRegistry);
-                        }
+                    // write the json file when done if not the plugin json file
+                } else {
+                    for (const packageString of params.arguments.plugin) {
+                        params.response.console.log("\n_______________________________________________________________");
+                        const pluginName = await install(packageString, installRegistry);
+                        params.response.console.log("Installed plugin name = '" + pluginName + "'");
+                        params.response.console.log(runValidatePlugin(pluginName));
                     }
-                    params.response.console.log(
-                        "Plug-ins within the Imperative CLI Framework can legitimately gain\n" +
-                            `control of the ${ImperativeConfig.instance.rootCommandName} CLI application ` +
-                            "during the execution of every command.\n" +
-                            "Install 3rd party plug-ins at your own risk.\n"
-                    );
-                    params.response.console.log(
-                        "Location = " + installRegistry
-                    );
-
-                    params.response.console.log(
-                        "\n_______________________________________________________________"
-                    );
-                    const pluginName = await install(
-                        `${plugin}`,
-                        installRegistry
-                    );
-                    params.response.console.log(
-                        "Installed plugin name = '" + pluginName + "'"
-                    );
-                    params.response.console.log(runValidatePlugin(pluginName));
                 }
             } catch (e) {
                 let installResultMsg = "Install Failed";
@@ -253,19 +161,13 @@ import { IO } from "../../../../../io";
                  * give a special message, as per UX request.
                  */
                 if (e.mMessage) {
-                    const matchArray = e.mMessage.match(
-                        /The intended symlink.*already exists and is not a symbolic link/
-                    );
+                    const matchArray = e.mMessage.match(/The intended symlink.*already exists and is not a symbolic link/);
                     if (matchArray !== null) {
-                        installResultMsg =
-                            "Installation completed. However, the plugin incorrectly contains\nits own copy of " +
+                        installResultMsg = "Installation completed. However, the plugin incorrectly contains\nits own copy of " +
                             `${PMFConstants.instance.CLI_CORE_PKG_NAME} or ${PMFConstants.instance.IMPERATIVE_PKG_NAME}.\n` +
                             "Some plugin operations may not work correctly.";
-                    } else if (
-                        e.mMessage.includes("Failed to create symbolic link")
-                    ) {
-                        installResultMsg =
-                            "Installation completed. However, due to the following error, the plugin will not operate correctly.";
+                    } else if (e.mMessage.includes("Failed to create symbolic link")) {
+                        installResultMsg = "Installation completed. However, due to the following error, the plugin will not operate correctly.";
                     }
                 }
                 throw new ImperativeError({

--- a/packages/imperative/src/imperative/src/plugins/cmd/install/install.handler.ts
+++ b/packages/imperative/src/imperative/src/plugins/cmd/install/install.handler.ts
@@ -76,7 +76,7 @@ export default class InstallHandler implements ICommandHandler {
         if (params.arguments.plugin != null && params.arguments.plugin.length > 0 && typeof params.arguments.file !== "undefined") {
             throw new ImperativeError({
                 msg: `Option ${chalk.yellow.bold("--file")} can not be specified if positional ${chalk.yellow.bold("package...")} is as well. ` +
-                    `They are mutually exclusive.`,
+                    `They are mutually exclusive.`
             });
         } else {
             try {
@@ -94,8 +94,6 @@ export default class InstallHandler implements ICommandHandler {
                     "Install 3rd party plug-ins at your own risk.\n"
                 );
 
-                params.response.console.log("Location = " + installRegistry);
-
                 // This section determines which npm logic needs to take place
                 if (params.arguments.plugin == null || params.arguments.plugin.length === 0) {
                     const configFile = typeof params.arguments.file === "undefined" ?
@@ -108,7 +106,8 @@ export default class InstallHandler implements ICommandHandler {
                     const packageJson: IPluginJson = readFileSync(configFile);
 
                     if (Object.keys(packageJson).length === 0) {
-                        params.response.console.log("No packages were found in " + configFile + ", so no plugins were installed.");
+                        params.response.console.log("No packages were found in " +
+                            configFile + ", so no plugins were installed.");
                         return;
                     }
 
@@ -119,7 +118,9 @@ export default class InstallHandler implements ICommandHandler {
                             // Registry is typed as optional in the doc but the function expects it
                             // to be passed. So we'll always set it if it hasn't been done yet.
                             const registryInfo = NpmRegistryUtils.buildRegistryInfo(packageInfo, params.arguments.registry);
-                            packageInfo.location ??= registryInfo.location;
+                            if (!packageInfo.location) {
+                                packageInfo.location = registryInfo.location;
+                            }
 
                             this.console.debug(`Installing plugin: ${packageName}`);
                             this.console.debug(`Package: ${packageInfo.package}`);
@@ -136,6 +137,7 @@ export default class InstallHandler implements ICommandHandler {
                             params.response.console.log("\n_______________________________________________________________");
                             const pluginName = await install(packageArgument, registryInfo, true);
                             params.response.console.log("Installed plugin name = '" + pluginName + "'");
+                            params.response.console.log("Location = " + packageInfo.location);
                             params.response.console.log(runValidatePlugin(pluginName));
                         }
                     }
@@ -147,6 +149,7 @@ export default class InstallHandler implements ICommandHandler {
                         const registryInfo = NpmRegistryUtils.buildRegistryInfo(packageString, params.arguments.registry);
                         const pluginName = await install(packageString, registryInfo);
                         params.response.console.log("Installed plugin name = '" + pluginName + "'");
+                        params.response.console.log("Location = " + registryInfo.location);
                         params.response.console.log(runValidatePlugin(pluginName));
                     }
                 }
@@ -168,7 +171,7 @@ export default class InstallHandler implements ICommandHandler {
                 throw new ImperativeError({
                     msg: installResultMsg,
                     causeErrors: e,
-                    additionalDetails: e.message,
+                    additionalDetails: e.message
                 });
             }
         }

--- a/packages/imperative/src/imperative/src/plugins/cmd/install/install.handler.ts
+++ b/packages/imperative/src/imperative/src/plugins/cmd/install/install.handler.ts
@@ -135,9 +135,9 @@ export default class InstallHandler implements ICommandHandler {
                             this.console.debug(`Package: ${packageArgument}`);
 
                             params.response.console.log("\n_______________________________________________________________");
+                            params.response.console.log("Location = " + packageInfo.location);
                             const pluginName = await install(packageArgument, registryInfo, true);
                             params.response.console.log("Installed plugin name = '" + pluginName + "'");
-                            params.response.console.log("Location = " + packageInfo.location);
                             params.response.console.log(runValidatePlugin(pluginName));
                         }
                     }
@@ -147,9 +147,9 @@ export default class InstallHandler implements ICommandHandler {
                     for (const packageString of params.arguments.plugin) {
                         params.response.console.log("\n_______________________________________________________________");
                         const registryInfo = NpmRegistryUtils.buildRegistryInfo(packageString, params.arguments.registry);
+                        params.response.console.log("Location = " + registryInfo.location);
                         const pluginName = await install(packageString, registryInfo);
                         params.response.console.log("Installed plugin name = '" + pluginName + "'");
-                        params.response.console.log("Location = " + registryInfo.location);
                         params.response.console.log(runValidatePlugin(pluginName));
                     }
                 }

--- a/packages/imperative/src/imperative/src/plugins/cmd/update/update.handler.ts
+++ b/packages/imperative/src/imperative/src/plugins/cmd/update/update.handler.ts
@@ -17,7 +17,7 @@ import { ImperativeError } from "../../../../../error";
 import { TextUtils } from "../../../../../utilities";
 import { IPluginJson } from "../../doc/IPluginJson";
 import { readFileSync, writeFileSync } from "jsonfile";
-import { NpmRegistryInfo } from "../../utilities/NpmFunctions";
+import { NpmRegistryUtils } from "../../utilities/NpmFunctions";
 
 /**
  * The update command handler for cli plugin install.
@@ -52,7 +52,7 @@ export default class UpdateHandler implements ICommandHandler {
         this.console.debug(`Root Directory: ${PMFConstants.instance.PLUGIN_INSTALL_LOCATION}`);
 
         const plugin: string = params.arguments.plugin;
-        const registryInfo = new NpmRegistryInfo(params.arguments.registry);
+        const registry = NpmRegistryUtils.getRegistry(params.arguments.registry);
 
         if (params.arguments.plugin == null || params.arguments.plugin.length === 0) {
             throw new ImperativeError({
@@ -64,7 +64,7 @@ export default class UpdateHandler implements ICommandHandler {
         const installedPlugins: IPluginJson = readFileSync(PMFConstants.instance.PLUGIN_JSON);
 
         if (params.arguments.registry != null && params.arguments.login) {
-            registryInfo.npmLogin();
+            NpmRegistryUtils.npmLogin(registry);
         }
 
         if (Object.prototype.hasOwnProperty.call(installedPlugins, plugin)) {
@@ -76,7 +76,7 @@ export default class UpdateHandler implements ICommandHandler {
                     // as package may not match the plugin value.  This is true for plugins installed by
                     // folder location.  Example: plugin 'imperative-sample-plugin' installed from ../imperative-plugins
                     packageName = installedPlugins[pluginName].package;
-                    registryInfo.setPackage(installedPlugins[pluginName]);
+                    const registryInfo = NpmRegistryUtils.buildRegistryInfo(installedPlugins[pluginName], params.arguments.registry);
                     // Call update which returns the plugin's version so plugins.json can be updated
                     installedPlugins[pluginName].version = await update(packageName, registryInfo);
                     installedPlugins[pluginName].location = registryInfo.location; // update in case it changed

--- a/packages/imperative/src/imperative/src/plugins/doc/INpmInstallArgs.ts
+++ b/packages/imperative/src/imperative/src/plugins/doc/INpmInstallArgs.ts
@@ -1,0 +1,30 @@
+/*
+* This program and the accompanying materials are made available under the terms of the
+* Eclipse Public License v2.0 which accompanies this distribution, and is available at
+* https://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Copyright Contributors to the Zowe Project.
+*
+*/
+
+/**
+ * Npm config options passed to the install command.
+ */
+export interface INpmInstallArgs {
+    /**
+     * The location to install global packages
+     */
+    prefix: string;
+
+    /**
+     * The base URL of the npm package registry
+     */
+    registry: string;
+
+    /**
+     * Allows us to handle scoped registries in the future
+     */
+    [key: string]: string;
+}

--- a/packages/imperative/src/imperative/src/plugins/doc/INpmInstallArgs.ts
+++ b/packages/imperative/src/imperative/src/plugins/doc/INpmInstallArgs.ts
@@ -21,7 +21,7 @@ export interface INpmInstallArgs {
     /**
      * The base URL of the npm package registry
      */
-    registry: string;
+    registry?: string;
 
     /**
      * Allows us to handle scoped registries in the future

--- a/packages/imperative/src/imperative/src/plugins/doc/INpmRegistryInfo.ts
+++ b/packages/imperative/src/imperative/src/plugins/doc/INpmRegistryInfo.ts
@@ -1,0 +1,20 @@
+/*
+* This program and the accompanying materials are made available under the terms of the
+* Eclipse Public License v2.0 which accompanies this distribution, and is available at
+* https://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Copyright Contributors to the Zowe Project.
+*
+*/
+
+import { INpmInstallArgs } from "./INpmInstallArgs";
+
+/**
+ * Location info for an npm package.
+ */
+export interface INpmRegistryInfo {
+    location: string;
+    npmArgs: Partial<INpmInstallArgs>;
+}

--- a/packages/imperative/src/imperative/src/plugins/doc/INpmRegistryInfo.ts
+++ b/packages/imperative/src/imperative/src/plugins/doc/INpmRegistryInfo.ts
@@ -15,6 +15,13 @@ import { INpmInstallArgs } from "./INpmInstallArgs";
  * Location info for an npm package.
  */
 export interface INpmRegistryInfo {
+    /**
+     * The origin of npm package (registry URL or absolute path)
+     */
     location: string;
+
+    /**
+     * Defines npm config values to pass to `npm install` command
+     */
     npmArgs: Partial<INpmInstallArgs>;
 }

--- a/packages/imperative/src/imperative/src/plugins/utilities/NpmFunctions.ts
+++ b/packages/imperative/src/imperative/src/plugins/utilities/NpmFunctions.ts
@@ -74,6 +74,11 @@ export async function getPackageInfo(pkgSpec: string): Promise<{ name: string, v
 }
 
 export class NpmRegistryUtils {
+    /**
+     * Get the registry to install to.
+     * @param userRegistry Registry override specified on the command line
+     * @return {string}
+     */
     public static getRegistry(userRegistry?: string): string {
         if (userRegistry != null) return userRegistry;
         const execOutput = ExecUtils.spawnAndGetOutput(npmCmd, ["config", "get", "registry"]);
@@ -97,6 +102,12 @@ export class NpmRegistryUtils {
         );
     }
 
+    /**
+     * Get package location and npm registry args for installing it.
+     * @param packageInfo Plugin name or object from plugins.json
+     * @param userRegistry Registry override specified on the command line
+     * @returns Location info for npm package to be installed
+     */
     public static buildRegistryInfo(packageInfo: string | IPluginJsonObject, userRegistry?: string): INpmRegistryInfo {
         const packageName = typeof packageInfo === "string" ? packageInfo : packageInfo.package;
         const packageScope = packageName.startsWith("@") ? packageName.split("/")[0] : undefined;

--- a/packages/imperative/src/imperative/src/plugins/utilities/NpmFunctions.ts
+++ b/packages/imperative/src/imperative/src/plugins/utilities/NpmFunctions.ts
@@ -47,7 +47,8 @@ export function installPackages(npmPackage: string, npmArgs: INpmInstallArgs): s
     const args = ["install", npmPackage, "-g", "--legacy-peer-deps"];
     for (const [k, v] of Object.entries(npmArgs)) {
         if (v != null) {
-            args.push(`--${k}`, v);
+            // If npm arg starts with @ like @zowe:registry, must use = as separator
+            args.push(...k.startsWith("@") ? [`--${k}=${v}`] : [`--${k}`, v]);
         }
     }
     const execOutput = ExecUtils.spawnAndGetOutput(npmCmd, args, {

--- a/packages/imperative/src/imperative/src/plugins/utilities/NpmFunctions.ts
+++ b/packages/imperative/src/imperative/src/plugins/utilities/NpmFunctions.ts
@@ -16,7 +16,7 @@ import { StdioOptions } from "child_process";
 import { readFileSync } from "jsonfile";
 import * as npmPackageArg from "npm-package-arg";
 import * as pacote from "pacote";
-import { ExecUtils, JsUtils } from "../../../../utilities";
+import { ExecUtils } from "../../../../utilities";
 import { INpmInstallArgs } from "../doc/INpmInstallArgs";
 import { IPluginJsonObject } from "../doc/IPluginJsonObject";
 import { INpmRegistryInfo } from "../doc/INpmRegistryInfo";
@@ -97,9 +97,8 @@ export class NpmRegistryUtils {
                 "--registry", registry,
                 "--always-auth",
                 "--auth-type=legacy"
-            ], {
-                stdio: [0,1,2]
-            }
+            ],
+            { stdio: "inherit" }
         );
     }
 
@@ -127,7 +126,7 @@ export class NpmRegistryUtils {
             };
         } else {
             // If updating a plug-in, fetch registry info from plugins.json
-            const cachedRegistry = JsUtils.isUrl(packageInfo.location) ? packageInfo.location : undefined;
+            const cachedRegistry = npmPackageArg(packageInfo.package).registry ? packageInfo.location : undefined;
             return {
                 location: packageInfo.location,
                 npmArgs: this.buildRegistryNpmArgs(cachedRegistry ?? this.getRegistry(), packageScope)

--- a/packages/imperative/src/imperative/src/plugins/utilities/NpmFunctions.ts
+++ b/packages/imperative/src/imperative/src/plugins/utilities/NpmFunctions.ts
@@ -101,11 +101,11 @@ export class NpmRegistryInfo {
      * NPM login to be able to install from secure registry
      * @param {string} registry The npm registry to install from.
      */
-    public npmLogin() {
+    public npmLogin(registry?: string) {
         ExecUtils.spawnAndGetOutput(npmCmd,
             [
                 "login",
-                "--registry", this.customRegistry,
+                "--registry", registry ?? this.customRegistry,
                 "--always-auth",
                 "--auth-type=legacy"
             ], {
@@ -115,7 +115,7 @@ export class NpmRegistryInfo {
     }
 
     public buildRegistryArgs(): Partial<INpmInstallArgs> {
-        const registrySpec = this.defaultRegistryScope ? `${this.defaultRegistryScope}:registry` : "registry";
+        const registrySpec = this.defaultRegistryScope != null ? `${this.defaultRegistryScope}:registry` : "registry";
         return this.customRegistry != null ? { [registrySpec]: this.location } : {};
     }
 

--- a/packages/imperative/src/imperative/src/plugins/utilities/NpmFunctions.ts
+++ b/packages/imperative/src/imperative/src/plugins/utilities/NpmFunctions.ts
@@ -17,7 +17,7 @@ import { readFileSync } from "jsonfile";
 import * as npmPackageArg from "npm-package-arg";
 import * as pacote from "pacote";
 import { ExecUtils } from "../../../../utilities";
-import { IO } from "../../../../io";
+import { INpmInstallArgs } from "../doc/INpmInstallArgs";
 const npmCmd = findNpmOnPath();
 
 /**
@@ -40,29 +40,12 @@ export function findNpmOnPath(): string {
  * @return {string} command response
  *
  */
-export function installPackages(prefix: string, registry: string, npmPackage: string): string {
+export function installPackages(npmPackage: string, npmArgs: INpmInstallArgs): string {
     const pipe: StdioOptions = ["pipe", "pipe", process.stderr];
-
-    const args = [
-        "install", npmPackage,
-        "--prefix", prefix,
-        "-g"
-    ];
-    let isDirTest: boolean;
-
-    try{
-        isDirTest = IO.isDir(registry);
+    const args = ["install", npmPackage, "-g", "--legacy-peer-deps"];
+    for (const [k, v] of Object.entries(npmArgs)) {
+        args.push(`--${k}`, v);
     }
-    catch(e){
-        isDirTest = false;
-    }
-
-    if (!(registry.substring(registry.lastIndexOf(".") + 1) === "tgz") && !isDirTest) {
-        args.push("--registry",registry);
-    }
-
-    args.push("--legacy-peer-deps");
-
     const execOutput = ExecUtils.spawnAndGetOutput(npmCmd, args, {
         cwd: PMFConstants.instance.PMF_ROOT,
         stdio: pipe
@@ -70,7 +53,6 @@ export function installPackages(prefix: string, registry: string, npmPackage: st
 
     return execOutput.toString();
 }
-
 
 /**
  * Get the registry to install to.

--- a/packages/imperative/src/imperative/src/plugins/utilities/NpmFunctions.ts
+++ b/packages/imperative/src/imperative/src/plugins/utilities/NpmFunctions.ts
@@ -16,8 +16,9 @@ import { StdioOptions } from "child_process";
 import { readFileSync } from "jsonfile";
 import * as npmPackageArg from "npm-package-arg";
 import * as pacote from "pacote";
-import { ExecUtils } from "../../../../utilities";
+import { ExecUtils, JsUtils } from "../../../../utilities";
 import { INpmInstallArgs } from "../doc/INpmInstallArgs";
+import { IPluginJsonObject } from "../doc/IPluginJsonObject";
 const npmCmd = findNpmOnPath();
 
 /**
@@ -44,7 +45,9 @@ export function installPackages(npmPackage: string, npmArgs: INpmInstallArgs): s
     const pipe: StdioOptions = ["pipe", "pipe", process.stderr];
     const args = ["install", npmPackage, "-g", "--legacy-peer-deps"];
     for (const [k, v] of Object.entries(npmArgs)) {
-        args.push(`--${k}`, v);
+        if (v != null) {
+            args.push(`--${k}`, v);
+        }
     }
     const execOutput = ExecUtils.spawnAndGetOutput(npmCmd, args, {
         cwd: PMFConstants.instance.PMF_ROOT,
@@ -52,39 +55,6 @@ export function installPackages(npmPackage: string, npmArgs: INpmInstallArgs): s
     });
 
     return execOutput.toString();
-}
-
-/**
- * Get the registry to install to.
- *
- * @return {string}
- */
-export function getRegistry(): string {
-    const execOutput = ExecUtils.spawnAndGetOutput(npmCmd, [ "config", "get", "registry" ]);
-    return execOutput.toString();
-}
-
-export function getScopeRegistry(scope: string): string {
-    const execOutput = ExecUtils.spawnAndGetOutput(npmCmd, [ "config", "get", `@${scope}:registry` ]);
-    if(execOutput.toString().trim() === 'undefined') return getRegistry();
-    return execOutput.toString();
-}
-
-/**
- * NPM login to be able to install from secure registry
- * @param {string} registry The npm registry to install from.
- */
-export function npmLogin(registry: string) {
-    ExecUtils.spawnAndGetOutput(npmCmd,
-        [
-            "login",
-            "--registry", registry,
-            "--always-auth",
-            "--auth-type=legacy"
-        ], {
-            stdio: [0,1,2]
-        }
-    );
 }
 
 /**
@@ -99,5 +69,64 @@ export async function getPackageInfo(pkgSpec: string): Promise<{ name: string, v
     } else {
         // Package name is unknown, so fetch name and version with pacote (npm SDK)
         return pacote.manifest(pkgSpec);
+    }
+}
+
+export class NpmRegistryInfo {
+    private defaultRegistry?: string;
+    private defaultRegistryScope?: string;
+
+    constructor(private customRegistry?: string) {
+        if (customRegistry == null) {
+            this.defaultRegistry = this.getRegistry();
+        }
+    }
+
+    private getRegistry(): string {
+        const execOutput = ExecUtils.spawnAndGetOutput(npmCmd, ["config", "get", "registry"]);
+        return execOutput.toString().replace("\n", "");
+    }
+
+    private getScopeRegistry(scope?: string): string {
+        const execOutput = ExecUtils.spawnAndGetOutput(npmCmd, ["config", "get", `${scope ?? this.defaultRegistryScope}:registry`]);
+        if (execOutput.toString().trim() === "undefined") return this.getRegistry();
+        return execOutput.toString().replace("\n", "");
+    }
+
+    public get location(): string {
+        return this.customRegistry ?? this.defaultRegistry;
+    }
+
+    /**
+     * NPM login to be able to install from secure registry
+     * @param {string} registry The npm registry to install from.
+     */
+    public npmLogin() {
+        ExecUtils.spawnAndGetOutput(npmCmd,
+            [
+                "login",
+                "--registry", this.customRegistry,
+                "--always-auth",
+                "--auth-type=legacy"
+            ], {
+                stdio: [0,1,2]
+            }
+        );
+    }
+
+    public buildRegistryArgs(): Partial<INpmInstallArgs> {
+        const registrySpec = this.defaultRegistryScope ? `${this.defaultRegistryScope}:registry` : "registry";
+        return this.customRegistry != null ? { [registrySpec]: this.location } : {};
+    }
+
+    public setPackage(packageInfo: string | IPluginJsonObject) {
+        const packageName = typeof packageInfo === "string" ? packageInfo : packageInfo.package;
+        const packageScope = packageName.startsWith("@") ? packageName.split("/")[0] : undefined;
+        if (typeof packageInfo === "string" || packageInfo.location == null) {
+            this.defaultRegistry = packageScope != null ? this.getScopeRegistry(packageScope) : this.getRegistry();
+        } else {
+            this.defaultRegistry = JsUtils.isUrl(packageInfo.location) ? packageInfo.location : undefined;
+            this.defaultRegistryScope = packageScope;
+        }
     }
 }

--- a/packages/imperative/src/imperative/src/plugins/utilities/npm-interface/install.ts
+++ b/packages/imperative/src/imperative/src/plugins/utilities/npm-interface/install.ts
@@ -28,6 +28,7 @@ import { IProfileTypeConfiguration } from "../../../../../profiles";
 import * as semver from "semver";
 import { ConfigUtils } from "../../../../../config";
 import { IExtendersJsonOpts } from "../../../../../config/src/doc/IExtenderOpts";
+import { JsUtils } from "../../../../../utilities";
 
 // Helper function to update extenders.json object during plugin install.
 // Returns true if the object was updated, and false otherwise
@@ -122,7 +123,10 @@ export async function install(packageLocation: string, registry: string, install
         // Perform the npm install.
         iConsole.info("Installing packages...this may take some time.");
 
-        installPackages(PMFConstants.instance.PLUGIN_INSTALL_LOCATION, registry, npmPackage);
+        installPackages(npmPackage, {
+            prefix: PMFConstants.instance.PLUGIN_INSTALL_LOCATION,
+            registry: JsUtils.isUrl(registry) ? registry : undefined,
+        });
 
         // We fetch the package name and version of newly installed plugin
         const packageInfo = await getPackageInfo(npmPackage);

--- a/packages/imperative/src/imperative/src/plugins/utilities/npm-interface/uninstall.ts
+++ b/packages/imperative/src/imperative/src/plugins/utilities/npm-interface/uninstall.ts
@@ -128,26 +128,29 @@ export function uninstall(packageName: string): void {
             throw new Error("Failed to uninstall plugin, install folder still exists:\n  " + installFolder);
         }
 
-        // Update the Imperative Configuration to add the profiles introduced by the recently installed plugin
-        const globalLayer = PMFConstants.instance.PLUGIN_CONFIG.layers.find((layer) => layer.global && layer.exists);
-        if (globalLayer) {
-            const schemaInfo = PMFConstants.instance.PLUGIN_CONFIG.getSchemaInfo();
-            if (schemaInfo.local && fs.existsSync(schemaInfo.resolved)) {
-                let loadedSchema: IProfileTypeConfiguration[];
-                try {
-                    // load schema from disk to prevent removal of profile types from other applications
-                    loadedSchema = ConfigSchema.loadSchema(readFileSync(schemaInfo.resolved));
-                } catch (err) {
-                    iConsole.error("Error when removing profile type for plugin %s: failed to parse schema", npmPackage);
-                }
-                // update extenders.json with any removed types - function returns the list of types to remove
-                const typesToRemove = updateAndGetRemovedTypes(npmPackage);
+        if (PMFConstants.instance.PLUGIN_USING_CONFIG) {
+            // Update the Imperative Configuration to add the profiles introduced by the recently installed plugin
+            // This might be needed outside of PLUGIN_USING_CONFIG scenarios, but we haven't had issues with other APIs before
+            const globalLayer = PMFConstants.instance.PLUGIN_CONFIG.layers.find((layer) => layer.global && layer.exists);
+            if (globalLayer) {
+                const schemaInfo = PMFConstants.instance.PLUGIN_CONFIG.getSchemaInfo();
+                if (schemaInfo.local && fs.existsSync(schemaInfo.resolved)) {
+                    let loadedSchema: IProfileTypeConfiguration[];
+                    try {
+                        // load schema from disk to prevent removal of profile types from other applications
+                        loadedSchema = ConfigSchema.loadSchema(readFileSync(schemaInfo.resolved));
+                    } catch (err) {
+                        iConsole.error("Error when removing profile type for plugin %s: failed to parse schema", npmPackage);
+                    }
+                    // update extenders.json with any removed types - function returns the list of types to remove
+                    const typesToRemove = updateAndGetRemovedTypes(npmPackage);
 
-                // Only update global schema if there are types to remove and accessible from disk
-                if (loadedSchema != null && typesToRemove.length > 0) {
-                    loadedSchema = loadedSchema.filter((typeCfg) => !typesToRemove.includes(typeCfg.type));
-                    const schema = ConfigSchema.buildSchema(loadedSchema);
-                    ConfigSchema.updateSchema({ layer: "global", schema });
+                    // Only update global schema if there are types to remove and accessible from disk
+                    if (loadedSchema != null && typesToRemove.length > 0) {
+                        loadedSchema = loadedSchema.filter((typeCfg) => !typesToRemove.includes(typeCfg.type));
+                        const schema = ConfigSchema.buildSchema(loadedSchema);
+                        ConfigSchema.updateSchema({ layer: "global", schema });
+                    }
                 }
             }
         }

--- a/packages/imperative/src/imperative/src/plugins/utilities/npm-interface/update.ts
+++ b/packages/imperative/src/imperative/src/plugins/utilities/npm-interface/update.ts
@@ -11,8 +11,7 @@
 
 import { PMFConstants } from "../PMFConstants";
 import { Logger } from "../../../../../logger";
-import { getPackageInfo, installPackages } from "../NpmFunctions";
-import { JsUtils } from "../../../../../utilities";
+import { getPackageInfo, installPackages, NpmRegistryInfo } from "../NpmFunctions";
 
 /**
  * @TODO - allow multiple packages to be updated?
@@ -20,10 +19,10 @@ import { JsUtils } from "../../../../../utilities";
  *
  * @param {string} packageName A package name. This value is a valid npm package name.
  *
- * @param {string} registry The npm registry.
+ * @param {NpmRegistryInfo} registryInfo The npm registry to use.
  *
  */
-export async function update(packageName: string, registry: string) {
+export async function update(packageName: string, registryInfo: NpmRegistryInfo) {
     const iConsole = Logger.getImperativeLogger();
     const npmPackage = packageName;
 
@@ -34,7 +33,7 @@ export async function update(packageName: string, registry: string) {
 
     installPackages(npmPackage, {
         prefix: PMFConstants.instance.PLUGIN_INSTALL_LOCATION,
-        registry: JsUtils.isUrl(registry) ? registry : undefined,
+        ...registryInfo.buildRegistryArgs(),
     });
 
     // We fetch the package version of newly installed plugin

--- a/packages/imperative/src/imperative/src/plugins/utilities/npm-interface/update.ts
+++ b/packages/imperative/src/imperative/src/plugins/utilities/npm-interface/update.ts
@@ -11,7 +11,8 @@
 
 import { PMFConstants } from "../PMFConstants";
 import { Logger } from "../../../../../logger";
-import { getPackageInfo, installPackages, NpmRegistryInfo } from "../NpmFunctions";
+import { getPackageInfo, installPackages } from "../NpmFunctions";
+import { INpmRegistryInfo } from "../../doc/INpmRegistryInfo";
 
 /**
  * @TODO - allow multiple packages to be updated?
@@ -19,10 +20,10 @@ import { getPackageInfo, installPackages, NpmRegistryInfo } from "../NpmFunction
  *
  * @param {string} packageName A package name. This value is a valid npm package name.
  *
- * @param {NpmRegistryInfo} registryInfo The npm registry to use.
+ * @param {INpmRegistryInfo} registryInfo The npm registry to use.
  *
  */
-export async function update(packageName: string, registryInfo: NpmRegistryInfo) {
+export async function update(packageName: string, registryInfo: INpmRegistryInfo) {
     const iConsole = Logger.getImperativeLogger();
     const npmPackage = packageName;
 
@@ -33,7 +34,7 @@ export async function update(packageName: string, registryInfo: NpmRegistryInfo)
 
     installPackages(npmPackage, {
         prefix: PMFConstants.instance.PLUGIN_INSTALL_LOCATION,
-        ...registryInfo.buildRegistryArgs(),
+        ...registryInfo.npmArgs,
     });
 
     // We fetch the package version of newly installed plugin
@@ -45,4 +46,3 @@ export async function update(packageName: string, registryInfo: NpmRegistryInfo)
     // return the package version so the plugins.json file can be updated
     return packageVersion;
 }
-

--- a/packages/imperative/src/imperative/src/plugins/utilities/npm-interface/update.ts
+++ b/packages/imperative/src/imperative/src/plugins/utilities/npm-interface/update.ts
@@ -12,6 +12,7 @@
 import { PMFConstants } from "../PMFConstants";
 import { Logger } from "../../../../../logger";
 import { getPackageInfo, installPackages } from "../NpmFunctions";
+import { JsUtils } from "../../../../../utilities";
 
 /**
  * @TODO - allow multiple packages to be updated?
@@ -31,7 +32,10 @@ export async function update(packageName: string, registry: string) {
     // NOTE: Using npm install in order to retrieve the version which may be updated
     iConsole.info("updating package...this may take some time.");
 
-    installPackages(PMFConstants.instance.PLUGIN_INSTALL_LOCATION, registry, npmPackage);
+    installPackages(npmPackage, {
+        prefix: PMFConstants.instance.PLUGIN_INSTALL_LOCATION,
+        registry: JsUtils.isUrl(registry) ? registry : undefined,
+    });
 
     // We fetch the package version of newly installed plugin
     const packageInfo = await getPackageInfo(npmPackage);


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->
Fixes #2317 

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->
Configure a scoped registry, for example:
`npm config set @zowe:registry https://zowe.jfrog.io/artifactory/api/npm/npm-local-release/`

Then try installing a plug-in with that scope:
`zowe plugins install @zowe/zos-ftp-for-zowe-cli@zowe-v3-lts`

**Review Checklist**
I certify that I have:
- [ ] tested my changes
- [x] added/updated automated tests
- [x] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
