### PR TITLE
refactor(zosfiles/List): `maxLength` with multiple patterns

### DIFF
--- a/packages/zosfiles/__tests__/__system__/methods/list/List.system.test.ts
+++ b/packages/zosfiles/__tests__/__system__/methods/list/List.system.test.ts
@@ -1154,7 +1154,7 @@ describe("List command group - encoded", () => {
             expect(caughtError).toBeUndefined();
             expect(response).toBeDefined();
             expect(response.success).toBe(true);
-            expect(response.commandResponse).toContain(format(ZosFilesMessages.dataSetsMatchedPattern.message, 2));
+            expect(response.commandResponse).toContain(format(ZosFilesMessages.dataSetsMatchedPattern.message, 1));
             expect(response.apiResponse.length).toBe(1);
             expect(response.apiResponse[0].dsname).toBe(dsname);
         });

--- a/packages/zosfiles/__tests__/__system__/methods/list/List.system.test.ts
+++ b/packages/zosfiles/__tests__/__system__/methods/list/List.system.test.ts
@@ -1141,6 +1141,24 @@ describe("List command group - encoded", () => {
             expect(response.apiResponse[1].dsname).toBe(dsname + ".LIKE");
         });
 
+        it("should find one data set when listing 2 patterns with maxLength = 1", async () => {
+            let response;
+            let caughtError;
+
+            try {
+                response = await List.dataSetsMatchingPattern(REAL_SESSION, [dsname, dsname + ".LIKE"], { maxLength: 1 });
+            } catch (error) {
+                caughtError = error;
+            }
+
+            expect(caughtError).toBeUndefined();
+            expect(response).toBeDefined();
+            expect(response.success).toBe(true);
+            expect(response.commandResponse).toContain(format(ZosFilesMessages.dataSetsMatchedPattern.message, 2));
+            expect(response.apiResponse.length).toBe(1);
+            expect(response.apiResponse[0].dsname).toBe(dsname);
+        });
+
         it("should exclude data sets that do not match a pattern", async () => {
             let response;
             let caughtError;

--- a/packages/zosfiles/__tests__/__unit__/methods/list/List.unit.test.ts
+++ b/packages/zosfiles/__tests__/__unit__/methods/list/List.unit.test.ts
@@ -1516,6 +1516,22 @@ describe("z/OS Files - List", () => {
             expect(listDataSetSpy).toHaveBeenCalledWith(dummySession, dataSetPS.dsname, {attributes: true});
         });
 
+        it("should skip listing data sets if totalCount exceeds maxLength param", async () => {
+            listDataSetSpy.mockResolvedValueOnce({
+                success: true,
+                apiResponse: {
+                    items: ["TEST.PS.DATA.SET.ONE", "TEST.PS.DATA.SET.TWO"]
+                },
+                commandResponse: ""
+            });
+
+            const response = await List.dataSetsMatchingPattern(dummySession, [`${dataSetPS.dsname}.*`, dataSetPO.dsname], { maxLength: 2 });
+            expect(response).not.toBeUndefined();
+
+            expect(listDataSetSpy).toHaveBeenCalledTimes(1);
+            expect(listDataSetSpy.mock.calls[0][1]).toBe(`${dataSetPS.dsname}.*`);
+        });
+
         it("should handle an error from the List.dataSet API 2", async () => {
             const dummyError = new ImperativeError({msg: "test", errorCode: "400"});
             let response;

--- a/packages/zosfiles/src/methods/list/List.ts
+++ b/packages/zosfiles/src/methods/list/List.ts
@@ -409,7 +409,7 @@ export class List {
      * @param {string[]} patterns Data set patterns to include
      * @param {IDsmListOptions} options Contains options for the z/OSMF request
      * @returns {Promise<IZosFilesResponse>} List of z/OSMF list responses for each data set
-     * 
+     *
      * @example
      * ```typescript
      *
@@ -428,9 +428,11 @@ export class List {
 
         const maxLength = options.maxLength;
 
+        // Keep a count of returned data sets to compare against the `maxLength` option.
         let totalCount = 0;
         // Get names of all data sets
         for (const pattern of patterns) {
+            // Stop searching for more data sets once we've reached the `maxLength` limit (if provided).
             if (maxLength && totalCount >= options.maxLength) {
                 break;
             }
@@ -475,6 +477,7 @@ export class List {
                     await asyncPool(maxConcurrentRequests, response.apiResponse.items, createListPromise);
                 }
             }
+            // Track the total number of datasets returned for this pattern.
             if (response.success && response.apiResponse?.items?.length > 0) {
                 totalCount += response.apiResponse.items.length;
             }

--- a/packages/zosfiles/src/methods/list/List.ts
+++ b/packages/zosfiles/src/methods/list/List.ts
@@ -410,6 +410,10 @@ export class List {
      * @param {IDsmListOptions} options Contains options for the z/OSMF request
      * @returns {Promise<IZosFilesResponse>} List of z/OSMF list responses for each data set
      *
+     * *Note*: When the `maxLength` option is provided, it is passed to z/OSMF when listing
+     * each data set pattern. For example, for three patterns with a `maxLength` of 10, the maximum
+     * number of returned items is 30.
+     * 
      * @example
      * ```typescript
      *

--- a/packages/zosfiles/src/methods/list/List.ts
+++ b/packages/zosfiles/src/methods/list/List.ts
@@ -430,11 +430,18 @@ export class List {
         ImperativeExpect.toNotBeEqual(patterns.length, 0, ZosFilesMessages.missingPatterns.message);
         const zosmfResponses: IZosmfListResponse[] = [];
 
+        const maxLength = options.maxLength;
+
+        let totalCount = 0;
         // Get names of all data sets
         for (const pattern of patterns) {
+            if (maxLength && totalCount >= options.maxLength) {
+                break;
+            }
             let response: any;
             try {
-                response = await List.dataSet(session, pattern, { attributes: true, maxLength: options.maxLength, start: options.start });
+                response = await List.dataSet(session, pattern,
+                    { attributes: true, maxLength: maxLength ? maxLength - totalCount : undefined, start: options.start });
             } catch (err) {
                 if (!(err instanceof ImperativeError && err.errorCode?.toString().startsWith("5"))) {
                     throw err;
@@ -471,6 +478,9 @@ export class List {
                 } else {
                     await asyncPool(maxConcurrentRequests, response.apiResponse.items, createListPromise);
                 }
+            }
+            if (response.success && response.apiResponse?.items?.length > 0) {
+                totalCount += response.apiResponse.items.length;
             }
             zosmfResponses.push(...response.apiResponse.items);
         }

--- a/packages/zosfiles/src/methods/list/List.ts
+++ b/packages/zosfiles/src/methods/list/List.ts
@@ -409,10 +409,6 @@ export class List {
      * @param {string[]} patterns Data set patterns to include
      * @param {IDsmListOptions} options Contains options for the z/OSMF request
      * @returns {Promise<IZosFilesResponse>} List of z/OSMF list responses for each data set
-     *
-     * *Note*: When the `maxLength` option is provided, it is passed to z/OSMF when listing
-     * each data set pattern. For example, for three patterns with a `maxLength` of 10, the maximum
-     * number of returned items is 30.
      * 
      * @example
      * ```typescript


### PR DESCRIPTION
**What It Does**

This PR improves the behavior of the `maxLength` parameter when listing multiple patterns. We'll gradually increment the total number of items returned for each pattern, and once we've reached the max length, we'll stop listing patterns.

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)
