### PR TITLE
Updated command response warning from 'copied aborted' to 'copy aborted'

### DIFF
--- a/packages/zosfiles/__tests__/__system__/methods/copy/Copy.system.test.ts
+++ b/packages/zosfiles/__tests__/__system__/methods/copy/Copy.system.test.ts
@@ -768,7 +768,7 @@ describe("Copy", () => {
                     }
                     expect(response?.success).toBeFalsy();
                     expect(error).toBeDefined();
-                    expect(error.message).toContain("Data set copied aborted. The source data set was not found.");
+                    expect(error.message).toContain("Data set copy aborted. The source data set was not found.");
                 });
 
                 it("should warn and fail if the destination data set exists", async() => {

--- a/packages/zosfiles/__tests__/__unit__/methods/copy/Copy.unit.test.ts
+++ b/packages/zosfiles/__tests__/__unit__/methods/copy/Copy.unit.test.ts
@@ -729,7 +729,7 @@ describe("Copy", () => {
                 );
                 expect(response).toEqual({
                     success: false,
-                    commandResponse: `Data set copied aborted. The source data set was not found.`
+                    commandResponse: `Data set copy aborted. The source data set was not found.`
                 });
             });
         });

--- a/packages/zosfiles/__tests__/__unit__/utils/__snapshots__/ZosFilesUtils.unit.test.ts.snap
+++ b/packages/zosfiles/__tests__/__unit__/utils/__snapshots__/ZosFilesUtils.unit.test.ts.snap
@@ -88,13 +88,13 @@ Object {
     "message": "Data set copy aborted. The existing target data set was not overwritten.",
   },
   "datasetCopiedAbortedNoPDS": Object {
-    "message": "Data set copied aborted. Copying from a PDS to PDS is not supported when using the 'dsclp' option.",
+    "message": "Data set copy aborted. Copying from a PDS to PDS is not supported when using the 'dsclp' option.",
   },
   "datasetCopiedAbortedNoTargetDS": Object {
-    "message": "Data set copied aborted. The source data set was not found.",
+    "message": "Data set copy aborted. The source data set was not found.",
   },
   "datasetCopiedAbortedTargetNotPDSMember": Object {
-    "message": "Data set copied aborted. Copying to a PDS without a member name is not supported when using the 'dsclp' option.",
+    "message": "Data set copy aborted. Copying to a PDS without a member name is not supported when using the 'dsclp' option.",
   },
   "datasetCopiedSuccessfully": Object {
     "message": "Data set copied successfully.",
@@ -117,7 +117,7 @@ Object {
 Destination: %s",
   },
   "datasetMemberCopiedAborted": Object {
-    "message": "Data set copied aborted. The existing target data set member was not overwritten.",
+    "message": "Data set copy aborted. The existing target data set member was not overwritten.",
   },
   "datasetMigrationRequested": Object {
     "message": "Data set migration requested.",

--- a/packages/zosfiles/src/constants/ZosFiles.messages.ts
+++ b/packages/zosfiles/src/constants/ZosFiles.messages.ts
@@ -684,7 +684,7 @@ export const ZosFilesMessages: { [key: string]: IMessageDefinition } = {
      * @type {IMessageDefinition}
      */
     datasetCopiedAbortedNoTargetDS: {
-        message: "Data set copied aborted. The source data set was not found."
+        message: "Data set copy aborted. The source data set was not found."
     },
 
     /**
@@ -700,7 +700,7 @@ export const ZosFilesMessages: { [key: string]: IMessageDefinition } = {
      * @type {IMessageDefinition}
      */
     datasetMemberCopiedAborted: {
-        message: "Data set copied aborted. The existing target data set member was not overwritten."
+        message: "Data set copy aborted. The existing target data set member was not overwritten."
     },
 
     /**
@@ -708,7 +708,7 @@ export const ZosFilesMessages: { [key: string]: IMessageDefinition } = {
      * @type {IMessageDefinition}
      */
     datasetCopiedAbortedNoPDS: {
-        message: "Data set copied aborted. Copying from a PDS to PDS is not supported when using the 'dsclp' option."
+        message: "Data set copy aborted. Copying from a PDS to PDS is not supported when using the 'dsclp' option."
     },
 
     /**
@@ -716,7 +716,7 @@ export const ZosFilesMessages: { [key: string]: IMessageDefinition } = {
      * @type {IMessageDefinition}
      */
     datasetCopiedAbortedTargetNotPDSMember: {
-        message: "Data set copied aborted. Copying to a PDS without a member name is not supported when using the 'dsclp' option."
+        message: "Data set copy aborted. Copying to a PDS without a member name is not supported when using the 'dsclp' option."
     },
 
     /**


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->
https://github.com/zowe/zowe-cli/issues/2447

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->
Use the copy command, and in the case when the functionality is aborted, the response is updated to say 'data set copy aborted'.

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [x] added/updated automated tests
- [] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
