### PR TITLE
Add content for api response on upload SDK methods

### DIFF
--- a/packages/zosfiles/CHANGELOG.md
+++ b/packages/zosfiles/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to the Zowe z/OS files SDK package will be documented in thi
 
 ## Recent Changes
 
+- BugFix: Corrected the `apiResponse` response value from `streamToDataSet()`,`streamToUss()`,`bufferToUss()` and `bufferToDataSet()` on the Upload SDK. [#2381](https://github.com/zowe/zowe-cli/pull/2381)
 - BugFix: Corrected the `Upload.BufferToUssFile()` SDK function to properly tag uploaded files. [#2378](https://github.com/zowe/zowe-cli/pull/2378)
 
 ## `8.9.0`

--- a/packages/zosfiles/__tests__/__system__/methods/upload/Upload.system.test.ts
+++ b/packages/zosfiles/__tests__/__system__/methods/upload/Upload.system.test.ts
@@ -315,11 +315,10 @@ describe("Upload Data Set", () => {
                 let uploadResponse;
                 let getResponse;
                 const data: Buffer = Buffer.from(testdata);
-                dsname = dsname+("(TEST)");
 
                 try {
-                    uploadResponse = await Upload.bufferToDataSet(REAL_SESSION, data, dsname);
-                    getResponse = await Get.dataSet(REAL_SESSION, dsname);
+                    uploadResponse = await Upload.bufferToDataSet(REAL_SESSION, data, dsname+"(TEST)");
+                    getResponse = await Get.dataSet(REAL_SESSION, dsname+"(TEST)");
                 } catch (err) {
                     error = err;
                     Imperative.console.info("Error: " + inspect(error));
@@ -327,7 +326,7 @@ describe("Upload Data Set", () => {
 
                 expect(error).toBeFalsy();
 
-                expect(uploadResponse.apiResponse).toMatchObject({"success": true, "from": "Buffer<>","to": dsname});
+                expect(uploadResponse.apiResponse).toMatchObject({"success": true, "from": "Buffer<>","to": dsname+"(TEST)"});
                 expect(Buffer.from(getResponse.toString().trim())).toEqual(data);
             });
 
@@ -339,11 +338,10 @@ describe("Upload Data Set", () => {
                 const inputStream = new Readable();
                 inputStream.push(testdata);
                 inputStream.push(null);
-                dsname = dsname+("(TEST)");
 
                 try {
-                    uploadResponse = await Upload.streamToDataSet(REAL_SESSION, inputStream, dsname);
-                    getResponse = await Get.dataSet(REAL_SESSION, dsname);
+                    uploadResponse = await Upload.streamToDataSet(REAL_SESSION, inputStream, dsname+"(TEST)");
+                    getResponse = await Get.dataSet(REAL_SESSION, dsname+"(TEST)");
                 } catch (err) {
                     error = err;
                     Imperative.console.info("Error: " + inspect(error));
@@ -351,7 +349,7 @@ describe("Upload Data Set", () => {
 
                 expect(error).toBeFalsy();
 
-                expect(uploadResponse.apiResponse).toMatchObject({"success": true, "from": "Stream<>","to": dsname});
+                expect(uploadResponse.apiResponse).toMatchObject({"success": true, "from": "Stream<>","to": dsname+"(TEST)"});
                 expect(getResponse.toString().trim()).toEqual(testdata);
             });
 

--- a/packages/zosfiles/__tests__/__unit__/methods/upload/Upload.unit.test.ts
+++ b/packages/zosfiles/__tests__/__unit__/methods/upload/Upload.unit.test.ts
@@ -749,6 +749,7 @@ describe("z/OS Files - Upload", () => {
 
             expect(error).toBeUndefined();
             expect(response).toBeDefined();
+            expect(response.apiResponse).toMatchObject({"from": "Stream<>", "success": true, "to": dsName});
 
             expect(zosmfPutFullSpy).toHaveBeenCalledTimes(1);
             expect(zosmfPutFullSpy).toHaveBeenCalledWith(dummySession, {resource: endpoint,
@@ -1832,6 +1833,7 @@ describe("z/OS Files - Upload", () => {
 
             expect(error).toBeUndefined();
             expect(USSresponse).toBeDefined();
+            expect(USSresponse.apiResponse).toMatchObject({"from": "Stream<>", "success": true, "to": dsName});
             expect(USSresponse.success).toBeTruthy();
 
             expect(zosmfExpectFullSpy).toHaveBeenCalledTimes(1);

--- a/packages/zosfiles/__tests__/__unit__/methods/upload/Upload.unit.test.ts
+++ b/packages/zosfiles/__tests__/__unit__/methods/upload/Upload.unit.test.ts
@@ -392,6 +392,7 @@ describe("z/OS Files - Upload", () => {
 
             expect(error).toBeUndefined();
             expect(response).toBeDefined();
+            expect(response.apiResponse).toMatchObject({"from": "Buffer<>", "success": true, "to": dsName});
 
             expect(zosmfPutFullSpy).toHaveBeenCalledTimes(1);
             expect(zosmfPutFullSpy).toHaveBeenCalledWith(dummySession, {resource: endpoint,
@@ -1755,6 +1756,7 @@ describe("z/OS Files - Upload", () => {
 
             expect(error).toBeUndefined();
             expect(USSresponse).toBeDefined();
+            expect(USSresponse.apiResponse).toMatchObject({"from": "Buffer<>", "success": true, "to": dsName});
 
             const normalizedData = ZosFilesUtils.normalizeNewline(data);
             expect(data.length).not.toBe(normalizedData.length);

--- a/packages/zosfiles/__tests__/__unit__/methods/upload/Upload.unit.test.ts
+++ b/packages/zosfiles/__tests__/__unit__/methods/upload/Upload.unit.test.ts
@@ -22,7 +22,7 @@ import { IUploadOptions } from "../../../../src/methods/upload/doc/IUploadOption
 import { Upload } from "../../../../src/methods/upload/Upload";
 import { List } from "../../../../src/methods/list/List";
 import { Utilities } from "../../../../src/methods/utilities/Utilities";
-
+import { inspect } from "util";
 import { ZosFilesUtils } from "../../../../src/utils/ZosFilesUtils";
 import { stripNewLines } from "../../../../../../__tests__/__src__/TestUtils";
 import { Create } from "../../../../src/methods/create";
@@ -379,7 +379,7 @@ describe("z/OS Files - Upload", () => {
             expect(error).toBeDefined();
             expect(error).toBe(testError);
         });
-        it("should return with proper response when upload buffer to a data set", async () => {
+        it("should return with proper response when upload buffer to a data set - buffer less than 10 chars", async () => {
             const buffer: Buffer = Buffer.from("testing");
             const endpoint = path.posix.join(ZosFilesConstants.RESOURCE, ZosFilesConstants.RES_DS_FILES, dsName);
             const reqHeaders = [ZosmfHeaders.X_IBM_TEXT, ZosmfHeaders.ACCEPT_ENCODING];
@@ -392,7 +392,27 @@ describe("z/OS Files - Upload", () => {
 
             expect(error).toBeUndefined();
             expect(response).toBeDefined();
-            expect(response.apiResponse).toMatchObject({"from": "Buffer<>", "success": true, "to": dsName});
+            expect(response.apiResponse).toMatchObject({"from": "<Buffer 74 65 73 74 69 6e 67>", "success": true, "to": dsName});
+
+            expect(zosmfPutFullSpy).toHaveBeenCalledTimes(1);
+            expect(zosmfPutFullSpy).toHaveBeenCalledWith(dummySession, {resource: endpoint,
+                reqHeaders,
+                writeData: buffer});
+        });
+        it("should return with proper response when upload buffer to a data set - buffer more than 10 chars", async () => {
+            const buffer: Buffer = Buffer.from("bufferLargerThan10Chars");
+            const endpoint = path.posix.join(ZosFilesConstants.RESOURCE, ZosFilesConstants.RES_DS_FILES, dsName);
+            const reqHeaders = [ZosmfHeaders.X_IBM_TEXT, ZosmfHeaders.ACCEPT_ENCODING];
+
+            try {
+                response = await Upload.bufferToDataSet(dummySession, buffer, dsName);
+            } catch (err) {
+                error = err;
+            }
+
+            expect(error).toBeUndefined();
+            expect(response).toBeDefined();
+            expect(response.apiResponse).toMatchObject({"from": "<Buffer 62 75 66 66 65 72 4c 61 72 67...>", "success": true, "to": dsName});
 
             expect(zosmfPutFullSpy).toHaveBeenCalledTimes(1);
             expect(zosmfPutFullSpy).toHaveBeenCalledWith(dummySession, {resource: endpoint,
@@ -749,7 +769,7 @@ describe("z/OS Files - Upload", () => {
 
             expect(error).toBeUndefined();
             expect(response).toBeDefined();
-            expect(response.apiResponse).toMatchObject({"from": "Stream<>", "success": true, "to": dsName});
+            expect(response.apiResponse).toMatchObject({"from": "[Readable]", "success": true, "to": dsName});
 
             expect(zosmfPutFullSpy).toHaveBeenCalledTimes(1);
             expect(zosmfPutFullSpy).toHaveBeenCalledWith(dummySession, {resource: endpoint,
@@ -1757,7 +1777,7 @@ describe("z/OS Files - Upload", () => {
 
             expect(error).toBeUndefined();
             expect(USSresponse).toBeDefined();
-            expect(USSresponse.apiResponse).toMatchObject({"from": "Buffer<>", "success": true, "to": dsName});
+            expect(USSresponse.apiResponse).toMatchObject({"from": "<Buffer 74 65 73 74 69 6e 67 0a 74 65...>", "success": true, "to": dsName});
 
             const normalizedData = ZosFilesUtils.normalizeNewline(data);
             expect(data.length).not.toBe(normalizedData.length);
@@ -1833,7 +1853,7 @@ describe("z/OS Files - Upload", () => {
 
             expect(error).toBeUndefined();
             expect(USSresponse).toBeDefined();
-            expect(USSresponse.apiResponse).toMatchObject({"from": "Stream<>", "success": true, "to": dsName});
+            expect(USSresponse.apiResponse).toMatchObject({"from": "[Readable]", "success": true, "to": dsName});
             expect(USSresponse.success).toBeTruthy();
 
             expect(zosmfExpectFullSpy).toHaveBeenCalledTimes(1);

--- a/packages/zosfiles/src/methods/upload/Upload.ts
+++ b/packages/zosfiles/src/methods/upload/Upload.ts
@@ -489,7 +489,7 @@ export class Upload {
         const uploadRequest: IRestClientResponse = await ZosmfRestClient.putExpectFullResponse(session, requestOptions);
 
         // By default, apiResponse is empty when uploading
-        const apiResponse: any = 
+        const apiResponse: any =
         {
             success: true,
             from: "Buffer<>",

--- a/packages/zosfiles/src/methods/upload/Upload.ts
+++ b/packages/zosfiles/src/methods/upload/Upload.ts
@@ -489,10 +489,11 @@ export class Upload {
         const uploadRequest: IRestClientResponse = await ZosmfRestClient.putExpectFullResponse(session, requestOptions);
 
         // By default, apiResponse is empty when uploading
-        const apiResponse: any = {
+        const apiResponse: any = 
+        {
             success: true,
             from: "Buffer<>",
-            to: ussname
+            to: origUssname
         };
 
         // Return Etag in apiResponse, if requested
@@ -556,7 +557,7 @@ export class Upload {
         const apiResponse: any = {
             success: true,
             from: "Stream<>",
-            to: ussname
+            to: origUssname
         };
 
         // Return Etag in apiResponse, if requested

--- a/packages/zosfiles/src/methods/upload/Upload.ts
+++ b/packages/zosfiles/src/methods/upload/Upload.ts
@@ -184,7 +184,11 @@ export class Upload {
         const uploadRequest: IRestClientResponse = await ZosmfRestClient.putExpectFullResponse(session, requestOptions);
 
         // By default, apiResponse is empty when uploading
-        const apiResponse: any = {};
+        const apiResponse: any = {
+            success: true,
+            from: "Buffer<>",
+            to: dataSetName
+        };
 
         // Return Etag in apiResponse, if requested
         if (options.returnEtag) {
@@ -242,7 +246,11 @@ export class Upload {
         const uploadRequest: IRestClientResponse = await ZosmfRestClient.putExpectFullResponse(session, requestOptions);
 
         // By default, apiResponse is empty when uploading
-        const apiResponse: any = {};
+        const apiResponse: any = {
+            success: true,
+            from: "Stream<>",
+            to: dataSetName
+        };
 
         // Return Etag in apiResponse, if requested
         if (options.returnEtag) {
@@ -481,7 +489,11 @@ export class Upload {
         const uploadRequest: IRestClientResponse = await ZosmfRestClient.putExpectFullResponse(session, requestOptions);
 
         // By default, apiResponse is empty when uploading
-        const apiResponse: any = {};
+        const apiResponse: any = {
+            success: true,
+            from: "Buffer<>",
+            to: ussname
+        };
 
         // Return Etag in apiResponse, if requested
         if (options.returnEtag) {
@@ -541,7 +553,11 @@ export class Upload {
         }
 
         // By default, apiResponse is empty when uploading
-        const apiResponse: any = {};
+        const apiResponse: any = {
+            success: true,
+            from: "Stream<>",
+            to: ussname
+        };
 
         // Return Etag in apiResponse, if requested
         if (options.returnEtag) {

--- a/packages/zosfiles/src/methods/upload/Upload.ts
+++ b/packages/zosfiles/src/methods/upload/Upload.ts
@@ -30,7 +30,7 @@ import { Utilities, Tag } from "../utilities";
 import { Readable } from "stream";
 import { CLIENT_PROPERTY } from "../../doc/types/ZosmfRestClientProperties";
 import { TransferMode } from "../../utils/ZosFilesAttributes";
-
+import { inspect } from "util";
 
 export class Upload {
 
@@ -183,10 +183,11 @@ export class Upload {
         }
         const uploadRequest: IRestClientResponse = await ZosmfRestClient.putExpectFullResponse(session, requestOptions);
 
+        const maxBufferPreviewSize = 10;
         // By default, apiResponse is empty when uploading
         const apiResponse: any = {
             success: true,
-            from: "Buffer<>",
+            from: fileBuffer.length > maxBufferPreviewSize ? inspect(fileBuffer.subarray(0, maxBufferPreviewSize)).slice(0, -1) + "...>" : inspect(fileBuffer),
             to: dataSetName
         };
 
@@ -248,7 +249,7 @@ export class Upload {
         // By default, apiResponse is empty when uploading
         const apiResponse: any = {
             success: true,
-            from: "Stream<>",
+            from: inspect(fileStream, { showHidden: false, depth: -1}),
             to: dataSetName
         };
 
@@ -488,11 +489,11 @@ export class Upload {
         }
         const uploadRequest: IRestClientResponse = await ZosmfRestClient.putExpectFullResponse(session, requestOptions);
 
+        const maxBufferPreviewSize = 10;
         // By default, apiResponse is empty when uploading
-        const apiResponse: any =
-        {
+        const apiResponse: any = {
             success: true,
-            from: "Buffer<>",
+            from: fileBuffer.length > maxBufferPreviewSize ? inspect(fileBuffer.subarray(0, maxBufferPreviewSize)).slice(0, -1) + "...>" : inspect(fileBuffer),
             to: origUssname
         };
 
@@ -556,7 +557,7 @@ export class Upload {
         // By default, apiResponse is empty when uploading
         const apiResponse: any = {
             success: true,
-            from: "Stream<>",
+            from: inspect(uploadStream, { showHidden: false, depth: -1}),
             to: origUssname
         };
 


### PR DESCRIPTION
**What It Does**
Add content for api response on upload SDK methods

**How to Test**
Invoke one of the following SDK methods and view results.
- bufferToUss
- streamtoUss
- bufferToDataSet
- streamToDataSet

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [x] added/updated automated tests
- [x] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)
