### PR TITLE
chore: adjust workflows to `ubuntu-22.04`; use `runner.os` for artifacts

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   audit:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
     - name: Checkout

--- a/.github/workflows/auto-comment.yml
+++ b/.github/workflows/auto-comment.yml
@@ -9,7 +9,7 @@ permissions:
 jobs:
   processLabelAction:
     name: Process Label Action
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
        

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   changelog:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: ${{ contains( github.event.pull_request.labels.*.name, 'no-changelog') != true }}
 
     steps:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   analyze:
     name: Analyze with CodeQL
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: (github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository) && !contains(github.event.head_commit.message, '[ci skip]')
 
     steps:

--- a/.github/workflows/merge-by-comments.yml
+++ b/.github/workflows/merge-by-comments.yml
@@ -6,7 +6,7 @@ on:
 jobs:
     rfr_add_date:
         name: "Post merge-by date as comment"
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         permissions:
             pull-requests: write
         steps:

--- a/.github/workflows/merge-by-table.yml
+++ b/.github/workflows/merge-by-table.yml
@@ -15,7 +15,7 @@ on:
 jobs:
     rfr_add_date:
         name: "Build table and notify users"
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         permissions:
             discussions: write
             pull-requests: write

--- a/.github/workflows/rust-cli-publish.yml
+++ b/.github/workflows/rust-cli-publish.yml
@@ -17,7 +17,7 @@ jobs:
   release:
 
     name: Create GitHub Release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       ZOWEX_VERSION: ${{ steps.get-version.outputs.ZOWEX_VERSION }}
 
@@ -52,7 +52,7 @@ jobs:
 
     needs: release
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
     - name: Install Rust toolchain

--- a/.github/workflows/rust-cli.yml
+++ b/.github/workflows/rust-cli.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   build-linux:
     name: Build Linux
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: (github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository) && !contains(github.event.head_commit.message, '[ci skip]')
 
     steps:

--- a/.github/workflows/secrets-sdk-publish.yml
+++ b/.github/workflows/secrets-sdk-publish.yml
@@ -6,7 +6,7 @@ name: Secrets SDK Publish
 jobs:
   publish:
     name: Publish
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     defaults:
       run:
         working-directory: packages/secrets

--- a/.github/workflows/secrets-sdk.yml
+++ b/.github/workflows/secrets-sdk.yml
@@ -38,27 +38,27 @@ jobs:
               npm run build -- --target i686-pc-windows-msvc
               npm run test
             target: i686-pc-windows-msvc
-          - host: ubuntu-latest
+          - host: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
             use-cross: true
             build: |
               set -e
               CARGO=cross npm run build -- --target x86_64-unknown-linux-gnu
-          - host: ubuntu-latest
+          - host: ubuntu-22.04
             target: i686-unknown-linux-gnu
             use-cross: true
             build: |
               set -e
               source scripts/configure-cross.sh i686-unknown-linux-gnu
               CARGO=cross npm run build -- --target i686-unknown-linux-gnu
-          - host: ubuntu-latest
+          - host: ubuntu-22.04
             target: armv7-unknown-linux-gnueabihf
             use-cross: true
             build: |
               set -e
               source scripts/configure-cross.sh armv7-unknown-linux-gnueabihf
               CARGO=cross npm run build -- --target armv7-unknown-linux-gnueabihf
-          - host: ubuntu-latest
+          - host: ubuntu-22.04
             target: x86_64-unknown-linux-musl
             use-cross: true
             build: |
@@ -67,14 +67,14 @@ jobs:
           - host: macos-latest
             target: aarch64-apple-darwin
             build: npm run build -- --target aarch64-apple-darwin
-          - host: ubuntu-latest
+          - host: ubuntu-22.04
             target: aarch64-unknown-linux-gnu
             use-cross: true
             build: |
               set -e
               source scripts/configure-cross.sh aarch64-unknown-linux-gnu
               CARGO=cross npm run build -- --target aarch64-unknown-linux-gnu
-          - host: ubuntu-latest
+          - host: ubuntu-22.04
             target: aarch64-unknown-linux-musl
             use-cross: true
             build: |
@@ -208,17 +208,17 @@ jobs:
           - host: macos-latest
             target: x86_64-apple-darwin
             architecture: x64
-          - host: ubuntu-latest
+          - host: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
-          - host: ubuntu-latest
+          - host: ubuntu-22.04
             target: x86_64-unknown-linux-musl
-          - host: ubuntu-latest
+          - host: ubuntu-22.04
             target: aarch64-unknown-linux-gnu
             platform: linux/arm64
-          - host: ubuntu-latest
+          - host: ubuntu-22.04
             target: aarch64-unknown-linux-musl
             platform: linux/arm64
-          - host: ubuntu-latest
+          - host: ubuntu-22.04
             target: armv7-unknown-linux-gnueabihf
             platform: linux/arm/v7
         node:
@@ -251,10 +251,10 @@ jobs:
         if: ${{ matrix.settings.platform }}
       - name: Test bindings
         run: npm run test
-        if: ${{ matrix.settings.host != 'ubuntu-latest' }}
+        if: ${{ matrix.settings.host != 'ubuntu-22.04' }}
       - name: Setup and run tests
         uses: addnab/docker-run-action@v3
-        if: ${{ matrix.settings.host == 'ubuntu-latest' && !endsWith(matrix.settings.target, 'musl') }}
+        if: ${{ matrix.settings.host == 'ubuntu-22.04' && !endsWith(matrix.settings.target, 'musl') }}
         with:
           image: ${{ format('node:{0}-slim', matrix.node) }}
           options: "-v ${{ github.workspace }}:/build -w /build --cap-add=IPC_LOCK ${{ matrix.settings.platform && format('--platform={0}', matrix.settings.platform) }}"
@@ -264,7 +264,7 @@ jobs:
             cd packages/secrets && dbus-run-session -- bash scripts/linux-test.sh
       - name: Setup and run tests (MUSL)
         uses: addnab/docker-run-action@v3
-        if: ${{ matrix.settings.host == 'ubuntu-latest' && endsWith(matrix.settings.target, 'musl') }}
+        if: ${{ matrix.settings.host == 'ubuntu-22.04' && endsWith(matrix.settings.target, 'musl') }}
         with:
           image: ${{ format('node:{0}-alpine', matrix.node) }}
           options: "-v ${{ github.workspace }}:/build -w /build --cap-add=IPC_LOCK ${{ matrix.settings.platform && format('--platform={0}', matrix.settings.platform) }}"

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   sonar:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: github.event.workflow_run.conclusion == 'success'
 
     steps:
@@ -21,7 +21,7 @@ jobs:
     - name: Configure Sonar Scan
       uses: zowe-actions/octorelease/script@v1
       env:
-        COVERAGE_ARTIFACT: "ubuntu-latest-20.x-results:__tests__/__results__"
+        COVERAGE_ARTIFACT: "Linux-20.x-results:__tests__/__results__"
       with:
         script: sonarConfig
 

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   stale:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/stale@v9
         with:

--- a/.github/workflows/update-project.yml
+++ b/.github/workflows/update-project.yml
@@ -18,7 +18,7 @@ permissions:
 jobs:
   update-project:
     name: Move project item
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - uses: zowe-actions/shared-actions/project-move-item@main
       if: ${{ github.event.issue && fromJSON(env.ISSUE_STATUSES)[github.event.label.name] }}

--- a/.github/workflows/zowe-cli.yml
+++ b/.github/workflows/zowe-cli.yml
@@ -41,7 +41,7 @@ jobs:
         node-version: [18.x, 20.x, 22.x]
         os:
           - windows-latest
-          - ubuntu-latest
+          - ubuntu-22.04
           - ${{ github.event.inputs.macos-type || 'macos-14'}}
 
     env:
@@ -96,7 +96,7 @@ jobs:
       # Ignore conflict if multiple jobs upload artifact at same time: https://github.com/actions/upload-artifact/issues/506
       continue-on-error: true
       with:
-        name: zowe-${{ matrix.os }}.tgz
+        name: zowe-${{ runner.os }}.tgz
         path: zowe.tgz
         overwrite: true
 
@@ -114,7 +114,7 @@ jobs:
 
     - name: Unlock Keyring
       id: unlock-keyring
-      if: ${{ always() && steps.build.outcome == 'success' && matrix.os == 'ubuntu-latest' }}
+      if: ${{ always() && steps.build.outcome == 'success' && matrix.os == 'ubuntu-22.04' }}
       uses: t1m0thyj/unlock-keyring@v1
 
     - name: Start Daemon
@@ -135,7 +135,7 @@ jobs:
       if: ${{ always() && steps.build.outcome == 'success' }}
       uses: actions/upload-artifact@v4
       with:
-        name: ${{ matrix.os }}-${{ matrix.node-version }}-results
+        name: ${{ runner.os }}-${{ matrix.node-version }}-results
         path: __tests__/__results__/
 
     - name: Upload Results to Codecov
@@ -148,7 +148,7 @@ jobs:
   release:
     if: github.event_name == 'push' && github.ref_protected
     needs: test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       issues: write
       contents: write

--- a/.github/workflows/zoweReleaseVersion.yaml
+++ b/.github/workflows/zoweReleaseVersion.yaml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   update_versions_and_create_pr:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout CLI Repo

--- a/scripts/testCliWorkflow.js
+++ b/scripts/testCliWorkflow.js
@@ -244,9 +244,9 @@ Usage:
 - npm run test: act -- --node 16.x --dr
 - npm run test: act -- --node 16.x --verbose
 - npm run test: act -- --node 16.x, 14.x
-- npm run test: act -- --node 16.x, 14.x --os ubuntu-latest
-- npm run test: act -- --node 16.x, 14.x --os ubuntu-latest, windows-latest
-- npm run test: act -- --node 16.x --os ubuntu-latest --ap ubuntu-latest=nektos/act-environments-ubuntu:18.04
+- npm run test: act -- --node 16.x, 14.x --os ubuntu-22.04
+- npm run test: act -- --node 16.x, 14.x --os ubuntu-22.04, windows-latest
+- npm run test: act -- --node 16.x --os ubuntu-22.04 --ap ubuntu-22.04=nektos/act-environments-ubuntu:18.04
 `);
 }
 


### PR DESCRIPTION
**What It Does**

Uses `ubuntu-22.04` instead of `ubuntu-latest` to work around some runner issues with Ubuntu 24 (missing glibc and cargo audit)

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [ ] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
