### PR TITLE
ci: add merge-by workflows

### DIFF
--- a/.github/workflows/merge-by-comments.yml
+++ b/.github/workflows/merge-by-comments.yml
@@ -1,0 +1,15 @@
+name: Merge-by
+
+on:
+  pull_request:
+    types: [opened, ready_for_review]
+jobs:
+    rfr_add_date:
+        name: "Post merge-by date as comment"
+        runs-on: ubuntu-latest
+        permissions:
+            pull-requests: write
+        steps:
+            - uses: zowe-actions/shared-actions/merge-by@main
+              with:
+                operation: "bump-dates"

--- a/.github/workflows/merge-by-table.yml
+++ b/.github/workflows/merge-by-table.yml
@@ -1,0 +1,25 @@
+name: Merge-by
+
+on:
+    pull_request:
+      types: [opened, ready_for_review, converted_to_draft]
+    pull_request_review:
+      types: [submitted]
+    push:
+      branches:
+        - main
+        - next
+    workflow_dispatch:
+    schedule:
+    - cron: "0 11 * * *"
+jobs:
+    rfr_add_date:
+        name: "Build table and notify users"
+        runs-on: ubuntu-latest
+        permissions:
+            discussions: write
+            pull-requests: write
+        steps:
+            - uses: zowe-actions/shared-actions/merge-by@main
+              with:
+                operation: "build-table"


### PR DESCRIPTION
**What It Does**

Adds a merge-by comment to PRs when they are marked as ready, and updates a table in the Discussions tab to track PRs that are ready for merge.

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [ ] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
