### PR TITLE
Secure value censorship refactor

### DIFF
--- a/packages/cli/__tests__/zosfiles/__unit__/copy/dsclp/TargetProfile.handler.unit.test.ts
+++ b/packages/cli/__tests__/zosfiles/__unit__/copy/dsclp/TargetProfile.handler.unit.test.ts
@@ -50,9 +50,10 @@ describe("TargetProfileHandler", () => {
                 api: {
                     layers: { get: jest.fn() },
                     profiles: { get: getProfileMock },
-                    secure: { secureFields: jest.fn().mockReturnValue([]) }
+                    secure: { findSecure: jest.fn().mockReturnValue([]), securePropsForProfile: jest.fn().mockReturnValue([]) }
                 },
-                exists: true
+                exists: true,
+                mProperties: { profiles: {} }
             },
             envVariablePrefix: "ZOWE",
             loadedConfig: {}

--- a/packages/imperative/src/censor/__tests__/Censor.unit.test.ts
+++ b/packages/imperative/src/censor/__tests__/Censor.unit.test.ts
@@ -1,0 +1,279 @@
+/*
+* This program and the accompanying materials are made available under the terms of the
+* Eclipse Public License v2.0 which accompanies this distribution, and is available at
+* https://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Copyright Contributors to the Zowe Project.
+*
+*/
+
+// Mock out config APIs
+jest.mock("../../config/src/Config");
+
+import { EnvironmentalVariableSettings } from "../../imperative/src/env/EnvironmentalVariableSettings";
+import { Censor } from "../src/Censor";
+import { ImperativeConfig } from "../../utilities/src/ImperativeConfig";
+
+beforeAll(() => {
+    Censor.setCensoredOptions();
+});
+
+afterAll(() => {
+    jest.restoreAllMocks();
+});
+
+describe("Censor tests", () => {
+    const nonCensoredOptionsList = ["certFile", "cert-file", "certKeyFile", "cert-key-file", "h", "host", "p", "port", "notSecret", "u", "user"];
+
+    it("should not change the default main censored options", () => {
+        expect(Censor.CENSORED_OPTIONS).toEqual(Censor.DEFAULT_CENSORED_OPTIONS);
+        expect(Censor.CENSORED_OPTIONS).toMatchSnapshot();
+    });
+
+    it("should not change the default secure prompt options", () => {
+        expect(Censor.SECURE_PROMPT_OPTIONS).toMatchSnapshot();
+    });
+
+    it("should not change the censor response", () => {
+        expect(Censor.CENSOR_RESPONSE).toMatchSnapshot();
+    });
+
+    describe("addCensoredOption", () => {
+        beforeEach(() => {
+            Censor.setCensoredOptions();
+        });
+
+        afterAll(() => {
+            Censor.setCensoredOptions();
+        });
+
+        it("should add a censored option", () => {
+            Censor.addCensoredOption("secret");
+            expect(Censor.CENSORED_OPTIONS).toContain("secret");
+        });
+
+        it("should add a censored option in kebab and camel case 1", () => {
+            Censor.addCensoredOption("secret-value");
+            expect(Censor.CENSORED_OPTIONS).toContain("secret-value");
+            expect(Censor.CENSORED_OPTIONS).toContain("secretValue");
+        });
+
+        it("should add a censored option in kebab and camel case 2", () => {
+            Censor.addCensoredOption("secretValue");
+            expect(Censor.CENSORED_OPTIONS).toContain("secret-value");
+            expect(Censor.CENSORED_OPTIONS).toContain("secretValue");
+        });
+    });
+
+    describe("censorCLIArgs", () => {
+        for (const opt of Censor.CENSORED_OPTIONS) {
+            it(`should hide --${opt} operand`, () => {
+                const data = Censor.censorCLIArgs([`--${opt}`, "cantSeeMe"]);
+                expect(data).toContain(Censor.CENSOR_RESPONSE);
+            });
+        }
+
+        for (const opt of nonCensoredOptionsList) {
+            it(`should not hide --${opt} operand`, () => {
+                const data = Censor.censorCLIArgs([`--${opt}`, "canSeeMe"]);
+                expect(data).not.toContain(Censor.CENSOR_RESPONSE);
+            });
+        }
+    });
+
+    describe("censorRawData", () => {
+        const secrets = ["secret0", "secret1"];
+        let impConfigSpy: jest.SpyInstance = null;
+        let envSettingsReadSpy: jest.SpyInstance = null;
+        let findSecure: jest.SpyInstance = null;
+        let impConfig: any = null; // tried Partial<ImperativeConfig> but some properties complain about missing functionality
+        beforeEach(() => {
+            jest.restoreAllMocks();
+            findSecure = jest.fn();
+            impConfigSpy = jest.spyOn(ImperativeConfig, "instance", "get");
+            envSettingsReadSpy = jest.spyOn(EnvironmentalVariableSettings, "read");
+            impConfig = {
+                config: {
+                    exists: true,
+                    api: {
+                        secure: { findSecure }
+                    },
+                    mProperties: {}
+                }
+            };
+            Censor.setProfileSchemas(new Map());
+        });
+
+        describe("should NOT censor", () => {
+            it("data if we are using old profiles 1", () => {
+                impConfigSpy.mockReturnValue({ config: { exists: false }, envVariablePrefix: "ZOWE" });
+                expect(Censor.censorRawData(secrets[0])).toEqual(secrets[0]);
+            });
+
+            it("data if we are using old profiles 2", () => {
+                impConfigSpy.mockReturnValue({ config: undefined, envVariablePrefix: "ZOWE" });
+                expect(Censor.censorRawData(secrets[0])).toEqual(secrets[0]);
+            });
+
+            it("Console Output if the MASK_OUTPUT env var is FALSE and category is console", () => {
+                impConfigSpy.mockReturnValue({
+                    config: { exists: true, api: { secure: { findSecure }}, mProperties: { profiles: []}},
+                    envVariablePrefix: "ZOWE"
+                });
+                findSecure.mockReturnValue([]);
+                envSettingsReadSpy.mockReturnValue({ maskOutput: { value: "FALSE" } });
+                expect(Censor.censorRawData(secrets[1], "console")).toEqual(secrets[1]);
+            });
+
+            it("Console Output if the MASK_OUTPUT env var is FALSE and category is json", () => {
+                impConfigSpy.mockReturnValue({
+                    config: { exists: true, api: { secure: { findSecure }}, mProperties: { profiles: []}},
+                    envVariablePrefix: "ZOWE"
+                });
+                findSecure.mockReturnValue([]);
+                envSettingsReadSpy.mockReturnValue({ maskOutput: { value: "FALSE" } });
+                expect(Censor.censorRawData(secrets[1], "json")).toEqual(secrets[1]);
+            });
+
+            describe("special value:", () => {
+                beforeEach(() => {
+                    impConfig.config.mProperties = {profiles: {secret: { properties: {}}}};
+                    impConfigSpy.mockReturnValue(impConfig);
+                    envSettingsReadSpy.mockReturnValue({ maskOutput: { value: "TRUE" } });
+                });
+
+                const _lazyTest = (prop: string): [string, string] => {
+                    findSecure.mockReturnValue([`profiles.secret.properties.${prop}`, "profiles.secret.properties.secret"]);
+                    impConfig.config.mProperties.profiles.secret.properties = {[prop]: secrets[0], secret: secrets[1] };
+
+                    const received = Censor.censorRawData(`visible secret: ${secrets[0]}, masked secret: ${secrets[1]}`);
+                    const expected = `visible secret: ${secrets[0]}, masked secret: ${Censor.CENSOR_RESPONSE}`;
+                    return [received, expected];
+                };
+
+                for (const opt of Censor.SECURE_PROMPT_OPTIONS) {
+                    it(`${opt}`, () => {
+                        const [received, expected] = _lazyTest(opt);
+                        expect(received).toEqual(expected);
+                    });
+                }
+            });
+        });
+
+        describe("should censor", () => {
+            beforeEach(() => {
+                impConfig.config.mProperties = {profiles: {secret: { properties: {}}}};
+                impConfigSpy.mockReturnValue(impConfig);
+                envSettingsReadSpy.mockReturnValue({ maskOutput: { value: "FALSE" } });
+            });
+
+            afterAll(() => {
+                (Censor as any).mConfig = null;
+            });
+
+            it("data if the logger category is not console, regardless of the MASK_OUTPUT env var value 1", () => {
+                findSecure.mockReturnValue(["profiles.secret.properties.secret"]);
+                impConfig.config.mProperties.profiles.secret.properties = {secret: secrets[1] };
+                const received = Censor.censorRawData(`masked secret: ${secrets[1]}`, "This is not the console");
+                const expected = `masked secret: ${Censor.CENSOR_RESPONSE}`;
+                expect(received).toEqual(expected);
+            });
+
+            it("data if the logger category is not console, regardless of the MASK_OUTPUT env var value 2", () => {
+                (Censor as any).mConfig = {
+                    exists: true,
+                    mProperties: {
+                        profiles: {
+                            secret: {
+                                properties: {
+                                    secret: secrets[1]
+                                }
+                            }
+                        }
+                    },
+                    api: {
+                        secure: {
+                            findSecure
+                        }
+                    }
+                };
+                findSecure.mockReturnValue(["profiles.secret.properties.secret"]);
+                const received = Censor.censorRawData(`masked secret: ${secrets[1]}`, "This is not the console");
+                const expected = `masked secret: ${Censor.CENSOR_RESPONSE}`;
+                expect(received).toEqual(expected);
+            });
+        });
+    });
+
+    describe("censorYargsArguments", () => {
+        for (const opt of Censor.CENSORED_OPTIONS) {
+            it(`should hide --${opt} operand`, () => {
+                const data = Censor.censorYargsArguments({ _: [], $0: "test", [opt]: "cantSeeMe" });
+                expect(data[opt]).toContain(Censor.CENSOR_RESPONSE);
+            });
+        }
+
+        for (const opt of nonCensoredOptionsList) {
+            it(`should not hide --${opt} operand`, () => {
+                const data = Censor.censorYargsArguments({ _: [], $0: "test", [opt]: "canSeeMe" });
+                expect(data[opt]).not.toContain(Censor.CENSOR_RESPONSE);
+            });
+        }
+
+        it("should handle passing in multiple arguments and censor the not normally censored options if they match", () => {
+            const args: any = {};
+            args[Censor.CENSORED_OPTIONS[0]] = "cantSeeMe";
+            for (const opt of nonCensoredOptionsList) {
+                args[opt] = "cantSeeMe";
+            }
+            const data = Censor.censorYargsArguments({ _: [], $0: "test", ...args });
+            expect(data[Censor.CENSORED_OPTIONS[0]]).toContain(Censor.CENSOR_RESPONSE);
+            for (const opt of nonCensoredOptionsList) {
+                expect(data[opt]).toContain(Censor.CENSOR_RESPONSE);
+            }
+        });
+    });
+
+    describe("profileSchemas getter", () => {
+        let impConfigSpy: jest.SpyInstance = null;
+
+        beforeEach(() => {
+            (Censor as any).mSchema = null;
+            impConfigSpy = jest.spyOn(ImperativeConfig, "instance", "get");
+        });
+
+        afterAll(() => {
+            (Censor as any).mSchema = null;
+        });
+
+        it("should return the schema from ImperativeConfig", () => {
+            const mockedProfiles = [{
+                type: "test",
+                schema: {
+                    title: "Fake Profile Type",
+                    description: "Fake Profile Description",
+                    type: "object",
+                    properties: {
+                        test: {
+                            type: "string",
+                            description: "Fake Test Description"
+                        }
+                    }
+                }
+            }];
+            impConfigSpy.mockReturnValue({
+                loadedConfig: {
+                    profiles: mockedProfiles
+                }
+            });
+            expect(Censor.profileSchemas).toEqual(mockedProfiles);
+        });
+
+        it("should return nothing", () => {
+            impConfigSpy.mockReturnValue({});
+            expect(Censor.profileSchemas).toEqual([]);
+        });
+    });
+});

--- a/packages/imperative/src/censor/__tests__/__snapshots__/Censor.unit.test.ts.snap
+++ b/packages/imperative/src/censor/__tests__/__snapshots__/Censor.unit.test.ts.snap
@@ -1,0 +1,34 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Censor tests should not change the censor response 1`] = `"****"`;
+
+exports[`Censor tests should not change the default main censored options 1`] = `
+Array [
+  "auth",
+  "authentication",
+  "basicAuth",
+  "basic-auth",
+  "certFilePassphrase",
+  "cert-file-passphrase",
+  "credentials",
+  "pw",
+  "pass",
+  "password",
+  "passphrase",
+  "tv",
+  "tokenValue",
+  "token-value",
+]
+`;
+
+exports[`Censor tests should not change the default secure prompt options 1`] = `
+Array [
+  "keyPassphrase",
+  "key-passphrase",
+  "password",
+  "passphrase",
+  "tokenValue",
+  "token-value",
+  "user",
+]
+`;

--- a/packages/imperative/src/censor/index.ts
+++ b/packages/imperative/src/censor/index.ts
@@ -1,0 +1,13 @@
+/*
+* This program and the accompanying materials are made available under the terms of the
+* Eclipse Public License v2.0 which accompanies this distribution, and is available at
+* https://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Copyright Contributors to the Zowe Project.
+*
+*/
+
+export * from "./src/Censor";
+export * from "./src/doc/ICensorOptions";

--- a/packages/imperative/src/censor/src/Censor.ts
+++ b/packages/imperative/src/censor/src/Censor.ts
@@ -28,10 +28,10 @@ export class Censor {
     *
     * NOTE(Harn): This list should be kept in sync with the base profile secure definitions and MUST be in camel case.
     */
-    private static readonly MAIN_CENSORED_OPTIONS = ["auth", "pw", "pass", "password", "passphrase", "credentials",
-        "authentication", "basicAuth", "tv", "tokenValue", "certFilePassphrase"];
+    private static readonly MAIN_CENSORED_OPTIONS = ["auth", "authentication", "basicAuth", "certFilePassphrase", "credentials",
+        "pw", "pass", "password", "passphrase", "tv", "tokenValue"];
 
-    private static readonly MAIN_SECURE_PROMPT_OPTIONS = ["user", "password", "tokenValue", "passphrase", "keyPassphrase"];
+    private static readonly MAIN_SECURE_PROMPT_OPTIONS = ["keyPassphrase", "password", "passphrase", "tokenValue", "user"];
 
     // The censor response.
     public static readonly CENSOR_RESPONSE = "****";

--- a/packages/imperative/src/censor/src/Censor.ts
+++ b/packages/imperative/src/censor/src/Censor.ts
@@ -17,8 +17,9 @@ import { ICensorOptions } from "./doc/ICensorOptions";
 import { Config } from "../../config/src/Config";
 import { ImperativeConfig } from "../../utilities/src/ImperativeConfig";
 import { EnvironmentalVariableSettings } from "../../imperative/src/env/EnvironmentalVariableSettings";
-import { ICommandProfileTypeConfiguration } from "../../cmd";
-import { IProfileSchema, IProfileTypeConfiguration } from "../../profiles";
+import { ICommandProfileTypeConfiguration } from "../../cmd/src/doc/profiles/definition/ICommandProfileTypeConfiguration";
+import { IProfileSchema} from "../../profiles/src/doc/definition/IProfileSchema";
+import { IProfileTypeConfiguration } from "../../profiles/src/doc/config/IProfileTypeConfiguration";
 
 export class Censor {
     /*

--- a/packages/imperative/src/censor/src/Censor.ts
+++ b/packages/imperative/src/censor/src/Censor.ts
@@ -1,0 +1,255 @@
+/*
+* This program and the accompanying materials are made available under the terms of the
+* Eclipse Public License v2.0 which accompanies this distribution, and is available at
+* https://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Copyright Contributors to the Zowe Project.
+*
+*/
+
+import * as lodash from "lodash";
+import { Arguments } from "yargs";
+import { ICommandProfileProperty } from "../../cmd/src/doc/profiles/definition/ICommandProfileProperty";
+import { CliUtils } from "../../utilities/src/CliUtils";
+import { ICensorOptions } from "./doc/ICensorOptions";
+import { Config } from "../../config/src/Config";
+import { ImperativeConfig } from "../../utilities/src/ImperativeConfig";
+import { EnvironmentalVariableSettings } from "../../imperative/src/env/EnvironmentalVariableSettings";
+import { ICommandProfileTypeConfiguration } from "../../cmd";
+import { IProfileSchema, IProfileTypeConfiguration } from "../../profiles";
+
+export class Censor {
+    /*
+    * NOTE(Kelosky): Ideally we might have a consolidated list for secure fields, but for now we'll just
+    * make sure they're collocated within the same class.
+    *
+    * NOTE(Harn): This list should be kept in sync with the base profile secure definitions and MUST be in camel case.
+    */
+    private static readonly MAIN_CENSORED_OPTIONS = ["auth", "p", "pass", "password", "passphrase", "credentials",
+        "authentication", "basicAuth", "tv", "tokenValue", "certFilePassphrase"];
+
+    private static readonly MAIN_SECURE_PROMPT_OPTIONS = ["user", "password", "tokenValue", "passphrase"];
+
+    // The censor response.
+    public static readonly CENSOR_RESPONSE = "****";
+
+    // A set of default censored options.
+    public static get DEFAULT_CENSORED_OPTIONS(): string[] {
+        const censoredList = new Set<string>();
+        for (const option of this.MAIN_CENSORED_OPTIONS) {
+            censoredList.add(option);
+            censoredList.add(CliUtils.getOptionFormat(option).kebabCase);
+        }
+        return Array.from(censoredList);
+    }
+
+    // Return a customized list of secure prompt options
+    public static get SECURE_PROMPT_OPTIONS(): string[] {
+        const censoredList = new Set<string>();
+        for (const option of this.MAIN_SECURE_PROMPT_OPTIONS) {
+            censoredList.add(option);
+            censoredList.add(CliUtils.getOptionFormat(option).kebabCase);
+        }
+        return Array.from(censoredList);
+    }
+
+    // Set a censored options list that can be set and retrieved for each command.
+    private static censored_options: Set<string> = new Set(this.DEFAULT_CENSORED_OPTIONS);
+
+    // Keep a cached config object if provided in another function
+    private static mConfig: Config = null;
+
+    // Return a customized list of censored options (or just the defaults if not set).
+    public static get CENSORED_OPTIONS(): string[] {
+        return Array.from(this.censored_options);
+    }
+
+    /**
+     * Specifies whether a given property path (e.g. "profiles.lpar1.properties.host") is a special value or not.
+     * Special value: Refers to any value defined as secure in the schema definition.
+     *                These values should be already masked by the application (and/or plugin) developer.
+     * @param prop Property path to determine if it is a special value
+     * @returns True - if the given property is to be treated as a special value; False - otherwise
+     */
+    public static isSpecialValue(prop: string): boolean {
+        for (const v of this.CENSORED_OPTIONS) {
+            if (prop.endsWith(`.${v}`)) return true;
+        }
+        return false;
+    }
+
+    /**
+     * Add a censored option, including it's camelCase and kebabCase versions
+     * @param {string} option - The option to censor
+     */
+    public static addCensoredOption(option: string) {
+        this.censored_options.add(option);
+        this.censored_options.add(CliUtils.getOptionFormat(option).camelCase);
+        this.censored_options.add(CliUtils.getOptionFormat(option).kebabCase);
+    }
+
+    /**
+     * Singleton implementation of an internal reference to the schema
+     */
+    private static mSchema: ICommandProfileTypeConfiguration[] = null;
+
+    /**
+     * Helper method to get an internal reference to the loaded profiles
+     */
+    public static get profileSchemas(): ICommandProfileTypeConfiguration[] {
+        if (this.mSchema == null) this.mSchema = ImperativeConfig.instance.loadedConfig?.profiles ?? [];
+        return this.mSchema;
+    }
+
+    /**
+     * Helper method to set an internal reference to loaded profiles
+     * @param _schemas - The schemas to pass in to set to the logger
+     */
+    public static setProfileSchemas(_schemas: IProfileTypeConfiguration[] | Map<string, IProfileSchema>) {
+        if (this.mSchema == null) {
+            this.mSchema = [];
+        }
+        if (_schemas instanceof Map) {
+            _schemas.forEach((v: IProfileSchema) => {
+                this.mSchema.push({ type: v.type, schema: v });
+            });
+        } else if (Array.isArray(_schemas)) {
+            _schemas.forEach((v: IProfileTypeConfiguration) => {
+                this.mSchema.push({ type: v.type, schema: v.schema });
+            });
+        }
+    }
+
+    /**
+     * Generate and set the list of censored options.
+     * Attempt to source the censored options from the schema, config, and/or command being executed.
+     * @param {ICensorOptions} censorOpts - The objects to use to gather options that should be censored
+     */
+    public static setCensoredOptions(censorOpts?: ICensorOptions) {
+        this.censored_options = new Set(this.DEFAULT_CENSORED_OPTIONS);
+
+        if (censorOpts) {
+            // Save off the config object
+            this.mConfig = censorOpts.config;
+
+            // If we have a ProfileTypeConfiguration (i.e. ImperativeConfig.instance.loadedConfig.profiles)
+            if (censorOpts.profiles) {this.setProfileSchemas(censorOpts.profiles);}
+
+            for (const profileType of this.profileSchemas ?? []) {
+                for (const [propName, propValue] of Object.entries(profileType.schema.properties)) {
+                    // Include the property itself
+                    if (propValue.secure) {
+                        this.addCensoredOption(propName);
+                    }
+
+                    // Include any known aliases (if available)
+                    if ((propValue as ICommandProfileProperty).optionDefinition?.aliases != null) {
+                        for (const alias of (propValue as ICommandProfileProperty).optionDefinition.aliases) {
+                            this.addCensoredOption(alias);
+                        }
+                    }
+                }
+            }
+
+            // Include any secure options from the config
+            if (censorOpts.config) {
+                // Try to use the command and inputs to find the profiles being loaded
+                if (censorOpts.commandDefinition && censorOpts.commandArguments) {
+                    const profiles = [];
+                    for (const prof of censorOpts.commandDefinition.profile?.required || []) {
+                        profiles.push(prof);
+                    }
+                    for (const prof of censorOpts.commandDefinition.profile?.optional || []) {
+                        profiles.push(prof);
+                    }
+
+                    for (const prof of profiles) {
+                        // If the profile exists, append all of the secure props to the censored list
+                        const profName = censorOpts.commandArguments?.[`${prof}-profile`];
+                        if (censorOpts.config.api.profiles.get(profName)) {
+                            censorOpts.config.api.secure.securePropsForProfile(profName).forEach(prop => this.addCensoredOption(prop));
+                        }
+                    }
+                } else {
+                    // We only have a configuration file, assume every property that is secured should be censored
+                    censorOpts.config.api.secure.findSecure(censorOpts.config.mProperties.profiles, "profiles").forEach(
+                        prop => this.addCensoredOption(prop.split(".").pop())
+                    );
+                }
+            }
+        }
+    }
+
+    /**
+     * Copy and censor any sensitive CLI arguments before logging/printing
+     * @param {string[]} args - The args list to censor
+     * @returns {string[]}
+     */
+    public static censorCLIArgs(args: string[]): string[] {
+        const newArgs: string[] = JSON.parse(JSON.stringify(args));
+        const censoredValues = this.CENSORED_OPTIONS.map(CliUtils.getDashFormOfOption);
+        for (const value of censoredValues) {
+            if (args.indexOf(value) >= 0) {
+                const valueIndex = args.indexOf(value);
+                if (valueIndex < args.length - 1) {
+                    newArgs[valueIndex + 1] = this.CENSOR_RESPONSE; // censor the argument after the option name
+                }
+            }
+        }
+        return newArgs;
+    }
+
+    /**
+     * Copy and censor any sensitive CLI arguments before logging/printing
+     * @param {string} data - the data to censor
+     * @returns {string} - the censored data
+     */
+    public static censorRawData(data: string, category: string = ""): string {
+        const config = this.mConfig ?? ImperativeConfig.instance?.config;
+
+        // Return the data if not using config
+        if (!config?.exists) return data;
+
+        // Return the data if we are printing to the console and masking is disabled
+        if (ImperativeConfig.instance?.envVariablePrefix) {
+            const envMaskOutput = EnvironmentalVariableSettings.read(ImperativeConfig.instance.envVariablePrefix).maskOutput.value;
+            // Hardcoding "console" instead of using Logger.DEFAULT_CONSOLE_NAME because of circular dependencies
+            if ((category === "console" || category === "json") && envMaskOutput.toUpperCase() === "FALSE") return data;
+        }
+
+        let newData = data;
+
+        const secureFields = config.api.secure.findSecure(config.mProperties.profiles, "profiles");
+        for (const prop of secureFields) {
+            const sec = lodash.get(config.mProperties, prop);
+            if (sec && typeof sec !== "object" && !this.isSpecialValue(prop)) {
+                newData = newData.replace(new RegExp(sec, "gi"), this.CENSOR_RESPONSE);
+            }
+        }
+        return newData;
+    }
+
+    /**
+     * Copy and censor a yargs argument object before logging
+     * @param {yargs.Arguments} args - the args to censor
+     * @returns {yargs.Arguments} - a censored copy of the arguments
+     */
+    public static censorYargsArguments(args: Arguments): Arguments {
+        const newArgs: Arguments = JSON.parse(JSON.stringify(args));
+
+        for (const optionName of Object.keys(newArgs)) {
+            if (this.CENSORED_OPTIONS.indexOf(optionName) >= 0) {
+                const valueToCensor = newArgs[optionName];
+                newArgs[optionName] = this.CENSOR_RESPONSE;
+                for (const checkAliasKey of Object.keys(newArgs)) {
+                    if (newArgs[checkAliasKey] === valueToCensor) {
+                        newArgs[checkAliasKey] = this.CENSOR_RESPONSE;
+                    }
+                }
+            }
+        }
+        return newArgs;
+    }
+}

--- a/packages/imperative/src/censor/src/doc/ICensorOptions.ts
+++ b/packages/imperative/src/censor/src/doc/ICensorOptions.ts
@@ -1,0 +1,36 @@
+/*
+* This program and the accompanying materials are made available under the terms of the
+* Eclipse Public License v2.0 which accompanies this distribution, and is available at
+* https://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Copyright Contributors to the Zowe Project.
+*
+*/
+
+import { ICommandDefinition, ICommandArguments } from "../../../cmd";
+import { Config } from "../../../config";
+import { IProfileTypeConfiguration } from "../../../profiles";
+
+export interface ICensorOptions {
+    /**
+     * An array of profile schema definitions
+     */
+    profiles?: IProfileTypeConfiguration[];
+
+    /**
+     * The team config API
+     */
+    config?: Config;
+
+    /**
+     * The command definition for the command being executed
+     */
+    commandDefinition?: ICommandDefinition;
+
+    /**
+     * The command arguments for the command being executed
+     */
+    commandArguments?: ICommandArguments;
+}

--- a/packages/imperative/src/cmd/__tests__/CommandProcessor.unit.test.ts
+++ b/packages/imperative/src/cmd/__tests__/CommandProcessor.unit.test.ts
@@ -790,7 +790,7 @@ describe("Command Processor", () => {
         expect(commandResponse.error?.additionalDetails).toEqual("Syntax validation error!");
     });
 
-    fit("should mask sensitive CLI options like user and password in log output", async () => {
+    it("should mask sensitive CLI options like user and password in log output", async () => {
         // Allocate the command processor
         const processor: CommandProcessor = new CommandProcessor({
             envVariablePrefix: ENV_VAR_PREFIX,
@@ -821,7 +821,7 @@ describe("Command Processor", () => {
         const commandResponse: ICommandResponse = await processor.invoke(parms);
 
         expect(mockLogInfo).toHaveBeenCalled();
-        expect(logOutput).toContain("--user **** --password **** --token-value **** --cert-file-passphrase **** --cert-key-file ****");
+        expect(logOutput).toContain("--user fakeUser --password **** --token-value **** --cert-file-passphrase **** --cert-key-file /fake/path");
     });
 
     it("should handle not being able to instantiate the handler", async () => {

--- a/packages/imperative/src/cmd/__tests__/CommandProcessor.unit.test.ts
+++ b/packages/imperative/src/cmd/__tests__/CommandProcessor.unit.test.ts
@@ -191,6 +191,7 @@ const FAKE_HELP_GENERATOR: IHelpGenerator = {
 
 const ENV_VAR_PREFIX: string = "UNIT_TEST";
 
+/* eslint-disable deprecation/deprecation */
 describe("Command Processor", () => {
     describe("Command Processor with --help and --version flags", () => {
         let faultyConfigProcessor: CommandProcessor;
@@ -789,7 +790,7 @@ describe("Command Processor", () => {
         expect(commandResponse.error?.additionalDetails).toEqual("Syntax validation error!");
     });
 
-    it("should mask sensitive CLI options like user and password in log output", async () => {
+    fit("should mask sensitive CLI options like user and password in log output", async () => {
         // Allocate the command processor
         const processor: CommandProcessor = new CommandProcessor({
             envVariablePrefix: ENV_VAR_PREFIX,

--- a/packages/imperative/src/cmd/src/CommandProcessor.ts
+++ b/packages/imperative/src/cmd/src/CommandProcessor.ts
@@ -382,8 +382,6 @@ export class CommandProcessor {
                     commandLine = commandLine.replace(regex, `-${secureArg} ${Censor.CENSOR_RESPONSE}`);
                 }
             }
-            console.dir(secureArg);
-            console.dir(commandLine);
         }
 
         // this.log.info(`post commandLine issued:\n\n${TextUtils.prettyJson(commandLine)}`);

--- a/packages/imperative/src/cmd/src/response/CommandResponse.ts
+++ b/packages/imperative/src/cmd/src/response/CommandResponse.ts
@@ -35,7 +35,7 @@ import { IPromptOptions } from "../doc/response/api/handler/IPromptOptions";
 import { DaemonRequest } from "../../../utilities/src/DaemonRequest";
 import { IDaemonResponse } from "../../../utilities/src/doc/IDaemonResponse";
 import { Logger } from "../../../logger";
-import { LoggerUtils } from "../../../logger/src/LoggerUtils";
+import { Censor } from "../../../censor";
 
 const DataObjectParser = require("dataobject-parser");
 
@@ -549,7 +549,7 @@ export class CommandResponse implements ICommandResponseApi {
                  * @returns {string} - The formatted data or the original data.toString() if a buffer was passed
                  */
                 public log(message: string | Buffer, ...values: any[]): string {
-                    let msg: string = LoggerUtils.censorRawData(message.toString(), Logger.DEFAULT_CONSOLE_NAME);
+                    let msg: string = Censor.censorRawData(message.toString(), Logger.DEFAULT_CONSOLE_NAME);
                     if (!Buffer.isBuffer(message)) {
                         msg = outer.formatMessage(msg.toString(), ...values) + "\n";
                     }
@@ -565,7 +565,7 @@ export class CommandResponse implements ICommandResponseApi {
                  * @returns {string} - The formatted data, or the original data.toString() if a buffer was passed
                  */
                 public error(message: string | Buffer, ...values: any[]): string {
-                    let msg: string = LoggerUtils.censorRawData(message.toString(), Logger.DEFAULT_CONSOLE_NAME);
+                    let msg: string = Censor.censorRawData(message.toString(), Logger.DEFAULT_CONSOLE_NAME);
                     if (!Buffer.isBuffer(message)) {
                         msg = outer.formatMessage(msg.toString(), ...values) + "\n";
                     }
@@ -581,7 +581,7 @@ export class CommandResponse implements ICommandResponseApi {
                  * @returns {string} - The string that is printed (including the color codes)
                  */
                 public errorHeader(message: string, delimeter = ":"): string {
-                    let msg: string = LoggerUtils.censorRawData(message.toString(), Logger.DEFAULT_CONSOLE_NAME);
+                    let msg: string = Censor.censorRawData(message.toString(), Logger.DEFAULT_CONSOLE_NAME);
                     msg = TextUtils.chalk.red(msg + `${delimeter}\n`);
                     outer.writeAndBufferStderr(msg);
                     return msg;
@@ -594,7 +594,7 @@ export class CommandResponse implements ICommandResponseApi {
                  * @returns {Promise<string>}
                  */
                 public prompt(questionText: string, opts?: IPromptOptions): Promise<string> {
-                    const msg: string = LoggerUtils.censorRawData(questionText.toString(), Logger.DEFAULT_CONSOLE_NAME);
+                    const msg: string = Censor.censorRawData(questionText.toString(), Logger.DEFAULT_CONSOLE_NAME);
 
                     if (outer.mStream) {
                         return new Promise<string>((resolve) => {
@@ -954,9 +954,9 @@ export class CommandResponse implements ICommandResponseApi {
             response = this.buildJsonResponse();
             (response.stderr as any) = response.stderr.toString();
             (response.stdout as any) = response.stdout.toString();
-            response.message = LoggerUtils.censorRawData(response.message, "json");
-            response.data =  response.data ? JSON.parse(LoggerUtils.censorRawData(JSON.stringify(response.data), "json")) : undefined;
-            response.error = response.error ? JSON.parse(LoggerUtils.censorRawData(JSON.stringify(response.error), "json")) : undefined;
+            response.message = Censor.censorRawData(response.message, "json");
+            response.data =  response.data ? JSON.parse(Censor.censorRawData(JSON.stringify(response.data), "json")) : undefined;
+            response.error = response.error ? JSON.parse(Censor.censorRawData(JSON.stringify(response.error), "json")) : undefined;
 
             if (!this.mSilent) {
                 this.writeStdout(JSON.stringify(response, null, 2));

--- a/packages/imperative/src/config/src/ProfileInfo.ts
+++ b/packages/imperative/src/config/src/ProfileInfo.ts
@@ -1066,7 +1066,9 @@ export class ProfileInfo {
                     } else {
                         schemaJson = lastSchema.json;
                     }
-                    for (const { type, schema } of ConfigSchema.loadSchema(schemaJson)) {
+                    const loadedSchemas = ConfigSchema.loadSchema(schemaJson);
+                    Censor.setProfileSchemas(loadedSchemas);
+                    for (const { type, schema } of loadedSchemas) {
                         this.mProfileSchemaCache.set(`${layer.path}:${type}`, schema);
                     }
                 } catch (error) {
@@ -1080,7 +1082,6 @@ export class ProfileInfo {
         }
 
         this.mHasValidSchema = lastSchema.path != null;
-        Censor.setProfileSchemas(this.mProfileSchemaCache);
     }
 
     /**

--- a/packages/imperative/src/config/src/ProfileInfo.ts
+++ b/packages/imperative/src/config/src/ProfileInfo.ts
@@ -38,7 +38,6 @@ import { IProfileLoaded, IProfileProperty, IProfileSchema } from "../../profiles
 import { CliUtils, ImperativeConfig } from "../../utilities";
 import { ImperativeExpect } from "../../expect";
 import { Logger } from "../../logger";
-import { LoggerUtils } from "../../logger/src/LoggerUtils";
 import {
     IOptionsForAddConnProps, ISession, Session, SessConstants, ConnectionPropsForSessCfg
 } from "../../rest";
@@ -52,6 +51,7 @@ import { ConfigBuilder } from "./ConfigBuilder";
 import { IAddProfTypeResult, IExtenderTypeInfo, IExtendersJsonOpts } from "./doc/IExtenderOpts";
 import { IConfigLayer } from "..";
 import { Constants } from "../../constants";
+import { Censor } from "../../censor";
 
 /**
  * This class provides functions to retrieve profile-related information.
@@ -1080,7 +1080,7 @@ export class ProfileInfo {
         }
 
         this.mHasValidSchema = lastSchema.path != null;
-        LoggerUtils.setProfileSchemas(this.mProfileSchemaCache);
+        Censor.setProfileSchemas(this.mProfileSchemaCache);
     }
 
     /**

--- a/packages/imperative/src/config/src/__mocks__/Config.ts
+++ b/packages/imperative/src/config/src/__mocks__/Config.ts
@@ -22,10 +22,15 @@ export class Config {
 
     public get api() {
         return {
-            // profiles: new ConfigProfiles(this),
+            profiles: {
+                get: () => [] as any
+            },
             plugins: {
                 get: () => [] as any
             },
+            secure: {
+                securePropsForProfile: () => [] as any 
+            }
             // layers: new ConfigLayers(this),
             // secure: new ConfigSecure(this)
         };

--- a/packages/imperative/src/config/src/__mocks__/Config.ts
+++ b/packages/imperative/src/config/src/__mocks__/Config.ts
@@ -9,7 +9,7 @@
 *
 */
 
-import { IConfigOpts, IConfigSchemaInfo } from "../..";
+import { IConfig, IConfigOpts, IConfigSchemaInfo } from "../..";
 import { IConfigLayer } from "../../src/doc/IConfigLayer";
 
 export class Config {
@@ -29,7 +29,8 @@ export class Config {
                 get: () => [] as any
             },
             secure: {
-                securePropsForProfile: () => [] as any 
+                securePropsForProfile: () => [] as any ,
+                findSecure: () => [] as any
             }
             // layers: new ConfigLayers(this),
             // secure: new ConfigSecure(this)
@@ -66,5 +67,13 @@ export class Config {
             resolved: "/some/path/to/schema.json",
             original: "/some/path/to/schema.json"
         };
+    }
+
+    public get mProperties() {
+        const config: IConfig = {
+            profiles: {},
+            defaults: {}
+        }
+        return config;
     }
 }

--- a/packages/imperative/src/imperative/src/config/cmd/report-env/EnvQuery.ts
+++ b/packages/imperative/src/imperative/src/config/cmd/report-env/EnvQuery.ts
@@ -483,12 +483,10 @@ export class EnvQuery {
                 nextVar != "ZOWE_APP_LOG_LEVEL" && nextVar != "ZOWE_IMPERATIVE_LOG_LEVEL")
             {
                 getResult.itemValMsg += nextVar + " = " ;
-                if (secureCredsList.includes(nextVar.toUpperCase()))
-                {
+                if (secureCredsList.some(secureOpt => nextVar.toUpperCase().includes(secureOpt))) {
                     getResult.itemValMsg += "******";
                 } else {
                     getResult.itemValMsg += envVars[nextVar];
-
                 }
                 getResult.itemValMsg += os.EOL;
             }

--- a/packages/imperative/src/imperative/src/config/cmd/report-env/EnvQuery.ts
+++ b/packages/imperative/src/imperative/src/config/cmd/report-env/EnvQuery.ts
@@ -25,6 +25,7 @@ import { IPluginJson } from "../../../plugins/doc/IPluginJson";
 import { PluginIssues } from "../../../plugins/utilities/PluginIssues";
 
 import { ItemId, IProbTest, probTests } from "./EnvItems";
+import { Censor } from "../../../../../censor";
 
 /**
  * This interface represents the result from getEnvItemVal().
@@ -476,13 +477,13 @@ export class EnvQuery {
     private static getOtherZoweEnvVars(getResult: IGetItemVal): void {
         getResult.itemValMsg = "";
         const envVars = process.env;
+        const secureCredsList = Censor.CENSORED_OPTIONS.map(opt => opt.toUpperCase().replaceAll("-", "_"));
         for (const nextVar of Object.keys(envVars)) {
             if (nextVar.startsWith("ZOWE_") && nextVar != "ZOWE_CLI_HOME" &&
                 nextVar != "ZOWE_APP_LOG_LEVEL" && nextVar != "ZOWE_IMPERATIVE_LOG_LEVEL")
             {
                 getResult.itemValMsg += nextVar + " = " ;
-                if (nextVar.toUpperCase().includes("PASSWORD") ||
-                    nextVar.toUpperCase().includes("TOKEN"))
+                if (secureCredsList.includes(nextVar.toUpperCase()))
                 {
                     getResult.itemValMsg += "******";
                 } else {

--- a/packages/imperative/src/index.ts
+++ b/packages/imperative/src/index.ts
@@ -9,6 +9,7 @@
 *
 */
 
+export * from "./censor";
 export * from "./cmd";
 export * from "./config";
 export * from "./console";

--- a/packages/imperative/src/logger/__tests__/LoggerUtils.unit.test.ts
+++ b/packages/imperative/src/logger/__tests__/LoggerUtils.unit.test.ts
@@ -9,9 +9,16 @@
 *
 */
 
+// Mock out config APIs
+jest.mock("../../config/src/Config");
+
 import { EnvironmentalVariableSettings } from "../../imperative/src/env/EnvironmentalVariableSettings";
 import { LoggerUtils } from "../src/LoggerUtils";
 import { ImperativeConfig } from "../../utilities/src/ImperativeConfig";
+
+afterAll(() => {
+    jest.restoreAllMocks();
+});
 
 /* eslint-disable deprecation/deprecation */
 describe("LoggerUtils tests", () => {
@@ -36,8 +43,8 @@ describe("LoggerUtils tests", () => {
         expect(data).toContain(LoggerUtils.CENSOR_RESPONSE);
     });
 
-    it("Should hide -p operand", () => {
-        const data = LoggerUtils.censorCLIArgs(["-p", "cantSeeMe"]);
+    it("Should hide --pw operand", () => {
+        const data = LoggerUtils.censorCLIArgs(["--pw", "cantSeeMe"]);
         expect(data).toContain(LoggerUtils.CENSOR_RESPONSE);
     });
 
@@ -60,22 +67,20 @@ describe("LoggerUtils tests", () => {
         const secrets = ["secret0", "secret1"];
         let impConfigSpy: jest.SpyInstance = null;
         let envSettingsReadSpy: jest.SpyInstance = null;
-        let secureFields: jest.SpyInstance = null;
-        let layersGet: jest.SpyInstance = null;
+        let findSecure: jest.SpyInstance = null;
         let impConfig: any = null; // tried Partial<ImperativeConfig> but some properties complain about missing functionality
         beforeEach(() => {
             jest.restoreAllMocks();
-            secureFields = jest.fn();
-            layersGet = jest.fn();
+            findSecure = jest.fn();
             impConfigSpy = jest.spyOn(ImperativeConfig, "instance", "get");
             envSettingsReadSpy = jest.spyOn(EnvironmentalVariableSettings, "read");
             impConfig = {
                 config: {
                     exists: true,
                     api: {
-                        layers: { get: layersGet },
-                        secure: { secureFields }
-                    }
+                        secure: { findSecure }
+                    },
+                    mProperties: {}
                 }
             };
             LoggerUtils.setProfileSchemas(new Map());
@@ -88,20 +93,22 @@ describe("LoggerUtils tests", () => {
             });
 
             it("Console Output if the MASK_OUTPUT env var is FALSE", () => {
-                impConfigSpy.mockReturnValue({ config: { exists: true } });
+                impConfigSpy.mockReturnValue({ config: { exists: true, api: { secure: { findSecure }}, mProperties: { profiles: []}}});
+                findSecure.mockReturnValue([]);
                 envSettingsReadSpy.mockReturnValue({ maskOutput: { value: "FALSE" } });
                 expect(LoggerUtils.censorRawData(secrets[1], "console")).toEqual(secrets[1]);
             });
 
             describe("special value:", () => {
                 beforeEach(() => {
+                    impConfig.config.mProperties = {profiles: {secret: { properties: {}}}};
                     impConfigSpy.mockReturnValue(impConfig);
                     envSettingsReadSpy.mockReturnValue({ maskOutput: { value: "TRUE" } });
                 });
 
                 const _lazyTest = (prop: string): [string, string] => {
-                    secureFields.mockReturnValue([`secret.${prop}`, "secret.secret"]);
-                    layersGet.mockReturnValue({ properties: { secret: { [prop]: secrets[0], secret: secrets[1] } } });
+                    findSecure.mockReturnValue([`profiles.secret.properties.${prop}`, "profiles.secret.properties.secret"]);
+                    impConfig.config.mProperties.profiles.secret.properties = {[prop]: secrets[0], secret: secrets[1] };
 
                     const received = LoggerUtils.censorRawData(`visible secret: ${secrets[0]}, masked secret: ${secrets[1]}`);
                     const expected = `visible secret: ${secrets[0]}, masked secret: ${LoggerUtils.CENSOR_RESPONSE}`;
@@ -125,12 +132,13 @@ describe("LoggerUtils tests", () => {
 
         describe("should censor", () => {
             beforeEach(() => {
+                impConfig.config.mProperties = {profiles: {secret: { properties: {}}}};
                 impConfigSpy.mockReturnValue(impConfig);
                 envSettingsReadSpy.mockReturnValue({ maskOutput: { value: "FALSE" } });
             });
             it("data if the logger category is not console, regardless of the MASK_OUTPUT env var value", () => {
-                secureFields.mockReturnValue(["secret.secret"]);
-                layersGet.mockReturnValue({ properties: { secret: { secret: secrets[1] } } });
+                findSecure.mockReturnValue(["profiles.secret.properties.secret"]);
+                impConfig.config.mProperties.profiles.secret.properties = {secret: secrets[1] };
                 const received = LoggerUtils.censorRawData(`masked secret: ${secrets[1]}`, "This is not the console");
                 const expected = `masked secret: ${LoggerUtils.CENSOR_RESPONSE}`;
                 expect(received).toEqual(expected);

--- a/packages/imperative/src/logger/__tests__/LoggerUtils.unit.test.ts
+++ b/packages/imperative/src/logger/__tests__/LoggerUtils.unit.test.ts
@@ -13,6 +13,7 @@ import { EnvironmentalVariableSettings } from "../../imperative/src/env/Environm
 import { LoggerUtils } from "../src/LoggerUtils";
 import { ImperativeConfig } from "../../utilities/src/ImperativeConfig";
 
+/* eslint-disable deprecation/deprecation */
 describe("LoggerUtils tests", () => {
 
     it("Should hide --password operand", () => {

--- a/packages/imperative/src/logger/src/Logger.ts
+++ b/packages/imperative/src/logger/src/Logger.ts
@@ -19,7 +19,7 @@ import { IConfigLogging } from "./doc/IConfigLogging";
 import { LoggerManager } from "./LoggerManager";
 import * as log4js from "log4js";
 import { Console } from "../../console/src/Console";
-import { LoggerUtils } from "./LoggerUtils";
+import { Censor } from "../../censor";
 
 /**
  * Note(Kelosky): it seems from the log4js doc that you only get a single
@@ -194,7 +194,7 @@ export class Logger {
      * @returns {any}
      */
     public debug(message: string, ...args: any[]): string {
-        const finalMessage = LoggerUtils.censorRawData(TextUtils.formatMessage.apply(this, [message].concat(args)), this.category);
+        const finalMessage = Censor.censorRawData(TextUtils.formatMessage.apply(this, [message].concat(args)), this.category);
         if (LoggerManager.instance.isLoggerInit || this.category === Logger.DEFAULT_CONSOLE_NAME) {
             this.logService.debug(this.getCallerFileAndLineTag() + finalMessage);
         } else {
@@ -212,7 +212,7 @@ export class Logger {
      * @returns {any}
      */
     public info(message: string, ...args: any[]): string {
-        const finalMessage = LoggerUtils.censorRawData(TextUtils.formatMessage.apply(this, [message].concat(args)), this.category);
+        const finalMessage = Censor.censorRawData(TextUtils.formatMessage.apply(this, [message].concat(args)), this.category);
         if (LoggerManager.instance.isLoggerInit || this.category === Logger.DEFAULT_CONSOLE_NAME) {
             this.logService.info(this.getCallerFileAndLineTag() + finalMessage);
         } else {
@@ -230,7 +230,7 @@ export class Logger {
      * @returns {any}
      */
     public warn(message: string, ...args: any[]): string {
-        const finalMessage = LoggerUtils.censorRawData(TextUtils.formatMessage.apply(this, [message].concat(args)), this.category);
+        const finalMessage = Censor.censorRawData(TextUtils.formatMessage.apply(this, [message].concat(args)), this.category);
         if (LoggerManager.instance.isLoggerInit || this.category === Logger.DEFAULT_CONSOLE_NAME) {
             this.logService.warn(this.getCallerFileAndLineTag() + finalMessage);
         } else {
@@ -247,7 +247,7 @@ export class Logger {
      * @returns {any}
      */
     public error(message: string, ...args: any[]): string {
-        const finalMessage = LoggerUtils.censorRawData(TextUtils.formatMessage.apply(this, [message].concat(args)), this.category);
+        const finalMessage = Censor.censorRawData(TextUtils.formatMessage.apply(this, [message].concat(args)), this.category);
         if (LoggerManager.instance.isLoggerInit || this.category === Logger.DEFAULT_CONSOLE_NAME) {
             this.logService.error(this.getCallerFileAndLineTag() + finalMessage);
         } else {
@@ -264,7 +264,7 @@ export class Logger {
      * @returns {any}
      */
     public fatal(message: string, ...args: any[]): string {
-        const finalMessage = LoggerUtils.censorRawData(TextUtils.formatMessage.apply(this, [message].concat(args)), this.category);
+        const finalMessage = Censor.censorRawData(TextUtils.formatMessage.apply(this, [message].concat(args)), this.category);
         if (LoggerManager.instance.isLoggerInit || this.category === Logger.DEFAULT_CONSOLE_NAME) {
             this.logService.fatal(this.getCallerFileAndLineTag() + finalMessage);
         } else {
@@ -281,7 +281,7 @@ export class Logger {
      * @returns {any}
      */
     public simple(message: string, ...args: any[]): string {
-        const finalMessage = LoggerUtils.censorRawData(TextUtils.formatMessage.apply(this, [message].concat(args)), this.category);
+        const finalMessage = Censor.censorRawData(TextUtils.formatMessage.apply(this, [message].concat(args)), this.category);
         if (LoggerManager.instance.isLoggerInit || this.category === Logger.DEFAULT_CONSOLE_NAME) {
             this.logService.info(finalMessage);
         } else {

--- a/packages/imperative/src/logger/src/LoggerUtils.ts
+++ b/packages/imperative/src/logger/src/LoggerUtils.ts
@@ -14,6 +14,10 @@ import { ICommandProfileTypeConfiguration } from "../../cmd/src/doc/profiles/def
 import { IProfileSchema } from "../../profiles/src/doc/definition/IProfileSchema";
 import { Censor } from "../../censor/src/Censor";
 
+/**
+ * @deprecated Use Censor
+ * Logging utilities
+ */
 export class LoggerUtils {
     /**
      * @deprecated Use Censor.CENSOR_RESPONSE

--- a/packages/imperative/src/logger/src/LoggerUtils.ts
+++ b/packages/imperative/src/logger/src/LoggerUtils.ts
@@ -10,115 +10,58 @@
 */
 
 import { Arguments } from "yargs";
-import { EnvironmentalVariableSettings } from "../../imperative/src/env/EnvironmentalVariableSettings";
-import { CliUtils } from "../../utilities/src/CliUtils";
-import { ImperativeConfig } from "../../utilities/src/ImperativeConfig";
-import * as lodash from "lodash";
-import { Config } from "../../config/src/Config";
-import { IConfigLayer } from "../../config/src/doc/IConfigLayer";
 import { ICommandProfileTypeConfiguration } from "../../cmd/src/doc/profiles/definition/ICommandProfileTypeConfiguration";
-import { ICommandProfileProperty } from "../../cmd/src/doc/profiles/definition/ICommandProfileProperty";
 import { IProfileSchema } from "../../profiles/src/doc/definition/IProfileSchema";
+import { Censor } from "../../censor/src/Censor";
 
 export class LoggerUtils {
-    public static readonly CENSOR_RESPONSE = "****";
+    /**
+     * @deprecated Use Censor.CENSOR_RESPONSE
+     */
+    public static CENSOR_RESPONSE = Censor.CENSOR_RESPONSE;
 
     /**
-     * NOTE(Kelosky): Ideally we might have a consolidated list for secure fields, but for now we'll just
-     * make sure they're collocated within the same class.
+     * @deprecated Use Censor.CENSORED_OPTIONS
      */
-    public static CENSORED_OPTIONS = ["auth", "p", "pass", "password", "passphrase", "credentials",
-        "authentication", "basic-auth", "basicAuth", "tv", "token-value", "tokenValue",
-        "cert-file-passphrase", "certFilePassphrase"];
+    public static CENSORED_OPTIONS = Censor.CENSORED_OPTIONS;
 
-    public static SECURE_PROMPT_OPTIONS = ["user", "password", "tokenValue", "passphrase"];
+    /**
+     * @deprecated Use Censor.SECURE_PROMPT_OPTIONS
+     */
+    public static SECURE_PROMPT_OPTIONS = Censor.SECURE_PROMPT_OPTIONS;
 
     /**
      * Copy and censor any sensitive CLI arguments before logging/printing
      * @param {string[]} args
      * @returns {string[]}
+     * @deprecated Use Censor.censorCLIArgs
      */
     public static censorCLIArgs(args: string[]): string[] {
-        const newArgs: string[] = JSON.parse(JSON.stringify(args));
-        const censoredValues = LoggerUtils.CENSORED_OPTIONS.map(CliUtils.getDashFormOfOption);
-        for (const value of censoredValues) {
-            if (args.indexOf(value) >= 0) {
-                const valueIndex = args.indexOf(value);
-                if (valueIndex < args.length - 1) {
-                    newArgs[valueIndex + 1] = LoggerUtils.CENSOR_RESPONSE; // censor the argument after the option name
-                }
-            }
-        }
-        return newArgs;
+        return Censor.censorCLIArgs(args);
     }
 
     /**
      * Copy and censor a yargs argument object before logging
      * @param {yargs.Arguments} args the args to censor
      * @returns {yargs.Arguments}  a censored copy of the arguments
+     * @deprecated Use Censor.censorYargsArguments
      */
     public static censorYargsArguments(args: Arguments): Arguments {
-        const newArgs: Arguments = JSON.parse(JSON.stringify(args));
-
-        for (const optionName of Object.keys(newArgs)) {
-            if (LoggerUtils.CENSORED_OPTIONS.indexOf(optionName) >= 0) {
-                const valueToCensor = newArgs[optionName];
-                newArgs[optionName] = LoggerUtils.CENSOR_RESPONSE;
-                for (const checkAliasKey of Object.keys(newArgs)) {
-                    if (newArgs[checkAliasKey] === valueToCensor) {
-                        newArgs[checkAliasKey] = LoggerUtils.CENSOR_RESPONSE;
-                    }
-                }
-            }
-        }
-        return newArgs;
+        return Censor.censorYargsArguments(args);
     }
 
     /**
-     * Singleton implementation of an internal reference of ImperativeConfig.instance.config
+     * @deprecated use Censor.profileSchemas
      */
-    private static mConfig: Config = null;
-    private static get config(): Config {
-        if (LoggerUtils.mConfig == null) LoggerUtils.mConfig = ImperativeConfig.instance.config;
-        return LoggerUtils.mConfig;
-    }
-
-    /**
-     * Singleton implementation of an internal reference to the active layer
-     * This should help with performance since one a single copy will be created for censoring data
-     */
-    private static mLayer: IConfigLayer = null;
-    private static get layer(): IConfigLayer {
-        // if (LoggerUtils.mLayer == null) LoggerUtils.mLayer = LoggerUtils.config.api.layers.get();
-        // Have to get a new copy every time because of how secure properties get lazy-loaded
-        LoggerUtils.mLayer = LoggerUtils.config.api.layers.get();
-        return LoggerUtils.mLayer;
-    }
-
-    /**
-     * Singleton implementation of an internal reference to the secure fields stored in the config
-     */
-    private static mSecureFields: string[] = null;
-    private static get secureFields(): string[] {
-        if (LoggerUtils.mSecureFields == null) LoggerUtils.mSecureFields = LoggerUtils.config.api.secure.secureFields();
-        return LoggerUtils.mSecureFields;
-    }
-
-    /**
-     * Singleton implementation of an internal reference to the loaded profiles
-     */
-    private static mProfiles: ICommandProfileTypeConfiguration[] = null;
     public static get profileSchemas(): ICommandProfileTypeConfiguration[] {
-        if (LoggerUtils.mProfiles == null) LoggerUtils.mProfiles = ImperativeConfig.instance.loadedConfig?.profiles ?? [];
-        return LoggerUtils.mProfiles;
+        return Censor.profileSchemas;
     }
+
+    /**
+     * @deprecated use Censor.setProfileSchemas
+     */
     public static setProfileSchemas(_schemas: Map<string, IProfileSchema>) {
-        if (LoggerUtils.mProfiles == null) {
-            LoggerUtils.mProfiles = [];
-        }
-        _schemas.forEach((v: IProfileSchema) => {
-            LoggerUtils.mProfiles.push({ type: v.type, schema: v });
-        });
+        Censor.setProfileSchemas(_schemas);
     }
 
     /**
@@ -127,60 +70,19 @@ export class LoggerUtils {
      *                These values should be already masked by the application (and/or plugin) developer.
      * @param prop Property path to determine if it is a special value
      * @returns True - if the given property is to be treated as a special value; False - otherwise
+     * @deprecated Use Censor.isSpecialValue
      */
     public static isSpecialValue = (prop: string): boolean => {
-        let specialValues = ["user", "password", "tokenValue", "keyPassphrase"];
-
-        /**
-         * Helper function that return a list of all optionDefinition names for a given ICommandProfileProperty
-         * @param prop profile property to get the optionDefinition names from
-         * @returns List of optionDefinition names
-         */
-        const getPropertyNames = (prop: ICommandProfileProperty): string[] => {
-            const ret: string[] = [];
-            ret.push(prop.optionDefinition?.name);
-            prop.optionDefinitions?.map(opDef => ret.push(opDef.name));
-            return ret;
-        };
-
-        for (const profile of LoggerUtils.profileSchemas) {
-            // eslint-disable-next-line unused-imports/no-unused-vars
-            for (const [_, prop] of Object.entries(profile.schema.properties)) {
-                if (prop.secure) specialValues = lodash.union(specialValues, getPropertyNames(prop));
-            }
-        }
-
-        // TODO: How to handle DNS resolution (using a wrong port)
-        //  ex: zowe jobs list jobs --port 12345
-        //      May print the IP address of the given host if the resolved IP:port combination is not valid
-
-        for (const v of specialValues) {
-            if (prop.endsWith(`.${v}`)) return true;
-        }
-        return false;
+        return Censor.isSpecialValue(prop);
     };
 
     /**
      * Copy and censor any sensitive CLI arguments before logging/printing
      * @param {string} data
      * @returns {string}
+     * @deprecated Use Censor.censorRawData
      */
     public static censorRawData(data: string, category: string = ""): string {
-        // Return the data if not using config
-        if (!ImperativeConfig.instance.config?.exists) return data;
-
-        // Return the data if we are printing to the console and masking is disabled
-        const envMaskOutput = EnvironmentalVariableSettings.read(ImperativeConfig.instance.envVariablePrefix).maskOutput.value;
-        // Hardcoding "console" instead of using Logger.DEFAULT_CONSOLE_NAME because of circular dependencies
-        if ((category === "console" || category === "json") && envMaskOutput.toUpperCase() === "FALSE") return data;
-
-        let newData = data;
-        const layer = LoggerUtils.layer;
-        for (const prop of LoggerUtils.secureFields) {
-            const sec = lodash.get(layer.properties, prop);
-            if (sec && typeof sec !== "object" && !LoggerUtils.isSpecialValue(prop))
-                newData = newData.replace(new RegExp(sec, "gi"), LoggerUtils.CENSOR_RESPONSE);
-        }
-        return newData;
+        return Censor.censorRawData(data, category);
     }
 }

--- a/packages/imperative/src/rest/src/session/ConnectionPropsForSessCfg.ts
+++ b/packages/imperative/src/rest/src/session/ConnectionPropsForSessCfg.ts
@@ -20,6 +20,7 @@ import { ISession } from "./doc/ISession";
 import { IProfileProperty } from "../../../profiles";
 import { ConfigAutoStore } from "../../../config/src/ConfigAutoStore";
 import { ConfigUtils } from "../../../config/src/ConfigUtils";
+import { Censor } from "../../../censor/src/Censor";
 
 /**
  * Extend options for IPromptOptions for internal wrapper method
@@ -353,11 +354,8 @@ export class ConnectionPropsForSessCfg {
     /**
      * List of properties on `sessCfg` object that should be kept secret and
      * may not appear in Imperative log files.
-     *
-     * NOTE(Kelosky): redundant from LoggerUtils.SECURE_PROMPT_OPTIONS - leaving
-     * for future date to consolidate
      */
-    private static secureSessCfgProps: Set<string> = new Set(["user", "password", "tokenValue", "passphrase"]);
+    private static secureSessCfgProps: Set<string> = new Set(Censor.SECURE_PROMPT_OPTIONS);
 
     /**
      * List of prompt messages that is used when the CLI prompts for session

--- a/packages/imperative/src/utilities/__tests__/DeferredPromise.unit.test.ts
+++ b/packages/imperative/src/utilities/__tests__/DeferredPromise.unit.test.ts
@@ -1,13 +1,13 @@
-/**
- * This program and the accompanying materials are made available under the terms of the
- * Eclipse Public License v2.0 which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
- *
- * SPDX-License-Identifier: EPL-2.0
- *
- * Copyright Contributors to the Zowe Project.
- *
- */
+/*
+* This program and the accompanying materials are made available under the terms of the
+* Eclipse Public License v2.0 which accompanies this distribution, and is available at
+* https://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Copyright Contributors to the Zowe Project.
+*
+*/
 
 import { DeferredPromise, DeferredPromiseStatus } from "../src/DeferredPromise";
 

--- a/packages/imperative/src/utilities/src/CliUtils.ts
+++ b/packages/imperative/src/utilities/src/CliUtils.ts
@@ -32,6 +32,7 @@ export class CliUtils {
      * Used as the place holder when censoring arguments in messages/command output
      * @static
      * @memberof CliUtils
+     * @deprecated Use Censor.CENSOR_RESPONSE
      */
     public static readonly CENSOR_RESPONSE = "****";
 
@@ -39,6 +40,7 @@ export class CliUtils {
      * A list of cli options/keywords that should normally be censored
      * @static
      * @memberof CliUtils
+     * @deprecated Use Censor.CENSORED_OPTIONS
      */
     public static CENSORED_OPTIONS = ["auth", "p", "pass", "password", "passphrase", "credentials",
         "authentication", "basic-auth", "basicAuth"];
@@ -64,14 +66,17 @@ export class CliUtils {
      * Copy and censor any sensitive CLI arguments before logging/printing
      * @param {string[]} args - The args list to censor
      * @returns {string[]}
+     * @deprecated Use Censor.censorCLIArgs
      */
     public static censorCLIArgs(args: string[]): string[] {
         const newArgs: string[] = JSON.parse(JSON.stringify(args));
+        // eslint-disable-next-line deprecation/deprecation
         const censoredValues = CliUtils.CENSORED_OPTIONS.map(CliUtils.getDashFormOfOption);
         for (const value of censoredValues) {
             if (args.indexOf(value) >= 0) {
                 const valueIndex = args.indexOf(value);
                 if (valueIndex < args.length - 1) {
+                    // eslint-disable-next-line deprecation/deprecation
                     newArgs[valueIndex + 1] = CliUtils.CENSOR_RESPONSE; // censor the argument after the option name
                 }
             }
@@ -83,16 +88,20 @@ export class CliUtils {
      * Copy and censor a yargs argument object before logging
      * @param {yargs.Arguments} args the args to censor
      * @returns {yargs.Arguments}  a censored copy of the arguments
+     * @deprecated Use Censor.censorYargsArguments
      */
     public static censorYargsArguments(args: Arguments): Arguments {
         const newArgs: Arguments = JSON.parse(JSON.stringify(args));
 
         for (const optionName of Object.keys(newArgs)) {
+            // eslint-disable-next-line deprecation/deprecation
             if (CliUtils.CENSORED_OPTIONS.indexOf(optionName) >= 0) {
                 const valueToCensor = newArgs[optionName];
+                // eslint-disable-next-line deprecation/deprecation
                 newArgs[optionName] = CliUtils.CENSOR_RESPONSE;
                 for (const checkAliasKey of Object.keys(newArgs)) {
                     if (newArgs[checkAliasKey] === valueToCensor) {
+                        // eslint-disable-next-line deprecation/deprecation
                         newArgs[checkAliasKey] = CliUtils.CENSOR_RESPONSE;
                     }
                 }

--- a/packages/imperative/src/utilities/src/DeferredPromise.ts
+++ b/packages/imperative/src/utilities/src/DeferredPromise.ts
@@ -1,13 +1,13 @@
-/**
- * This program and the accompanying materials are made available under the terms of the
- * Eclipse Public License v2.0 which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-v20.html
- *
- * SPDX-License-Identifier: EPL-2.0
- *
- * Copyright Contributors to the Zowe Project.
- *
- */
+/*
+* This program and the accompanying materials are made available under the terms of the
+* Eclipse Public License v2.0 which accompanies this distribution, and is available at
+* https://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Copyright Contributors to the Zowe Project.
+*
+*/
 
 /* Status of the deferred promise */
 export enum DeferredPromiseStatus {

--- a/packages/imperative/src/utilities/src/ImperativeConfig.ts
+++ b/packages/imperative/src/utilities/src/ImperativeConfig.ts
@@ -101,7 +101,11 @@ export class ImperativeConfig {
      * @returns {string} - the configured or default prefix for environmental variables for use in the environmental variable service
      */
     public get envVariablePrefix(): string {
-        return this.loadedConfig.envVariablePrefix == null ? this.loadedConfig.name : this.loadedConfig.envVariablePrefix;
+        if (this.loadedConfig) {
+            return this.loadedConfig.envVariablePrefix == null ? this.loadedConfig.name : this.loadedConfig.envVariablePrefix;
+        } else {
+            return "ZOWE"; // Turns out this doesn't always return something, so set a default.
+        }
     }
 
     /**


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->
Refactors LoggerUtils into a new Censor class to globally use the same list of censored options, and intelligently add options to censor on the fly. Also removes duplication (and deprecates functions) to the old utilities. Points old utilities to use the new utility when possible.

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->

**Review Checklist**
I certify that I have:
- [ ] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [ ] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
