### PR TITLE
fix: updated regex that itentifies deprecated profiles warning

### DIFF
--- a/__tests__/__packages__/cli-test-utils/CHANGELOG.md
+++ b/__tests__/__packages__/cli-test-utils/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Zowe CLI test utils package will be documented in this file.
 
+## Recent Changes
+
+- BugFix: Updated deprecated-profile warning to include spaces. [zowe-cli-sample-plugin#113](https://github.com/zowe/zowe-cli-sample-plugin/pull/113)
+
 ## `7.28.3`
 
 - BugFix: Refactored code to reduce the use of deprecated functions to prepare for upcoming Node.js 22 support. [#2191](https://github.com/zowe/zowe-cli/issues/2191)

--- a/__tests__/__packages__/cli-test-utils/src/TestUtils.ts
+++ b/__tests__/__packages__/cli-test-utils/src/TestUtils.ts
@@ -81,8 +81,8 @@ export function isStderrEmptyForProfilesCommand(output: Buffer): boolean {
  */
 export function stripProfileDeprecationMessages(stderr: Buffer | string): string {
     return stderr.toString()
-        .replace(/Warning: The command 'profiles [a-z]+' is deprecated\./g, "")
-        .replace(/Recommended replacement: The 'config [a-z]+' command/g, "")
+        .replace(/Warning: The command 'profiles [a-z\s]+' is deprecated\./g, "")
+        .replace(/Recommended replacement: The 'config [a-z\s]+' command/g, "")
         .replace(/Recommended replacement: Edit your Zowe V2 configuration\s+zowe\.config\.json/g, "")
         .trim();
 }

--- a/__tests__/__packages__/cli-test-utils/src/TestUtils.ts
+++ b/__tests__/__packages__/cli-test-utils/src/TestUtils.ts
@@ -81,8 +81,8 @@ export function isStderrEmptyForProfilesCommand(output: Buffer): boolean {
  */
 export function stripProfileDeprecationMessages(stderr: Buffer | string): string {
     return stderr.toString()
-        .replace(/Warning: The command 'profiles [a-z\s]+' is deprecated\./g, "")
-        .replace(/Recommended replacement: The 'config [a-z\s]+' command/g, "")
+        .replace(/Warning: The command 'profiles [\w\s]+' is deprecated\./g, "")
+        .replace(/Recommended replacement: The 'config [\w\s]+' command/g, "")
         .replace(/Recommended replacement: Edit your Zowe V2 configuration\s+zowe\.config\.json/g, "")
         .trim();
 }


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [ ] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
