### PR TITLE
Enhanced #2301 to include "--help-web" commands to pass even if presence of a faulty configuration

### DIFF
--- a/packages/imperative/CHANGELOG.md
+++ b/packages/imperative/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Imperative package will be documented in this file.
 
+## Recent Changes
+
+- Enhancement: Enhanced [#2301](https://github.com/zowe/zowe-cli/pull/2301) to include "--help-web" commands to pass even if presence of a faulty configuration.
+
 ## `8.8.1`
 
 - BugFix: Fixed an issue where the `ProfileInfo.profileManagerWillLoad` method failed if profiles were not yet read from disk. [#2284](https://github.com/zowe/zowe-cli/issues/2284)

--- a/packages/imperative/__tests__/__integration__/hello_world/__tests__/HelloWorldCliBadConfig.integration.test.ts
+++ b/packages/imperative/__tests__/__integration__/hello_world/__tests__/HelloWorldCliBadConfig.integration.test.ts
@@ -40,4 +40,11 @@ describe("Hello World", () => {
         expect(response.stdout.toString()).toContain("help");
         expect(response.stderr.toString()).toContain("Please check this configuration file for errors.");
     });
+
+    it ("should trigger help-web even if bad config", async () => {
+        const response = await TestUtils.runCliScript(__dirname + "/scripts/help.sh", TEST_ENVIRONMENT.workingDir);
+        expect(response.status).toBe(0);
+        expect(response.stdout.toString()).toContain("help-web");
+        expect(response.stderr.toString()).toContain("Please check this configuration file for errors.");
+    });
 });

--- a/packages/imperative/__tests__/__integration__/hello_world/__tests__/scripts/help-web.sh
+++ b/packages/imperative/__tests__/__integration__/hello_world/__tests__/scripts/help-web.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+hello-world-cli --help-web

--- a/packages/imperative/src/cmd/__tests__/CommandProcessor.unit.test.ts
+++ b/packages/imperative/src/cmd/__tests__/CommandProcessor.unit.test.ts
@@ -215,7 +215,7 @@ describe("Command Processor", () => {
             jest.restoreAllMocks();
         });
 
-        it("should fail command execution without --help or --version if config is faulty", async () => {
+        it("should fail command execution without --help, --help-web or --version if config is faulty", async () => {
             const parms: any = { arguments: { _: ["some", "command"], $0: "" }, silent: true };
             const response: ICommandResponse = await faultyConfigProcessor.invoke(parms);
 

--- a/packages/imperative/src/imperative/src/Imperative.ts
+++ b/packages/imperative/src/imperative/src/Imperative.ts
@@ -143,6 +143,8 @@ export class Imperative {
             // Detect CLI arguments to determine if errors should be ignored
             const ignoreErrors = process.argv.includes(Constants.OPT_LONG_DASH + Constants.HELP_OPTION) ||
                 process.argv.includes(Constants.OPT_SHORT_DASH + Constants.HELP_OPTION_ALIAS) ||
+                process.argv.includes(Constants.OPT_LONG_DASH + Constants.HELP_WEB_OPTION) ||
+                process.argv.includes(Constants.OPT_SHORT_DASH + Constants.HELP_WEB_OPTION_ALIAS) ||
                 process.argv.includes(Constants.OPT_LONG_DASH + Constants.VERSION_OPTION) ||
                 process.argv.includes(Constants.OPT_SHORT_DASH + Constants.VERSION_OPTION_ALIAS) ||
                 process.argv[process.argv.length - 1] === require.resolve('@zowe/cli');


### PR DESCRIPTION
**What It Does**
Enhances [#2301](https://github.com/zowe/zowe-cli/pull/2301) to include "--help-web" commands to pass even if presence of a faulty configuration.

**How to Test**
Mess up your configuration and run any zowe command with --help-web to ensure the web help is still triggered and a warning about your configuration appears in your terminal.

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [x] added/updated automated tests
- [x] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)

