### PR TITLE
Fix Daemon degradation due to Censor.mSchema array never being cleared

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Change Log
 All notable changes to the Zowe CLI package will be documented in this file.
 
+## Recent Changes
+
+- BugFix: Fixed a bug that resulted in daemon commands running slower with every additional command. [#2470](https://github.com/zowe/zowe-cli/issues/2470)
+
 ## `8.16.0`
 
 - Enhancement: Add the ability to search data sets with regex patterns by passing `--regex` into the search command. [#2432](https://github.com/zowe/zowe-cli/issues/2432)

--- a/packages/imperative/CHANGELOG.md
+++ b/packages/imperative/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Imperative package will be documented in this file.
 
+## Recent Changes
+
+- BugFix: Fixed a bug that resulted in daemon commands running slower with every additional command. [#2470](https://github.com/zowe/zowe-cli/issues/2470)
+
 ## `8.16.0`
 
 - Enhancement: Added a line to the output to display the authentication type when using the `--show-inputs-only` option. [#2462] (https://github.com/zowe/zowe-cli/issues/2462)

--- a/packages/imperative/src/censor/__tests__/Censor.unit.test.ts
+++ b/packages/imperative/src/censor/__tests__/Censor.unit.test.ts
@@ -790,6 +790,79 @@ describe("Censor tests", () => {
             expect(Censor.CENSORED_OPTIONS).not.toContain("t");
         });
 
+        it("should clear a previously stored schema if a new one is specified", () => {
+            (Censor as any).mSchema = [{
+                type: "test",
+                schema: {
+                    title: "Fake Profile Type",
+                    description: "Fake Profile Description",
+                    type: "object",
+                    properties: {
+                        test: {
+                            type: "string",
+                            secure: true,
+                            optionDefinitions: [{
+                                name: "test1",
+                                type: "string",
+                                description: "Fake Test Description"
+                            }, {
+                                name: "test2",
+                                type: "string",
+                                description: "Fake Test Description",
+                                aliases: ["t"]
+                            }, {
+                                name: "test3",
+                                type: "string",
+                                description: "Fake Test Description"
+                            }]
+                        }
+                    }
+                }
+            }];
+
+            const censorOpts: ICensorOptions = {
+                profiles: [{
+                    type: "test",
+                    schema: {
+                        title: "Fake Profile Type",
+                        description: "Fake Profile Description",
+                        type: "object",
+                        properties: {
+                            test: {
+                                type: "string",
+                                secure: true,
+                                optionDefinitions: [{
+                                    name: "test1",
+                                    type: "string",
+                                    description: "Fake Test Description"
+                                }, {
+                                    name: "test2",
+                                    type: "string",
+                                    description: "Fake Test Description",
+                                    aliases: ["t"]
+                                }]
+                            }
+                        }
+                    }
+                }],
+                commandDefinition: {
+                    name: "test",
+                    description: "test",
+                    type: "command",
+                    profile: {
+                        required: ["test"]
+                    }
+                },
+            };
+
+            Censor.setCensoredOptions(censorOpts);
+
+            expect(Censor.CENSORED_OPTIONS).toContain("test1");
+            expect(Censor.CENSORED_OPTIONS).toContain("test2");
+            expect(Censor.CENSORED_OPTIONS).toContain("t");
+            expect(Censor.CENSORED_OPTIONS).not.toContain("test3");
+        });
+
         it("should apply a config without command definitions", () => {
             const censorOpts: ICensorOptions = {
                 config: {

--- a/packages/imperative/src/censor/src/Censor.ts
+++ b/packages/imperative/src/censor/src/Censor.ts
@@ -209,7 +209,7 @@ export class Censor {
             this.mConfig = censorOpts.config;
 
             // If we have a ProfileTypeConfiguration (i.e. ImperativeConfig.instance.loadedConfig.profiles)
-            if (censorOpts.profiles) { this.setProfileSchemas(censorOpts.profiles); }
+            if (censorOpts.profiles) { this.mSchema = []; this.setProfileSchemas(censorOpts.profiles); }
 
             for (const profileType of this.profileSchemas ?? []) {
                 // If we know the command we are running, and we know the profile types that the command uses


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->
Fixes #2470

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->
Build the branch, and run the Zowe Daemon repeatedly using the same script as was provided in the issue.

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [x] added/updated automated tests
- [x] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
