### PR TITLE
Help web 2

### DIFF
--- a/packages/imperative/CHANGELOG.md
+++ b/packages/imperative/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Imperative package will be documented in this file.
 
+## Recent Changes
+
+- BugFix: Modified 8.8.2 bugfix to correct web help alias. [#2361](https://github.com/zowe/zowe-cli/pull/2361)
+
 ## `8.8.2`
 
 - BugFix: Fixed an issue where the Imperative Event Emitter could skip triggering event callbacks. [#2360](https://github.com/zowe/zowe-cli/pull/2360)

--- a/packages/imperative/src/imperative/src/Imperative.ts
+++ b/packages/imperative/src/imperative/src/Imperative.ts
@@ -144,7 +144,7 @@ export class Imperative {
             const ignoreErrors = process.argv.includes(Constants.OPT_LONG_DASH + Constants.HELP_OPTION) ||
                 process.argv.includes(Constants.OPT_SHORT_DASH + Constants.HELP_OPTION_ALIAS) ||
                 process.argv.includes(Constants.OPT_LONG_DASH + Constants.HELP_WEB_OPTION) ||
-                process.argv.includes(Constants.OPT_SHORT_DASH + Constants.HELP_WEB_OPTION_ALIAS) ||
+                process.argv.includes(Constants.OPT_LONG_DASH + Constants.HELP_WEB_OPTION_ALIAS) ||
                 process.argv.includes(Constants.OPT_LONG_DASH + Constants.VERSION_OPTION) ||
                 process.argv.includes(Constants.OPT_SHORT_DASH + Constants.VERSION_OPTION_ALIAS) ||
                 process.argv[process.argv.length - 1] === require.resolve('@zowe/cli');


### PR DESCRIPTION
**What It Does**
Modified 8.8.2 bugfix to correct web help alias. [#2361](https://github.com/zowe/zowe-cli/pull/2361)

**How to Test**
Ensure help-web can be called with --hw and --help-web despite faulty config. 
- this pr exists because I accidentally added the alias with just 1 dash instead of 2 to imperative.ts

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [x] added/updated automated tests
- [x] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)

