### PR TITLE
doc(zosfiles/List): add note to typedoc about maxLength

### DIFF
--- a/packages/zosfiles/src/methods/list/List.ts
+++ b/packages/zosfiles/src/methods/list/List.ts
@@ -410,6 +410,10 @@ export class List {
      * @param {IDsmListOptions} options Contains options for the z/OSMF request
      * @returns {Promise<IZosFilesResponse>} List of z/OSMF list responses for each data set
      *
+     * *Note*: When the `maxLength` option is provided, it is passed to z/OSMF when listing
+     * each data set pattern. For example, for three patterns with a `maxLength` of 10, the maximum
+     * number of returned items is 30.
+     * 
      * @example
      * ```typescript
      *


### PR DESCRIPTION
**What It Does**

Adds note to typedoc regarding use of `maxLength` parameter within `List.dataSetsMatchingPattern`

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->

**Review Checklist**
I certify that I have:
- [ ] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
