### PR TITLE
fix(dsclp): pass `targetMember` as `start` param for `List.allMembers` call

### DIFF
--- a/packages/zosfiles/__tests__/__unit__/methods/copy/Copy.unit.test.ts
+++ b/packages/zosfiles/__tests__/__unit__/methods/copy/Copy.unit.test.ts
@@ -954,6 +954,7 @@ describe("Copy", () => {
 
                     expect(listDatasetSpy).toHaveBeenCalledTimes(2);
                     expect(listAllMembersSpy).toHaveBeenCalledTimes(1);
+                    expect(listAllMembersSpy.mock.calls[0][2].start).toBe(memberName);
                     expect(getDatasetSpy).toHaveBeenCalledTimes(1);
                     expect(uploadDatasetSpy).toHaveBeenCalledTimes(1);
                 });

--- a/packages/zosfiles/src/methods/copy/Copy.ts
+++ b/packages/zosfiles/src/methods/copy/Copy.ts
@@ -328,7 +328,7 @@ export class Copy {
             */
             if(targetMember != undefined && targetFound == true){
                 const TargetMemberList = await List.allMembers(targetSession, targetDataset,
-                    {attributes: true, maxLength: 1, start: targetDataset, recall: "wait", pattern: targetMember});
+                    { attributes: true, maxLength: 1, recall: "wait", start: targetMember });
                 if(TargetMemberList.apiResponse.returnedRows > 0){
                     targetMemberFound = true;
                 }


### PR DESCRIPTION
**What It Does**

Fixes an issue spotted while working on #2409.

No changelog since the `start` param had no effect in `List.allMembers` before the work done in #2409.

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [x] added/updated automated tests
- [ ] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
