### PR TITLE
Fix `--show-inputs-only` on chained command handlers

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Change Log
 All notable changes to the Zowe CLI package will be documented in this file.
 
+## Recent Changes
+
+- BugFix: Fixed the `--show-inputs-only` option on commands with chained command handlers, such as `zowe zos-files copy data-set-cross-lpar`. [#2446](https://github.com/zowe/zowe-cli/issues/2446)
+
 ## `8.15.0`
 
 - Enhancement: Added the `overwrite` parameter to the `Copy.DataSet()` command to allow for overwriting all members of a target data set with source data set members. [#2450] (https://github.com/zowe/zowe-cli/pull/2450)

--- a/packages/cli/src/zosfiles/-strings-/en.ts
+++ b/packages/cli/src/zosfiles/-strings-/en.ts
@@ -210,7 +210,8 @@ export default {
                     EX5: "Copy the data set named 'USER.FROM.SET' to the data set named 'USER.TO.SET' and replace members with identical names",
                     EX6: "Copy the partitioned data set named 'TEST.PDS1' to the partitioned data set named 'TEST.PDS2'",
                     EX7: "Copy the partitioned data set named 'EXISTING.PDS' to a non-existent target 'NEW.PDS'",
-                    EX8: "Copy the partitioned data set named 'USER.FROM.SET' to the partitioned data set named 'USER.FROM.SET' and overwrite the original contents",
+                    EX8: "Copy the partitioned data set named 'USER.FROM.SET' to the partitioned data set named 'USER.FROM.SET' and " +
+                        "overwrite the original contents",
                 }
             },
             DATA_SET_CROSS_LPAR: {

--- a/packages/imperative/CHANGELOG.md
+++ b/packages/imperative/CHANGELOG.md
@@ -2,7 +2,12 @@
 
 All notable changes to the Imperative package will be documented in this file.
 
+## Recent Changes
+
+- BugFix: Fixed the `--show-inputs-only` option on commands with chained command handlers. [#2446](https://github.com/zowe/zowe-cli/issues/2446)
+
 ## `8.14.1`
+
 - BugFix: Fixed help text example section's wrapping issue where the first line of the description is wrapped differently than the rest of the lines. [#1945] (https://github.com/zowe/zowe-cli/issues/1945).
 
 ## `8.14.0`

--- a/packages/imperative/src/cmd/__tests__/CommandProcessor.unit.test.ts
+++ b/packages/imperative/src/cmd/__tests__/CommandProcessor.unit.test.ts
@@ -1284,6 +1284,61 @@ describe("Command Processor", () => {
         expect(commandResponse.data.commandValues[parm1Key]).toBe(parm1Value);
     });
 
+    it("should display input value for simple parm when --show-inputs-only flag is set with a chained handler", async () => {
+
+        // values to test
+        const parm1Key = `parm1`;
+        const parm1Value = `value1`;
+
+        // Allocate the command processor
+        const processor: CommandProcessor = new CommandProcessor({
+            envVariablePrefix: ENV_VAR_PREFIX,
+            fullDefinition: SAMPLE_COMPLEX_COMMAND, // `group action`
+            definition: { // `object`
+                name: "banana",
+                description: "The banana command",
+                type: "command",
+                chainedHandlers: [
+                    {
+                        handler: __dirname + "/__model__/TestCmdHandler",
+                        mapping: [
+                            {
+                                from: parm1Key,
+                                to: parm1Key,
+                                mapFromArguments: true,
+                                applyToHandlers: [0]
+                            }
+                        ]
+                    }
+                ],
+                options: [
+                    {
+                        name: parm1Key,
+                        type: "string",
+                        description: "The first parameter",
+                    }
+                ],
+            },
+            helpGenerator: FAKE_HELP_GENERATOR,
+            rootCommandName: SAMPLE_ROOT_COMMAND,
+            commandLine: "",
+            promptPhrase: "dummydummy"
+        });
+
+        const parms: any = {
+            arguments: {
+                _: ["check", "for", "banana"],
+                $0: "",
+                [parm1Key]: parm1Value,
+                valid: true,
+                showInputsOnly: true,
+            },
+            silent: true
+        };
+        const commandResponse: ICommandResponse = await processor.invoke(parms);
+        expect(commandResponse.data.commandValues[parm1Key]).toBe(parm1Value);
+    });
+
     it("should display input value for simple parm when --show-inputs-only flag is set and team config exists", async () => {
 
         // values to test
@@ -1337,6 +1392,124 @@ describe("Command Processor", () => {
                 description: "The banana command",
                 type: "command",
                 handler: __dirname + "/__model__/TestArgHandler",
+                options: [
+                    {
+                        name: "boolean-opt",
+                        type: "boolean",
+                        description: "A boolean option.",
+                    },
+                    {
+                        name: "color",
+                        type: "string",
+                        description: "The banana color.",
+                        required: true
+                    }
+                ],
+                profile: {
+                    optional: ["banana"]
+                }
+            },
+            helpGenerator: FAKE_HELP_GENERATOR,
+            rootCommandName: SAMPLE_ROOT_COMMAND,
+            commandLine: "",
+            promptPhrase: "dummydummy",
+            config: ImperativeConfig.instance.config
+        });
+
+        const parms: any = {
+            arguments: {
+                _: ["check", "for", "banana"],
+                $0: "",
+                [parm1Key]: parm1Value,
+                valid: true,
+                showInputsOnly: true,
+            },
+            silent: true
+        };
+        const commandResponse: ICommandResponse = await processor.invoke(parms);
+        expect(commandResponse.data.locations.length).toBeGreaterThan(0);
+        expect(commandResponse.data.optionalProfiles[0]).toBe(`banana`);
+        expect(commandResponse.data.requiredProfiles).toBeUndefined();
+    });
+
+    it("should display input value for simple parm when --show-inputs-only flag is set and team config exists with a chained handler", async () => {
+
+        // values to test
+        const parm1Key = `parm1`;
+        const parm1Value = `value1`;
+
+        await setupConfigToLoad({
+            "profiles": {
+                "fruit": {
+                    "properties": {
+                        "origin": "California"
+                    },
+                    "profiles": {
+                        "apple": {
+                            "type": "fruit",
+                            "properties": {
+                                "color": "red"
+                            }
+                        },
+                        "banana": {
+                            "type": "fruit",
+                            "properties": {
+                                "color": "yellow"
+                            }
+                        },
+                        "orange": {
+                            "type": "fruit",
+                            "properties": {
+                                "color": "orange"
+                            }
+                        }
+                    },
+                    "secure": []
+                }
+            },
+            "defaults": {
+                "fruit": "fruit.apple",
+                "banana": "fruit.banana"
+            },
+            "plugins": [
+                "@zowe/fruit-for-imperative"
+            ]
+        });
+
+        // Allocate the command processor
+        const processor: CommandProcessor = new CommandProcessor({
+            envVariablePrefix: ENV_VAR_PREFIX,
+            fullDefinition: SAMPLE_CMD_WITH_OPTS_AND_PROF, // `group action`
+            definition: {
+                name: "banana",
+                description: "The banana command",
+                type: "command",
+                chainedHandlers: [
+                    {
+                        handler: __dirname + "/__model__/TestArgHandler",
+                        mapping: [
+                            {
+                                from: parm1Key,
+                                to: parm1Key,
+                                mapFromArguments: true,
+                                applyToHandlers: [0]
+                            },
+                            {
+                                from: "boolean-opt",
+                                to: "boolean-opt",
+                                mapFromArguments: true,
+                                applyToHandlers: [0],
+                                optional: true
+                            },
+                            {
+                                from: "color",
+                                to: "color",
+                                mapFromArguments: true,
+                                applyToHandlers: [0]
+                            }
+                        ]
+                    }
+                ],
                 options: [
                     {
                         name: "boolean-opt",
@@ -1481,6 +1654,135 @@ describe("Command Processor", () => {
         expect(commandResponse.data.requiredProfiles).toBeUndefined();
     });
 
+    it("should mask input value for a default secure parm when --show-inputs-only flag is set with chained handlers", async () => {
+
+        // values to test
+        const secretParmKey = `brownSpots`;
+        const secretParmValue = true;
+        const secure = `(secure value)`;
+
+        await setupConfigToLoad({
+            "profiles": {
+                "fruit": {
+                    "properties": {
+                        "origin": "California"
+                    },
+                    "profiles": {
+                        "apple": {
+                            "type": "fruit",
+                            "properties": {
+                                "color": "red"
+                            }
+                        },
+                        "banana": {
+                            "type": "fruit",
+                            "properties": {
+                                "color": "yellow",
+                                secretParmKey : secretParmValue
+                            },
+                            "secure": [
+                                secretParmKey
+                            ]
+                        },
+                        "orange": {
+                            "type": "fruit",
+                            "properties": {
+                                "color": "orange"
+                            }
+                        }
+                    }
+                }
+            },
+            "defaults": {
+                "fruit": "fruit.apple",
+                "banana": "fruit.banana"
+            },
+            "plugins": [
+                "@zowe/fruit-for-imperative"
+            ]
+        });
+
+        // Allocate the command processor
+        const processor: CommandProcessor = new CommandProcessor({
+            envVariablePrefix: ENV_VAR_PREFIX,
+            fullDefinition: SAMPLE_CMD_WITH_OPTS_AND_PROF, // `group action`
+            definition: {
+                name: "banana",
+                description: "The banana command",
+                type: "command",
+                chainedHandlers: [
+                    {
+                        handler: __dirname + "/__model__/TestArgHandler",
+                        mapping: [
+                            {
+                                from: "boolean-opt",
+                                to: "boolean-opt",
+                                mapFromArguments: true,
+                                applyToHandlers: [0],
+                                optional: true
+                            },
+                            {
+                                from: "color",
+                                to: "color",
+                                mapFromArguments: true,
+                                applyToHandlers: [0]
+                            },
+                            {
+                                from: secretParmKey,
+                                to: secretParmKey,
+                                mapFromArguments: true,
+                                applyToHandlers: [0]
+                            }
+                        ]
+                    }
+                ],
+                options: [
+                    {
+                        name: "boolean-opt",
+                        type: "boolean",
+                        description: "A boolean option.",
+                    },
+                    {
+                        name: "color",
+                        type: "string",
+                        description: "The banana color.",
+                        required: true
+                    },
+                    {
+                        name: secretParmKey,
+                        type: "boolean",
+                        description: "Whether or not the banana has brown spots"
+                    },
+                ],
+                profile: {
+                    optional: ["banana"]
+                }
+            },
+            helpGenerator: FAKE_HELP_GENERATOR,
+            rootCommandName: SAMPLE_ROOT_COMMAND,
+            commandLine: "",
+            promptPhrase: "dummydummy",
+            config: ImperativeConfig.instance.config
+        });
+
+        const parms: any = {
+            arguments: {
+                _: ["check", "for", "banana"],
+                $0: "",
+                [secretParmKey]: secretParmValue,
+                valid: true,
+                showInputsOnly: true,
+            },
+            silent: true
+        };
+
+        const commandResponse: ICommandResponse = await processor.invoke(parms);
+        expect(commandResponse.data.locations.length).toBeGreaterThan(0);
+        expect(commandResponse.data.optionalProfiles[0]).toBe(`banana`);
+        expect(commandResponse.data.commandValues[secretParmKey]).toBe(secure);
+        expect(commandResponse.data.requiredProfiles).toBeUndefined();
+    });
+
     it.each(Censor.SECURE_PROMPT_OPTIONS)("should mask input value for secure parm %s when --show-inputs-only flag is set", async (propName) => {
 
         // values to test
@@ -1546,6 +1848,85 @@ describe("Command Processor", () => {
         expect(commandResponse.stderr.toString()).toContain(`Some inputs are not displayed`);
     });
 
+    it.each(Censor.SECURE_PROMPT_OPTIONS)("should mask input value for secure parm %s when --show-inputs-only flag is set with chained handlers",
+        async (propName) => {
+
+            // values to test
+            const parm1Key = CliUtils.getOptionFormat(propName).kebabCase;
+            const parm1KeyCamel = CliUtils.getOptionFormat(propName).camelCase;
+            const parm1Value = `secret`;
+            const secure = `(secure value)`;
+            jest.spyOn(ImperativeConfig, "instance", "get").mockReturnValue({
+                config: {
+                    api: {
+                        secure: {
+                            securePropsForProfile: jest.fn(() => [propName])
+                        }
+                    },
+                    layers: [{ exists: true, path: "zowe.config.json" }],
+                    properties: Config.empty(),
+                    mProperties: Config.empty()
+                },
+                envVariablePrefix: "ZOWE"
+            } as any);
+
+            // Allocate the command processor
+            const processor: CommandProcessor = new CommandProcessor({
+                envVariablePrefix: ENV_VAR_PREFIX,
+                fullDefinition: SAMPLE_COMPLEX_COMMAND, // `group action`
+                definition: { // `object`
+                    name: "banana",
+                    description: "The banana command",
+                    type: "command",
+                    chainedHandlers: [
+                        {
+                            handler: __dirname + "/__model__/TestCmdHandler",
+                            mapping: [
+                                {
+                                    from: parm1Key,
+                                    to: parm1Key,
+                                    mapFromArguments: true,
+                                    applyToHandlers: [0]
+                                }
+                            ]
+                        }
+                    ],
+                    options: [
+                        {
+                            name: parm1Key,
+                            type: "string",
+                            description: "The first parameter",
+                        }
+                    ],
+                    profile: {
+                        optional: ["fruit"]
+                    }
+                },
+                helpGenerator: FAKE_HELP_GENERATOR,
+                rootCommandName: SAMPLE_ROOT_COMMAND,
+                commandLine: "",
+                promptPhrase: "dummydummy",
+                config: ImperativeConfig.instance.config
+            });
+
+            // return the "fake" args object with values from profile
+            jest.spyOn(CliUtils, "getOptValuesFromConfig").mockReturnValueOnce({});
+
+            const parms: any = {
+                arguments: {
+                    _: ["check", "for", "banana"],
+                    $0: "",
+                    [parm1Key]: parm1Value,
+                    valid: true,
+                    showInputsOnly: true,
+                },
+                silent: true
+            };
+            const commandResponse: ICommandResponse = await processor.invoke(parms);
+            expect(commandResponse.data.commandValues[parm1Key]).toBe(secure);
+            expect(commandResponse.stderr.toString()).toContain(`Some inputs are not displayed`);
+        });
+
     it("should not mask input value for a secure parm when --show-inputs-only flag is set with env setting", async () => {
 
         // values to test
@@ -1563,6 +1944,66 @@ describe("Command Processor", () => {
                 description: "The banana command",
                 type: "command",
                 handler: __dirname + "/__model__/TestCmdHandler",
+                options: [
+                    {
+                        name: parm1Key,
+                        type: "string",
+                        description: "The first parameter",
+                    }
+                ],
+            },
+            helpGenerator: FAKE_HELP_GENERATOR,
+            rootCommandName: SAMPLE_ROOT_COMMAND,
+            commandLine: "",
+            promptPhrase: "dummydummy"
+        });
+
+        const parms: any = {
+            arguments: {
+                _: ["check", "for", "banana"],
+                $0: "",
+                [parm1Key]: parm1Value,
+                valid: true,
+                showInputsOnly: true,
+            },
+            silent: true
+        };
+        const commandResponse: ICommandResponse = await processor.invoke(parms);
+        expect(commandResponse.data.commandValues[parm1Key]).toBe(parm1Value);
+        expect(commandResponse.stderr.toString()).not.toContain(`Some inputs are not displayed`);
+
+        delete process.env["test-cli_SHOW_SECURE_ARGS"];
+    });
+
+    it("should not mask input value for a secure parm when --show-inputs-only flag is set with env setting and chained handlers", async () => {
+
+        // values to test
+        const parm1Key = `user`;
+        const parm1Value = `secret`;
+
+        process.env["test-cli_SHOW_SECURE_ARGS"] = "true";
+
+        // Allocate the command processor
+        const processor: CommandProcessor = new CommandProcessor({
+            envVariablePrefix: ENV_VAR_PREFIX,
+            fullDefinition: SAMPLE_COMPLEX_COMMAND, // `group action`
+            definition: { // `object`
+                name: "banana",
+                description: "The banana command",
+                type: "command",
+                chainedHandlers: [
+                    {
+                        handler: __dirname + "/__model__/TestCmdHandler",
+                        mapping: [
+                            {
+                                from: parm1Key,
+                                to: parm1Key,
+                                mapFromArguments: true,
+                                applyToHandlers: [0]
+                            }
+                        ]
+                    }
+                ],
                 options: [
                     {
                         name: parm1Key,

--- a/packages/imperative/src/cmd/__tests__/CommandProcessor.unit.test.ts
+++ b/packages/imperative/src/cmd/__tests__/CommandProcessor.unit.test.ts
@@ -1853,7 +1853,6 @@ describe("Command Processor", () => {
 
             // values to test
             const parm1Key = CliUtils.getOptionFormat(propName).kebabCase;
-            const parm1KeyCamel = CliUtils.getOptionFormat(propName).camelCase;
             const parm1Value = `secret`;
             const secure = `(secure value)`;
             jest.spyOn(ImperativeConfig, "instance", "get").mockReturnValue({

--- a/packages/imperative/src/cmd/src/CommandProcessor.ts
+++ b/packages/imperative/src/cmd/src/CommandProcessor.ts
@@ -614,7 +614,7 @@ export class CommandProcessor {
             };
             try {
                 if (handlerParms.arguments.showInputsOnly) {
-                    this.showInputsOnly(response, handlerParms);
+                    this.showInputsOnly(handlerParms);
                 } else {
                     await handler.process(handlerParms);
                 }
@@ -646,7 +646,7 @@ export class CommandProcessor {
             let bufferedStdOut = Buffer.from([]);
             let bufferedStdErr = Buffer.from([]);
             if (preparedArgs.showInputsOnly) {
-                this.showInputsOnly(response, {
+                this.showInputsOnly({
                     response,
                     arguments: preparedArgs,
                     positionals: preparedArgs._,
@@ -711,9 +711,8 @@ export class CommandProcessor {
                         return this.finishResponse(chainedResponse);
                     }
                 }
-
-                this.log.info(`Chained handlers for command "${this.definition.name}" succeeded.`);
             }
+            this.log.info(`Chained handlers for command "${this.definition.name}" succeeded.`);
             response.succeeded();
             response.endProgressBar();
 
@@ -730,7 +729,7 @@ export class CommandProcessor {
      * @returns
      * @memberof CommandProcessor
      */
-    private showInputsOnly(response: IHandlerResponseApi, commandParameters: IHandlerParameters) {
+    private showInputsOnly(commandParameters: IHandlerParameters) {
 
         /**
          * Determine if we should display secure values.  If the ENV variable is set to true,
@@ -813,8 +812,8 @@ export class CommandProcessor {
          * Show warning if we censored output and we were not instructed to show secure values
          */
         if (censored && !showSecure) {
-            response.console.errorHeader("Some inputs are not displayed");
-            response.console.error(
+            commandParameters.response.console.errorHeader("Some inputs are not displayed");
+            commandParameters.response.console.error(
                 `Inputs below may be displayed as '${ConfigConstants.SECURE_VALUE}'. ` +
                 `Properties identified as secure fields are not displayed by default.\n\n` +
                 `Set the environment variable ` +
@@ -824,8 +823,8 @@ export class CommandProcessor {
         /**
          * Show the inputs
          */
-        response.console.log(TextUtils.prettyJson(showInputsOnly).trim());
-        response.data.setObj(showInputsOnly);
+        commandParameters.response.console.log(TextUtils.prettyJson(showInputsOnly).trim());
+        commandParameters.response.data.setObj(showInputsOnly);
 
         return;
     }

--- a/packages/imperative/src/cmd/src/CommandProcessor.ts
+++ b/packages/imperative/src/cmd/src/CommandProcessor.ts
@@ -645,66 +645,75 @@ export class CommandProcessor {
 
             let bufferedStdOut = Buffer.from([]);
             let bufferedStdErr = Buffer.from([]);
-            this.log.debug("Attempting to invoke %d chained handlers for command: '%s'", this.definition.chainedHandlers.length,
-                this.definition.name);
-            for (let chainedHandlerIndex = 0; chainedHandlerIndex < this.definition.chainedHandlers.length; chainedHandlerIndex++) {
-                const chainedHandler = this.definition.chainedHandlers[chainedHandlerIndex];
-                this.log.debug("Loading chained handler '%s' (%d of %d)",
-                    chainedHandler.handler, chainedHandlerIndex + 1, this.definition.chainedHandlers.length);
-                const handler: ICommandHandler = this.attemptHandlerLoad(response, chainedHandler.handler);
-                if (handler == null) {
-                    // if the handler load failed
-                    this.log.fatal("failed to load a chained handler! aborting chained handler sequence.");
-                    return this.finishResponse(response);
-                }
-                this.log.debug("Constructing new response object for handler '%s': silent?: %s. json?: %s",
-                    chainedHandler.handler, chainedHandler.silent + "", params.arguments[Constants.JSON_OPTION] + "");
-                chainedResponse = this.constructResponseObject({
-                    arguments: params.arguments,
-                    silent: chainedHandler.silent,
-                    responseFormat: params.arguments[Constants.JSON_OPTION] ? "json" : "default"
-                });
-
-                // make sure the new chained response preserves output
-                chainedResponse.bufferStdout(bufferedStdOut);
-                chainedResponse.bufferStderr(bufferedStdErr);
-                const handlerParms: IHandlerParameters = {
-                    response: chainedResponse,
-                    arguments: ChainedHandlerService.getArguments(
-                        this.mCommandRootName,
-                        this.definition.chainedHandlers,
-                        chainedHandlerIndex,
-                        chainedResponses,
-                        preparedArgs,
-                        this.log
-                    ),
+            if (preparedArgs.showInputsOnly) {
+                this.showInputsOnly(response, {
+                    response,
+                    arguments: preparedArgs,
                     positionals: preparedArgs._,
                     definition: this.definition,
                     fullDefinition: this.fullDefinition,
-                    stdin: this.getStdinStream(),
-                    isChained: true
-                };
-                try {
-                    // showInputsOnly gets lost on handlerParms.arguments, so use preparedArgs instead
-                    if (preparedArgs.showInputsOnly) {
-                        this.showInputsOnly(chainedResponse, handlerParms);
-                    } else {
-                        await handler.process(handlerParms);
+                    stdin: this.getStdinStream()
+                });
+                response.succeeded();
+                response.endProgressBar();
+                return this.finishResponse(response);
+            } else {
+                this.log.debug("Attempting to invoke %d chained handlers for command: '%s'", this.definition.chainedHandlers.length,
+                    this.definition.name);
+                for (let chainedHandlerIndex = 0; chainedHandlerIndex < this.definition.chainedHandlers.length; chainedHandlerIndex++) {
+                    const chainedHandler = this.definition.chainedHandlers[chainedHandlerIndex];
+                    this.log.debug("Loading chained handler '%s' (%d of %d)",
+                        chainedHandler.handler, chainedHandlerIndex + 1, this.definition.chainedHandlers.length);
+                    const handler: ICommandHandler = this.attemptHandlerLoad(response, chainedHandler.handler);
+                    if (handler == null) {
+                        // if the handler load failed
+                        this.log.fatal("failed to load a chained handler! aborting chained handler sequence.");
+                        return this.finishResponse(response);
+                    }
+                    this.log.debug("Constructing new response object for handler '%s': silent?: %s. json?: %s",
+                        chainedHandler.handler, chainedHandler.silent + "", params.arguments[Constants.JSON_OPTION] + "");
+                    chainedResponse = this.constructResponseObject({
+                        arguments: params.arguments,
+                        silent: chainedHandler.silent,
+                        responseFormat: params.arguments[Constants.JSON_OPTION] ? "json" : "default"
+                    });
+
+                    // make sure the new chained response preserves output
+                    chainedResponse.bufferStdout(bufferedStdOut);
+                    chainedResponse.bufferStderr(bufferedStdErr);
+
+                    try {
+                        await handler.process({
+                            response: chainedResponse,
+                            arguments: ChainedHandlerService.getArguments(
+                                this.mCommandRootName,
+                                this.definition.chainedHandlers,
+                                chainedHandlerIndex,
+                                chainedResponses,
+                                preparedArgs,
+                                this.log
+                            ),
+                            positionals: preparedArgs._,
+                            definition: this.definition,
+                            fullDefinition: this.fullDefinition,
+                            stdin: this.getStdinStream(),
+                            isChained: true
+                        });
                         const builtResponse = chainedResponse.buildJsonResponse();
                         chainedResponses.push(builtResponse.data);
                         // save the stdout and stderr to pass to the next chained handler (if any)
                         bufferedStdOut = builtResponse.stdout;
                         bufferedStdErr = builtResponse.stderr;
+                    } catch (processErr) {
+                        this.handleHandlerError(processErr, chainedResponse, chainedHandler.handler);
+
+                        // Return the failed response to the caller
+                        return this.finishResponse(chainedResponse);
                     }
-                } catch (processErr) {
-                    this.handleHandlerError(processErr, chainedResponse, chainedHandler.handler);
-
-                    // Return the failed response to the caller
-                    return this.finishResponse(chainedResponse);
                 }
-            }
 
-            this.log.info(`Chained handlers for command "${this.definition.name}" succeeded.`);
+                this.log.info(`Chained handlers for command "${this.definition.name}" succeeded.`);
+            }
             response.succeeded();
             response.endProgressBar();
 
@@ -815,8 +824,8 @@ export class CommandProcessor {
         /**
          * Show the inputs
          */
-        commandParameters.response.console.log(TextUtils.prettyJson(showInputsOnly).trim());
-        commandParameters.response.data.setObj(showInputsOnly);
+        response.console.log(TextUtils.prettyJson(showInputsOnly).trim());
+        response.data.setObj(showInputsOnly);
 
         return;
     }

--- a/packages/zosfiles/src/methods/copy/Copy.ts
+++ b/packages/zosfiles/src/methods/copy/Copy.ts
@@ -298,6 +298,7 @@ export class Copy {
             }
             const truncatedMembersFile = path.join(tmpdir(), 'truncatedMembers.txt');
             if(truncatedMembers.length > 0) {
+                // eslint-disable-next-line @typescript-eslint/no-magic-numbers
                 const firstTenMembers = truncatedMembers.slice(0, 10);
                 fs.writeFileSync(truncatedMembersFile, truncatedMembers.join('\n'), {flag: 'w'});
                 const numMembers = truncatedMembers.length - firstTenMembers.length;


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->
Resolves #2446
Removed `response` variable on `showInputsOnly` as it is present in the handler that gets passed in

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [x] added/updated automated tests
- [x] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
