### PR TITLE
Added authentication type to command response for --show-inputs-only

### DIFF
--- a/packages/imperative/src/cmd/src/CommandProcessor.ts
+++ b/packages/imperative/src/cmd/src/CommandProcessor.ts
@@ -44,6 +44,8 @@ import { IDaemonContext } from "../../imperative/src/doc/IDaemonContext";
 import { IHandlerResponseApi } from "./doc/response/api/handler/IHandlerResponseApi";
 import { Censor } from "../../censor/src/Censor";
 import { EnvironmentalVariableSettings } from "../../imperative/src/env/EnvironmentalVariableSettings";
+import { AbstractSession } from "../../rest/src/session/AbstractSession";
+import { ConnectionPropsForSessCfg, ISession } from "../../rest";
 
 
 /**
@@ -78,7 +80,7 @@ interface IResolvedArgsResponse {
      * @type {string[]}
      * @memberof IResolvedArgsResponse
      */
-    locations?: string[]
+    locations?: string[];
 }
 
 /**
@@ -782,12 +784,16 @@ export class CommandProcessor {
         const secureInputs: Set<string> = new Set([...configSecureProps]);
         let censored = false;
 
+        const sessCfg: ISession = {};
+        ConnectionPropsForSessCfg.resolveSessCfgProps(sessCfg, commandParameters.arguments);
+        showInputsOnly.commandValues["authentication type"] = sessCfg.type;
+
         /**
          * Only attempt to show the input if it is in the command definition
          */
         for (let i = 0; i < commandParameters.definition.options?.length; i++) {
             const name = commandParameters.definition.options[i].name;
-
+            // console.log(commandParameters.definition.options[i]);
             if (commandParameters.arguments[name] != null) {
 
                 if (showSecure || !secureInputs.has(name)) {


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->
Added a line to `--show-inputs-only` output that displays the authentication used for the command.

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->
Use a command with `--show-inputs-only` to view the authentication type.

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [x] added/updated automated tests
- [ ] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
