### PR TITLE
feat: Add `attributes, recall, volume` options to `List.dataSetsMatchingPattern`

### DIFF
--- a/packages/cli/__tests__/zosfiles/__system__/search/ds/cli.files.search.ds.system.test.ts
+++ b/packages/cli/__tests__/zosfiles/__system__/search/ds/cli.files.search.ds.system.test.ts
@@ -148,13 +148,13 @@ describe("Search Data Sets", () => {
                 "--rfj"
             ]);
             const expectedApiResponse = [
-                {dsn: `${dsnPrefix}.PDS1`, member: "MEM2", matchList: [{line: 1, column: 41, contents: goodTestString}]},
-                {dsn: `${dsnPrefix}.PDS1`, member: "MEM3", matchList: [{line: 1, column: 41, contents: goodTestString}]},
-                {dsn: `${dsnPrefix}.PDS2`, member: "MEM2", matchList: [{line: 1, column: 41, contents: goodTestString}]},
-                {dsn: `${dsnPrefix}.PDS2`, member: "MEM3", matchList: [{line: 1, column: 41, contents: goodTestString}]},
-                {dsn: `${dsnPrefix}.SEQ1`, matchList: [{line: 1, column: 41, contents: goodTestString}]},
-                {dsn: `${dsnPrefix}.SEQ4`, matchList: [{line: 1, column: 41, contents: goodTestString}]},
-                {dsn: `${dsnPrefix}.SEQ5`, matchList: [{line: 1, column: 41, contents: goodTestString}]},
+                {dsn: `${dsnPrefix}.PDS1`, member: "MEM2", matchList: [{line: 1, column: 41, contents: goodTestString, length: 8 }]},
+                {dsn: `${dsnPrefix}.PDS1`, member: "MEM3", matchList: [{line: 1, column: 41, contents: goodTestString, length: 8 }]},
+                {dsn: `${dsnPrefix}.PDS2`, member: "MEM2", matchList: [{line: 1, column: 41, contents: goodTestString, length: 8 }]},
+                {dsn: `${dsnPrefix}.PDS2`, member: "MEM3", matchList: [{line: 1, column: 41, contents: goodTestString, length: 8 }]},
+                {dsn: `${dsnPrefix}.SEQ1`, matchList: [{line: 1, column: 41, contents: goodTestString, length: 8 }]},
+                {dsn: `${dsnPrefix}.SEQ4`, matchList: [{line: 1, column: 41, contents: goodTestString, length: 8 }]},
+                {dsn: `${dsnPrefix}.SEQ5`, matchList: [{line: 1, column: 41, contents: goodTestString, length: 8 }]},
             ];
 
             expect(response.stderr.toString()).toBe("");
@@ -380,13 +380,13 @@ describe("Search Data Sets", () => {
         it("should search and find the correct data sets rfj", async () => {
             const response = runCliScript(shellScript, TEST_ENVIRONMENT, [pattern, searchString, "--rfj"]);
             const expectedApiResponse = [
-                {dsn: `${dsnPrefix}.PDS1`, member: "MEM2", matchList: [{line: 1, column: 41, contents: goodTestString}]},
-                {dsn: `${dsnPrefix}.PDS1`, member: "MEM3", matchList: [{line: 1, column: 41, contents: goodTestString}]},
-                {dsn: `${dsnPrefix}.PDS2`, member: "MEM2", matchList: [{line: 1, column: 41, contents: goodTestString}]},
-                {dsn: `${dsnPrefix}.PDS2`, member: "MEM3", matchList: [{line: 1, column: 41, contents: goodTestString}]},
-                {dsn: `${dsnPrefix}.SEQ1`, matchList: [{line: 1, column: 41, contents: goodTestString}]},
-                {dsn: `${dsnPrefix}.SEQ4`, matchList: [{line: 1, column: 41, contents: goodTestString}]},
-                {dsn: `${dsnPrefix}.SEQ5`, matchList: [{line: 1, column: 41, contents: goodTestString}]},
+                {dsn: `${dsnPrefix}.PDS1`, member: "MEM2", matchList: [{line: 1, column: 41, contents: goodTestString, length: 8}]},
+                {dsn: `${dsnPrefix}.PDS1`, member: "MEM3", matchList: [{line: 1, column: 41, contents: goodTestString, length: 8}]},
+                {dsn: `${dsnPrefix}.PDS2`, member: "MEM2", matchList: [{line: 1, column: 41, contents: goodTestString, length: 8}]},
+                {dsn: `${dsnPrefix}.PDS2`, member: "MEM3", matchList: [{line: 1, column: 41, contents: goodTestString, length: 8}]},
+                {dsn: `${dsnPrefix}.SEQ1`, matchList: [{line: 1, column: 41, contents: goodTestString, length: 8}]},
+                {dsn: `${dsnPrefix}.SEQ4`, matchList: [{line: 1, column: 41, contents: goodTestString, length: 8}]},
+                {dsn: `${dsnPrefix}.SEQ5`, matchList: [{line: 1, column: 41, contents: goodTestString, length: 8}]},
             ];
 
             expect(response.stderr.toString()).toBe("");

--- a/packages/cli/__tests__/zosfiles/__unit__/download/dsm/DataSetMatching.handler.unit.test.ts
+++ b/packages/cli/__tests__/zosfiles/__unit__/download/dsm/DataSetMatching.handler.unit.test.ts
@@ -23,6 +23,7 @@ const DEFAULT_PARAMETERS: IHandlerParameters = mockHandlerParameters({
 });
 
 const fakeListOptions: IDsmListOptions = {
+    attributes: true,
     task: {
         percentComplete: 0,
         stageName: 0,

--- a/packages/cli/src/zosfiles/download/dsm/DataSetMatching.handler.ts
+++ b/packages/cli/src/zosfiles/download/dsm/DataSetMatching.handler.ts
@@ -40,6 +40,7 @@ export default class DataSetMatchingHandler extends ZosFilesBaseHandler {
             stageName: TaskStage.IN_PROGRESS
         };
         const listOptions: IDsmListOptions = {
+            attributes: true,
             excludePatterns: commandParameters.arguments.excludePatterns?.split(","),
             maxConcurrentRequests: commandParameters.arguments.maxConcurrentRequests,
             task: listStatus,

--- a/packages/zosfiles/CHANGELOG.md
+++ b/packages/zosfiles/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Zowe z/OS files SDK package will be documented in this file.
 
+## Recent Changes
+
+- Enhancement: Added support for the `attributes`, `recall`, and `volume` options to the `List.dataSetsMatchingPattern` function. [#2476](https://github.com/zowe/zowe-cli/issues/2476)
+
 ## `8.17.0`
 
 - Enhancement: Adding the `responseTimeout` option to missing areas in the ZosFiles SDK so that the option is allowable on all methods. [#2467](https://github.com/zowe/zowe-cli/pull/2467)

--- a/packages/zosfiles/__tests__/__system__/methods/list/List.system.test.ts
+++ b/packages/zosfiles/__tests__/__system__/methods/list/List.system.test.ts
@@ -1138,8 +1138,8 @@ describe("List command group - encoded", () => {
             expect(response.commandResponse).toContain(format(ZosFilesMessages.dataSetsMatchedPattern.message, 3));
             expect(response.apiResponse.length).toBe(3);
             expect(response.apiResponse[0].dsname).toBe(dsname);
-            expect(response.apiResponse[1].dsname).toBe(dsname + ".LIKE");
-            expect(response.apiResponse[2].dsname).toBe(dsname + ".DIFFVOL");
+            expect(response.apiResponse[1].dsname).toBe(dsname + ".DIFFVOL");
+            expect(response.apiResponse[2].dsname).toBe(dsname + ".LIKE");
         });
 
         it("should not return attributes when attributes option is falsy", async () => {
@@ -1161,8 +1161,8 @@ describe("List command group - encoded", () => {
                 expect(Object.keys(item).length).toBe(1);
             }
             expect(response.apiResponse[0].dsname).toBe(dsname);
-            expect(response.apiResponse[1].dsname).toBe(dsname + ".LIKE");
-            expect(response.apiResponse[2].dsname).toBe(dsname + ".DIFFVOL");
+            expect(response.apiResponse[1].dsname).toBe(dsname + ".DIFFVOL");
+            expect(response.apiResponse[2].dsname).toBe(dsname + ".LIKE");
         });
 
         it("should return attributes when attributes option is true", async () => {
@@ -1185,27 +1185,8 @@ describe("List command group - encoded", () => {
                 expect(item["dsorg"]).toBeDefined();
             }
             expect(response.apiResponse[0].dsname).toBe(dsname);
-            expect(response.apiResponse[1].dsname).toBe(dsname + ".LIKE");
-            expect(response.apiResponse[2].dsname).toBe(dsname + ".DIFFVOL");
-        });
-
-        it("should only return data sets matching given volume", async () => {
-            let response;
-            let caughtError;
-
-            try {
-                response = await List.dataSetsMatchingPattern(REAL_SESSION, [dsname], { volume: defaultSystem.datasets.vol });
-            } catch (error) {
-                caughtError = error;
-            }
-
-            expect(caughtError).toBeUndefined();
-            expect(response).toBeDefined();
-            expect(response.success).toBe(true);
-            expect(response.commandResponse).toContain(format(ZosFilesMessages.dataSetsMatchedPattern.message, 2));
-            expect(response.apiResponse.length).toBe(2);
-            expect(response.apiResponse[0].dsname).toBe(dsname);
-            expect(response.apiResponse[1].dsname).toBe(dsname + ".LIKE");
+            expect(response.apiResponse[1].dsname).toBe(dsname + ".DIFFVOL");
+            expect(response.apiResponse[2].dsname).toBe(dsname + ".LIKE");
         });
 
         it("should find one data set when listing 2 patterns with maxLength = 1", async () => {

--- a/packages/zosfiles/__tests__/__system__/methods/list/List.system.test.ts
+++ b/packages/zosfiles/__tests__/__system__/methods/list/List.system.test.ts
@@ -1109,7 +1109,6 @@ describe("List command group - encoded", () => {
             await wait(waitTime);
             await Create.dataSet(REAL_SESSION, CreateDataSetTypeEnum.DATA_SET_SEQUENTIAL, dsname + ".LIKE",
                 { volser: defaultSystem.datasets.vol });
-            await Create.dataSet(REAL_SESSION, CreateDataSetTypeEnum.DATA_SET_SEQUENTIAL, dsname + ".DIFFVOL");
             await wait(waitTime);
         });
 
@@ -1117,8 +1116,6 @@ describe("List command group - encoded", () => {
             await Delete.dataSet(REAL_SESSION, dsname);
             await wait(waitTime);
             await Delete.dataSet(REAL_SESSION, dsname + ".LIKE");
-            await wait(waitTime);
-            await Delete.dataSet(REAL_SESSION, dsname + ".DIFFVOL");
             await wait(waitTime);
         });
 
@@ -1135,11 +1132,10 @@ describe("List command group - encoded", () => {
             expect(caughtError).toBeUndefined();
             expect(response).toBeDefined();
             expect(response.success).toBe(true);
-            expect(response.commandResponse).toContain(format(ZosFilesMessages.dataSetsMatchedPattern.message, 3));
-            expect(response.apiResponse.length).toBe(3);
+            expect(response.commandResponse).toContain(format(ZosFilesMessages.dataSetsMatchedPattern.message, 2));
+            expect(response.apiResponse.length).toBe(2);
             expect(response.apiResponse[0].dsname).toBe(dsname);
-            expect(response.apiResponse[1].dsname).toBe(dsname + ".DIFFVOL");
-            expect(response.apiResponse[2].dsname).toBe(dsname + ".LIKE");
+            expect(response.apiResponse[1].dsname).toBe(dsname + ".LIKE");
         });
 
         it("should not return attributes when attributes option is falsy", async () => {
@@ -1155,14 +1151,13 @@ describe("List command group - encoded", () => {
             expect(caughtError).toBeUndefined();
             expect(response).toBeDefined();
             expect(response.success).toBe(true);
-            expect(response.commandResponse).toContain(format(ZosFilesMessages.dataSetsMatchedPattern.message, 3));
-            expect(response.apiResponse.length).toBe(3);
+            expect(response.commandResponse).toContain(format(ZosFilesMessages.dataSetsMatchedPattern.message, 2));
+            expect(response.apiResponse.length).toBe(2);
             for (const item of response.apiResponse) {
                 expect(Object.keys(item).length).toBe(1);
             }
             expect(response.apiResponse[0].dsname).toBe(dsname);
-            expect(response.apiResponse[1].dsname).toBe(dsname + ".DIFFVOL");
-            expect(response.apiResponse[2].dsname).toBe(dsname + ".LIKE");
+            expect(response.apiResponse[1].dsname).toBe(dsname + ".LIKE");
         });
 
         it("should return attributes when attributes option is true", async () => {
@@ -1178,15 +1173,14 @@ describe("List command group - encoded", () => {
             expect(caughtError).toBeUndefined();
             expect(response).toBeDefined();
             expect(response.success).toBe(true);
-            expect(response.commandResponse).toContain(format(ZosFilesMessages.dataSetsMatchedPattern.message, 3));
-            expect(response.apiResponse.length).toBe(3);
+            expect(response.commandResponse).toContain(format(ZosFilesMessages.dataSetsMatchedPattern.message, 2));
+            expect(response.apiResponse.length).toBe(2);
             for (const item of response.apiResponse) {
                 expect(Object.keys(item).length).toBeGreaterThan(1);
                 expect(item["dsorg"]).toBeDefined();
             }
             expect(response.apiResponse[0].dsname).toBe(dsname);
-            expect(response.apiResponse[1].dsname).toBe(dsname + ".DIFFVOL");
-            expect(response.apiResponse[2].dsname).toBe(dsname + ".LIKE");
+            expect(response.apiResponse[1].dsname).toBe(dsname + ".LIKE");
         });
 
         it("should find one data set when listing 2 patterns with maxLength = 1", async () => {
@@ -1221,10 +1215,9 @@ describe("List command group - encoded", () => {
             expect(caughtError).toBeUndefined();
             expect(response).toBeDefined();
             expect(response.success).toBe(true);
-            expect(response.commandResponse).toContain(format(ZosFilesMessages.dataSetsMatchedPattern.message, 2));
-            expect(response.apiResponse.length).toBe(2);
+            expect(response.commandResponse).toContain(format(ZosFilesMessages.dataSetsMatchedPattern.message, 1));
+            expect(response.apiResponse.length).toBe(1);
             expect(response.apiResponse[0].dsname).toBe(dsname);
-            expect(response.apiResponse[1].dsname).toBe(dsname + ".DIFFVOL");
         });
 
         it("should fail when no data sets match", async () => {

--- a/packages/zosfiles/__tests__/__system__/methods/search/Search.system.test.ts
+++ b/packages/zosfiles/__tests__/__system__/methods/search/Search.system.test.ts
@@ -110,13 +110,13 @@ describe("Search", () => {
             };
 
             expectedApiResponse = [
-                {dsn: `${dsnPrefix}.PDS1`, member: "MEM2", matchList: [{line: 1, column: 39, contents: goodTestString}]},
-                {dsn: `${dsnPrefix}.PDS1`, member: "MEM3", matchList: [{line: 1, column: 39, contents: goodTestString}]},
-                {dsn: `${dsnPrefix}.PDS2`, member: "MEM2", matchList: [{line: 1, column: 39, contents: goodTestString}]},
-                {dsn: `${dsnPrefix}.PDS2`, member: "MEM3", matchList: [{line: 1, column: 39, contents: goodTestString}]},
-                {dsn: `${dsnPrefix}.SEQ1`, matchList: [{line: 1, column: 39, contents: goodTestString}]},
-                {dsn: `${dsnPrefix}.SEQ4`, matchList: [{line: 1, column: 39, contents: goodTestString}]},
-                {dsn: `${dsnPrefix}.SEQ5`, matchList: [{line: 1, column: 39, contents: goodTestString}]},
+                {dsn: `${dsnPrefix}.PDS1`, member: "MEM2", matchList: [{line: 1, column: 39, contents: goodTestString, length: 8}]},
+                {dsn: `${dsnPrefix}.PDS1`, member: "MEM3", matchList: [{line: 1, column: 39, contents: goodTestString, length: 8}]},
+                {dsn: `${dsnPrefix}.PDS2`, member: "MEM2", matchList: [{line: 1, column: 39, contents: goodTestString, length: 8}]},
+                {dsn: `${dsnPrefix}.PDS2`, member: "MEM3", matchList: [{line: 1, column: 39, contents: goodTestString, length: 8}]},
+                {dsn: `${dsnPrefix}.SEQ1`, matchList: [{line: 1, column: 39, contents: goodTestString, length: 8}]},
+                {dsn: `${dsnPrefix}.SEQ4`, matchList: [{line: 1, column: 39, contents: goodTestString, length: 8}]},
+                {dsn: `${dsnPrefix}.SEQ5`, matchList: [{line: 1, column: 39, contents: goodTestString, length: 8}]},
             ];
 
             jest.restoreAllMocks();

--- a/packages/zosfiles/__tests__/__unit__/methods/list/List.unit.test.ts
+++ b/packages/zosfiles/__tests__/__unit__/methods/list/List.unit.test.ts
@@ -1376,7 +1376,7 @@ describe("z/OS Files - List", () => {
             });
 
             try {
-                response = await List.dataSetsMatchingPattern(dummySession, [pattern], { maxLength: 2 });
+                response = await List.dataSetsMatchingPattern(dummySession, [pattern], { attributes: true, maxLength: 2 });
             } catch (e) {
                 caughtError = e;
             }
@@ -1390,6 +1390,96 @@ describe("z/OS Files - List", () => {
 
             expect(listDataSetSpy).toHaveBeenCalledTimes(1);
             expect(listDataSetSpy).toHaveBeenCalledWith(dummySession, pattern, { attributes: true, maxLength: 2 });
+        });
+
+        it("should pass attributes option to List.dataSet API", async () => {
+            const pattern = "TEST.**.DATA.SET";
+            let response;
+            let caughtError;
+
+            listDataSetSpy.mockImplementation(async (): Promise<any> => {
+                return {
+                    apiResponse: {
+                        items: [{ dsname: dataSetPS.dsname }, { dsname: dataSetPO.dsname }]
+                    }
+                };
+            });
+
+            try {
+                response = await List.dataSetsMatchingPattern(dummySession, [pattern], { attributes: false });
+            } catch (e) {
+                caughtError = e;
+            }
+
+            expect(caughtError).toBeUndefined();
+            expect(response).toEqual({
+                success: true,
+                commandResponse: util.format(ZosFilesMessages.dataSetsMatchedPattern.message, 2),
+                apiResponse: [{ dsname: dataSetPS.dsname }, { dsname: dataSetPO.dsname }]
+            });
+
+            expect(listDataSetSpy).toHaveBeenCalledTimes(1);
+            expect(listDataSetSpy).toHaveBeenCalledWith(dummySession, pattern, { attributes: false });
+        });
+
+        it("should pass volume option to List.dataSet API", async () => {
+            const pattern = "TEST.**.DATA.SET";
+            let response;
+            let caughtError;
+
+            listDataSetSpy.mockImplementation(async (): Promise<any> => {
+                return {
+                    apiResponse: {
+                        items: [{ dsname: dataSetPS.dsname }, { dsname: dataSetPO.dsname }]
+                    }
+                };
+            });
+
+            try {
+                response = await List.dataSetsMatchingPattern(dummySession, [pattern], { volume: "USER01" });
+            } catch (e) {
+                caughtError = e;
+            }
+
+            expect(caughtError).toBeUndefined();
+            expect(response).toEqual({
+                success: true,
+                commandResponse: util.format(ZosFilesMessages.dataSetsMatchedPattern.message, 2),
+                apiResponse: [{ dsname: dataSetPS.dsname }, { dsname: dataSetPO.dsname }]
+            });
+
+            expect(listDataSetSpy).toHaveBeenCalledTimes(1);
+            expect(listDataSetSpy).toHaveBeenCalledWith(dummySession, pattern, { volume: "USER01" });
+        });
+
+        it("should pass recall option to List.dataSet API", async () => {
+            const pattern = "TEST.**.DATA.SET";
+            let response;
+            let caughtError;
+
+            listDataSetSpy.mockImplementation(async (): Promise<any> => {
+                return {
+                    apiResponse: {
+                        items: [{ dsname: dataSetPS.dsname }, { dsname: dataSetPO.dsname }]
+                    }
+                };
+            });
+
+            try {
+                response = await List.dataSetsMatchingPattern(dummySession, [pattern], { recall: "nowait" });
+            } catch (e) {
+                caughtError = e;
+            }
+
+            expect(caughtError).toBeUndefined();
+            expect(response).toEqual({
+                success: true,
+                commandResponse: util.format(ZosFilesMessages.dataSetsMatchedPattern.message, 2),
+                apiResponse: [{ dsname: dataSetPS.dsname }, { dsname: dataSetPO.dsname }]
+            });
+
+            expect(listDataSetSpy).toHaveBeenCalledTimes(1);
+            expect(listDataSetSpy).toHaveBeenCalledWith(dummySession, pattern, { recall: "nowait" });
         });
 
         it("should pass start option to List.dataSet API", async () => {
@@ -1406,7 +1496,7 @@ describe("z/OS Files - List", () => {
             });
 
             try {
-                response = await List.dataSetsMatchingPattern(dummySession, [pattern], { start: dataSetPO.dsname });
+                response = await List.dataSetsMatchingPattern(dummySession, [pattern], { attributes: true, start: dataSetPO.dsname });
             } catch (e) {
                 caughtError = e;
             }
@@ -1436,7 +1526,7 @@ describe("z/OS Files - List", () => {
             });
 
             try {
-                response = await List.dataSetsMatchingPattern(dummySession, [pattern]);
+                response = await List.dataSetsMatchingPattern(dummySession, [pattern], { attributes: true });
             } catch (e) {
                 caughtError = e;
             }
@@ -1449,7 +1539,7 @@ describe("z/OS Files - List", () => {
             });
 
             expect(listDataSetSpy).toHaveBeenCalledTimes(1);
-            expect(listDataSetSpy).toHaveBeenCalledWith(dummySession, pattern, {attributes: true});
+            expect(listDataSetSpy).toHaveBeenCalledWith(dummySession, pattern, { attributes: true });
         });
 
         it("should throw an error if the data set name is not specified", async () => {
@@ -1502,7 +1592,7 @@ describe("z/OS Files - List", () => {
             });
 
             try {
-                response = await List.dataSetsMatchingPattern(dummySession, [dataSetPS.dsname]);
+                response = await List.dataSetsMatchingPattern(dummySession, [dataSetPS.dsname], { attributes: true });
             } catch (e) {
                 caughtError = e;
             }
@@ -1540,7 +1630,7 @@ describe("z/OS Files - List", () => {
             });
 
             try {
-                response = await List.dataSetsMatchingPattern(dummySession, [dataSetPS.dsname]);
+                response = await List.dataSetsMatchingPattern(dummySession, [dataSetPS.dsname], { attributes: true });
             } catch (e) {
                 caughtError = e;
             }

--- a/packages/zosfiles/__tests__/__unit__/methods/search/Search.unit.test.ts
+++ b/packages/zosfiles/__tests__/__unit__/methods/search/Search.unit.test.ts
@@ -215,7 +215,7 @@ describe("Search", () => {
             const response = await Search.dataSets(dummySession, searchOptions);
 
             expect(listDataSetsMatchingPatternSpy).toHaveBeenCalledTimes(1);
-            expect(listDataSetsMatchingPatternSpy).toHaveBeenCalledWith(dummySession, ["TEST*"], {maxConcurrentRequests: 1});
+            expect(listDataSetsMatchingPatternSpy).toHaveBeenCalledWith(dummySession, ["TEST*"], {attributes: true, maxConcurrentRequests: 1});
             expect(listAllMembersSpy).toHaveBeenCalledTimes(1);
             expect(listAllMembersSpy).toHaveBeenCalledWith(dummySession, "TEST3.PDS", {});
             expect(searchOnMainframeSpy).toHaveBeenCalledTimes(1);
@@ -261,7 +261,7 @@ describe("Search", () => {
             const response = await Search.dataSets(dummySession, searchOptions);
 
             expect(listDataSetsMatchingPatternSpy).toHaveBeenCalledTimes(1);
-            expect(listDataSetsMatchingPatternSpy).toHaveBeenCalledWith(dummySession, ["TEST*"], {maxConcurrentRequests: 1});
+            expect(listDataSetsMatchingPatternSpy).toHaveBeenCalledWith(dummySession, ["TEST*"], {attributes: true, maxConcurrentRequests: 1});
             expect(listAllMembersSpy).toHaveBeenCalledTimes(1);
             expect(listAllMembersSpy).toHaveBeenCalledWith(dummySession, "TEST3.PDS", {});
             expect(searchOnMainframeSpy).toHaveBeenCalledTimes(1);
@@ -318,7 +318,7 @@ describe("Search", () => {
             const response = await Search.dataSets(dummySession, searchOptions);
 
             expect(listDataSetsMatchingPatternSpy).toHaveBeenCalledTimes(1);
-            expect(listDataSetsMatchingPatternSpy).toHaveBeenCalledWith(dummySession, ["TEST*"], {maxConcurrentRequests: 1});
+            expect(listDataSetsMatchingPatternSpy).toHaveBeenCalledWith(dummySession, ["TEST*"], {attributes: true, maxConcurrentRequests: 1});
             expect(listAllMembersSpy).toHaveBeenCalledTimes(1);
             expect(listAllMembersSpy).toHaveBeenCalledWith(dummySession, "TEST3.PDS", {});
             expect(searchOnMainframeSpy).toHaveBeenCalledTimes(1);
@@ -370,7 +370,7 @@ describe("Search", () => {
             const response = await Search.dataSets(dummySession, searchOptions);
 
             expect(listDataSetsMatchingPatternSpy).toHaveBeenCalledTimes(1);
-            expect(listDataSetsMatchingPatternSpy).toHaveBeenCalledWith(dummySession, ["TEST*"], {maxConcurrentRequests: 1});
+            expect(listDataSetsMatchingPatternSpy).toHaveBeenCalledWith(dummySession, ["TEST*"], {attributes: true, maxConcurrentRequests: 1});
             expect(listAllMembersSpy).toHaveBeenCalledTimes(1);
             expect(listAllMembersSpy).toHaveBeenCalledWith(dummySession, "TEST3.PDS", {});
             expect(searchOnMainframeSpy).toHaveBeenCalledTimes(1);
@@ -424,7 +424,7 @@ describe("Search", () => {
             const response = await Search.dataSets(dummySession, searchOptions);
 
             expect(listDataSetsMatchingPatternSpy).toHaveBeenCalledTimes(1);
-            expect(listDataSetsMatchingPatternSpy).toHaveBeenCalledWith(dummySession, ["TEST*"], {maxConcurrentRequests: 1});
+            expect(listDataSetsMatchingPatternSpy).toHaveBeenCalledWith(dummySession, ["TEST*"], {attributes: true, maxConcurrentRequests: 1});
             expect(listAllMembersSpy).toHaveBeenCalledTimes(1);
             expect(listAllMembersSpy).toHaveBeenCalledWith(dummySession, "TEST3.PDS", {});
             expect(searchOnMainframeSpy).toHaveBeenCalledTimes(0);
@@ -452,7 +452,7 @@ describe("Search", () => {
             const response = await Search.dataSets(dummySession, searchOptions);
 
             expect(listDataSetsMatchingPatternSpy).toHaveBeenCalledTimes(1);
-            expect(listDataSetsMatchingPatternSpy).toHaveBeenCalledWith(dummySession, ["TEST*"], {maxConcurrentRequests: 1});
+            expect(listDataSetsMatchingPatternSpy).toHaveBeenCalledWith(dummySession, ["TEST*"], {attributes: true, maxConcurrentRequests: 1});
             expect(listAllMembersSpy).toHaveBeenCalledTimes(1);
             expect(listAllMembersSpy).toHaveBeenCalledWith(dummySession, "TEST3.PDS", {});
             expect(searchOnMainframeSpy).toHaveBeenCalledTimes(0);
@@ -480,7 +480,7 @@ describe("Search", () => {
             const response = await Search.dataSets(dummySession, searchOptions);
 
             expect(listDataSetsMatchingPatternSpy).toHaveBeenCalledTimes(1);
-            expect(listDataSetsMatchingPatternSpy).toHaveBeenCalledWith(dummySession, ["TEST*"], {maxConcurrentRequests: 1});
+            expect(listDataSetsMatchingPatternSpy).toHaveBeenCalledWith(dummySession, ["TEST*"], {attributes: true, maxConcurrentRequests: 1});
             expect(listAllMembersSpy).toHaveBeenCalledTimes(1);
             expect(listAllMembersSpy).toHaveBeenCalledWith(dummySession, "TEST3.PDS", {});
             expect(searchOnMainframeSpy).toHaveBeenCalledTimes(0);
@@ -513,7 +513,7 @@ describe("Search", () => {
             const response = await Search.dataSets(dummySession, searchOptions);
 
             expect(listDataSetsMatchingPatternSpy).toHaveBeenCalledTimes(1);
-            expect(listDataSetsMatchingPatternSpy).toHaveBeenCalledWith(dummySession, ["TEST*"], {maxConcurrentRequests: 1});
+            expect(listDataSetsMatchingPatternSpy).toHaveBeenCalledWith(dummySession, ["TEST*"], {attributes: true, maxConcurrentRequests: 1});
             expect(listAllMembersSpy).toHaveBeenCalledTimes(1);
             expect(listAllMembersSpy).toHaveBeenCalledWith(dummySession, "TEST3.PDS", {});
             expect(searchOnMainframeSpy).toHaveBeenCalledTimes(1);
@@ -572,7 +572,7 @@ describe("Search", () => {
             const response = await Search.dataSets(dummySession, searchOptions);
 
             expect(listDataSetsMatchingPatternSpy).toHaveBeenCalledTimes(1);
-            expect(listDataSetsMatchingPatternSpy).toHaveBeenCalledWith(dummySession, ["TEST*"], {maxConcurrentRequests: 1});
+            expect(listDataSetsMatchingPatternSpy).toHaveBeenCalledWith(dummySession, ["TEST*"], {attributes: true, maxConcurrentRequests: 1});
             expect(listAllMembersSpy).toHaveBeenCalledTimes(1);
             expect(listAllMembersSpy).toHaveBeenCalledWith(dummySession, "TEST3.PDS", {});
             expect(searchOnMainframeSpy).toHaveBeenCalledTimes(0);
@@ -605,7 +605,7 @@ describe("Search", () => {
             const response = await Search.dataSets(dummySession, searchOptions);
 
             expect(listDataSetsMatchingPatternSpy).toHaveBeenCalledTimes(1);
-            expect(listDataSetsMatchingPatternSpy).toHaveBeenCalledWith(dummySession, ["TEST*"], {maxConcurrentRequests: 1});
+            expect(listDataSetsMatchingPatternSpy).toHaveBeenCalledWith(dummySession, ["TEST*"], {attributes: true, maxConcurrentRequests: 1});
             expect(listAllMembersSpy).toHaveBeenCalledTimes(1);
             expect(listAllMembersSpy).toHaveBeenCalledWith(dummySession, "TEST3.PDS", {});
             expect(searchOnMainframeSpy).toHaveBeenCalledTimes(0);
@@ -638,7 +638,7 @@ describe("Search", () => {
             const response = await Search.dataSets(dummySession, searchOptions);
 
             expect(listDataSetsMatchingPatternSpy).toHaveBeenCalledTimes(1);
-            expect(listDataSetsMatchingPatternSpy).toHaveBeenCalledWith(dummySession, ["TEST*"], {maxConcurrentRequests: 1});
+            expect(listDataSetsMatchingPatternSpy).toHaveBeenCalledWith(dummySession, ["TEST*"], {attributes: true, maxConcurrentRequests: 1});
             expect(listAllMembersSpy).toHaveBeenCalledTimes(1);
             expect(listAllMembersSpy).toHaveBeenCalledWith(dummySession, "TEST3.PDS", {});
             expect(searchOnMainframeSpy).toHaveBeenCalledTimes(0);
@@ -664,7 +664,7 @@ describe("Search", () => {
             const response = await Search.dataSets(dummySession, searchOptions);
 
             expect(listDataSetsMatchingPatternSpy).toHaveBeenCalledTimes(1);
-            expect(listDataSetsMatchingPatternSpy).toHaveBeenCalledWith(dummySession, ["TEST*"], {maxConcurrentRequests: 1});
+            expect(listDataSetsMatchingPatternSpy).toHaveBeenCalledWith(dummySession, ["TEST*"], {attributes: true, maxConcurrentRequests: 1});
             expect(listAllMembersSpy).toHaveBeenCalledTimes(1);
             expect(listAllMembersSpy).toHaveBeenCalledWith(dummySession, "TEST3.PDS", {});
             expect(searchOnMainframeSpy).toHaveBeenCalledTimes(1);
@@ -695,7 +695,7 @@ describe("Search", () => {
             const response = await Search.dataSets(dummySession, searchOptions);
 
             expect(listDataSetsMatchingPatternSpy).toHaveBeenCalledTimes(1);
-            expect(listDataSetsMatchingPatternSpy).toHaveBeenCalledWith(dummySession, ["TEST*"], {maxConcurrentRequests: 1});
+            expect(listDataSetsMatchingPatternSpy).toHaveBeenCalledWith(dummySession, ["TEST*"], {attributes: true, maxConcurrentRequests: 1});
             expect(listAllMembersSpy).toHaveBeenCalledTimes(1);
             expect(listAllMembersSpy).toHaveBeenCalledWith(dummySession, "TEST3.PDS", {});
             expect(searchOnMainframeSpy).toHaveBeenCalledTimes(1);
@@ -725,7 +725,7 @@ describe("Search", () => {
             const response = await Search.dataSets(dummySession, searchOptions);
 
             expect(listDataSetsMatchingPatternSpy).toHaveBeenCalledTimes(1);
-            expect(listDataSetsMatchingPatternSpy).toHaveBeenCalledWith(dummySession, ["TEST*"], {maxConcurrentRequests: 1});
+            expect(listDataSetsMatchingPatternSpy).toHaveBeenCalledWith(dummySession, ["TEST*"], {attributes: true, maxConcurrentRequests: 1});
             expect(listAllMembersSpy).toHaveBeenCalledTimes(1);
             expect(listAllMembersSpy).toHaveBeenCalledWith(dummySession, "TEST3.PDS", {});
             expect(searchOnMainframeSpy).toHaveBeenCalledTimes(1);
@@ -776,7 +776,7 @@ describe("Search", () => {
             const response = await Search.dataSets(dummySession, searchOptions);
 
             expect(listDataSetsMatchingPatternSpy).toHaveBeenCalledTimes(1);
-            expect(listDataSetsMatchingPatternSpy).toHaveBeenCalledWith(dummySession, ["TEST*"], {maxConcurrentRequests: 1});
+            expect(listDataSetsMatchingPatternSpy).toHaveBeenCalledWith(dummySession, ["TEST*"], {attributes: true, maxConcurrentRequests: 1});
             expect(listAllMembersSpy).toHaveBeenCalledTimes(0);
             expect(searchOnMainframeSpy).toHaveBeenCalledTimes(1);
             expect(searchLocalSpy).toHaveBeenCalledTimes(1);
@@ -811,7 +811,7 @@ describe("Search", () => {
             const response = await Search.dataSets(dummySession, searchOptions);
 
             expect(listDataSetsMatchingPatternSpy).toHaveBeenCalledTimes(1);
-            expect(listDataSetsMatchingPatternSpy).toHaveBeenCalledWith(dummySession, ["TEST*"], {maxConcurrentRequests: 1});
+            expect(listDataSetsMatchingPatternSpy).toHaveBeenCalledWith(dummySession, ["TEST*"], {attributes: true, maxConcurrentRequests: 1});
             expect(listAllMembersSpy).toHaveBeenCalledTimes(1);
             expect(listAllMembersSpy).toHaveBeenCalledWith(dummySession, "TEST3.PDS", {});
             expect(searchOnMainframeSpy).toHaveBeenCalledTimes(1);
@@ -858,7 +858,7 @@ describe("Search", () => {
             const response = await Search.dataSets(dummySession, searchOptions);
 
             expect(listDataSetsMatchingPatternSpy).toHaveBeenCalledTimes(1);
-            expect(listDataSetsMatchingPatternSpy).toHaveBeenCalledWith(dummySession, ["TEST*"], {maxConcurrentRequests: 1});
+            expect(listDataSetsMatchingPatternSpy).toHaveBeenCalledWith(dummySession, ["TEST*"], {attributes: true, maxConcurrentRequests: 1});
             expect(listAllMembersSpy).toHaveBeenCalledTimes(1);
             expect(listAllMembersSpy).toHaveBeenCalledWith(dummySession, "TEST3.PDS", {});
             expect(searchOnMainframeSpy).toHaveBeenCalledTimes(1);
@@ -925,7 +925,7 @@ describe("Search", () => {
             const response = await Search.dataSets(dummySession, searchOptions);
 
             expect(listDataSetsMatchingPatternSpy).toHaveBeenCalledTimes(1);
-            expect(listDataSetsMatchingPatternSpy).toHaveBeenCalledWith(dummySession, ["TEST*"], {maxConcurrentRequests: 1});
+            expect(listDataSetsMatchingPatternSpy).toHaveBeenCalledWith(dummySession, ["TEST*"], {attributes: true, maxConcurrentRequests: 1});
             expect(listAllMembersSpy).toHaveBeenCalledTimes(1);
             expect(listAllMembersSpy).toHaveBeenCalledWith(dummySession, "TEST3.PDS", {});
             expect(searchOnMainframeSpy).toHaveBeenCalledTimes(1);
@@ -975,7 +975,7 @@ describe("Search", () => {
             const response = await Search.dataSets(dummySession, searchOptions);
 
             expect(listDataSetsMatchingPatternSpy).toHaveBeenCalledTimes(1);
-            expect(listDataSetsMatchingPatternSpy).toHaveBeenCalledWith(dummySession, ["TEST*"], {maxConcurrentRequests: 1});
+            expect(listDataSetsMatchingPatternSpy).toHaveBeenCalledWith(dummySession, ["TEST*"], {attributes: true, maxConcurrentRequests: 1});
             expect(listAllMembersSpy).toHaveBeenCalledTimes(1);
             expect(listAllMembersSpy).toHaveBeenCalledWith(dummySession, "TEST3.PDS", {});
             expect(searchOnMainframeSpy).toHaveBeenCalledTimes(1);
@@ -1011,7 +1011,7 @@ describe("Search", () => {
             const response = await Search.dataSets(dummySession, searchOptions);
 
             expect(listDataSetsMatchingPatternSpy).toHaveBeenCalledTimes(1);
-            expect(listDataSetsMatchingPatternSpy).toHaveBeenCalledWith(dummySession, ["TEST*"], {maxConcurrentRequests: 1});
+            expect(listDataSetsMatchingPatternSpy).toHaveBeenCalledWith(dummySession, ["TEST*"], {attributes: true, maxConcurrentRequests: 1});
             expect(listAllMembersSpy).toHaveBeenCalledTimes(1);
             expect(listAllMembersSpy).toHaveBeenCalledWith(dummySession, "TEST3.PDS", {});
             expect(searchOnMainframeSpy).toHaveBeenCalledTimes(1);
@@ -1047,7 +1047,7 @@ describe("Search", () => {
             const response = await Search.dataSets(dummySession, searchOptions);
 
             expect(listDataSetsMatchingPatternSpy).toHaveBeenCalledTimes(1);
-            expect(listDataSetsMatchingPatternSpy).toHaveBeenCalledWith(dummySession, ["TEST*"], {maxConcurrentRequests: 1});
+            expect(listDataSetsMatchingPatternSpy).toHaveBeenCalledWith(dummySession, ["TEST*"], {attributes: true, maxConcurrentRequests: 1});
             expect(listAllMembersSpy).toHaveBeenCalledTimes(0);
             expect(searchOnMainframeSpy).toHaveBeenCalledTimes(1);
             expect(searchLocalSpy).toHaveBeenCalledTimes(1);
@@ -1072,7 +1072,7 @@ describe("Search", () => {
             }
 
             expect(listDataSetsMatchingPatternSpy).toHaveBeenCalledTimes(1);
-            expect(listDataSetsMatchingPatternSpy).toHaveBeenCalledWith(dummySession, ["TEST*"], {maxConcurrentRequests: 1});
+            expect(listDataSetsMatchingPatternSpy).toHaveBeenCalledWith(dummySession, ["TEST*"], {attributes: true, maxConcurrentRequests: 1});
             expect(listAllMembersSpy).toHaveBeenCalledTimes(0);
             expect(searchOnMainframeSpy).toHaveBeenCalledTimes(0);
             expect(searchLocalSpy).toHaveBeenCalledTimes(0);
@@ -1111,7 +1111,7 @@ describe("Search", () => {
             const response = await Search.dataSets(dummySession, searchOptions);
 
             expect(listDataSetsMatchingPatternSpy).toHaveBeenCalledTimes(1);
-            expect(listDataSetsMatchingPatternSpy).toHaveBeenCalledWith(dummySession, ["TEST*"], {maxConcurrentRequests: 1});
+            expect(listDataSetsMatchingPatternSpy).toHaveBeenCalledWith(dummySession, ["TEST*"], {attributes: true, maxConcurrentRequests: 1});
             expect(listAllMembersSpy).toHaveBeenCalledTimes(1);
             expect(listAllMembersSpy).toHaveBeenCalledWith(dummySession, "TEST3.PDS", {});
             expect(searchOnMainframeSpy).toHaveBeenCalledTimes(1);
@@ -1155,7 +1155,7 @@ describe("Search", () => {
             const response = await Search.dataSets(dummySession, searchOptions);
 
             expect(listDataSetsMatchingPatternSpy).toHaveBeenCalledTimes(1);
-            expect(listDataSetsMatchingPatternSpy).toHaveBeenCalledWith(dummySession, ["TEST*"], {maxConcurrentRequests: 1});
+            expect(listDataSetsMatchingPatternSpy).toHaveBeenCalledWith(dummySession, ["TEST*"], {attributes: true, maxConcurrentRequests: 1});
             expect(listAllMembersSpy).toHaveBeenCalledTimes(1);
             expect(listAllMembersSpy).toHaveBeenCalledWith(dummySession, "TEST3.PDS", {});
             expect(searchOnMainframeSpy).toHaveBeenCalledTimes(1);
@@ -1192,7 +1192,7 @@ describe("Search", () => {
             const response = await Search.dataSets(dummySession, searchOptions);
 
             expect(listDataSetsMatchingPatternSpy).toHaveBeenCalledTimes(1);
-            expect(listDataSetsMatchingPatternSpy).toHaveBeenCalledWith(dummySession, ["TEST*"], {maxConcurrentRequests: 1});
+            expect(listDataSetsMatchingPatternSpy).toHaveBeenCalledWith(dummySession, ["TEST*"], {attributes: true, maxConcurrentRequests: 1});
             expect(listAllMembersSpy).toHaveBeenCalledTimes(1);
             expect(listAllMembersSpy).toHaveBeenCalledWith(dummySession, "TEST3.PDS", {});
             expect(searchOnMainframeSpy).toHaveBeenCalledTimes(1);
@@ -1229,7 +1229,7 @@ describe("Search", () => {
             const response = await Search.dataSets(dummySession, searchOptions);
 
             expect(listDataSetsMatchingPatternSpy).toHaveBeenCalledTimes(1);
-            expect(listDataSetsMatchingPatternSpy).toHaveBeenCalledWith(dummySession, ["TEST*"], {maxConcurrentRequests: 1});
+            expect(listDataSetsMatchingPatternSpy).toHaveBeenCalledWith(dummySession, ["TEST*"], {attributes: true, maxConcurrentRequests: 1});
             expect(listAllMembersSpy).toHaveBeenCalledTimes(1);
             expect(listAllMembersSpy).toHaveBeenCalledWith(dummySession, "TEST3.PDS", {});
             expect(searchOnMainframeSpy).toHaveBeenCalledTimes(1);

--- a/packages/zosfiles/src/methods/list/List.ts
+++ b/packages/zosfiles/src/methods/list/List.ts
@@ -438,8 +438,13 @@ export class List {
             }
             let response: any;
             try {
-                response = await List.dataSet(session, pattern,
-                    { attributes: true, maxLength: maxLength ? maxLength - totalCount : undefined, start: options.start });
+                response = await List.dataSet(session, pattern, {
+                    attributes: options.attributes,
+                    volume: options.volume,
+                    recall: options.recall,
+                    maxLength: maxLength ? maxLength - totalCount : undefined,
+                    start: options.start
+                });
             } catch (err) {
                 if (!(err instanceof ImperativeError && err.errorCode?.toString().startsWith("5"))) {
                     throw err;

--- a/packages/zosfiles/src/methods/list/doc/IDsmListOptions.ts
+++ b/packages/zosfiles/src/methods/list/doc/IDsmListOptions.ts
@@ -10,12 +10,12 @@
 */
 
 import { ITaskWithStatus } from "@zowe/imperative";
-import { IZosFilesOptions } from "../../../doc/IZosFilesOptions";
+import { IListOptions } from "./IListOptions";
 
 /**
  * This interface defines the options that can be sent into the list data sets matching function
  */
-export interface IDsmListOptions extends IZosFilesOptions {
+export interface IDsmListOptions extends Omit<IListOptions, "pattern"> {
     /**
      * Exclude data sets that match these DSLEVEL patterns. Any data sets that match
      * this pattern will not be listed
@@ -31,16 +31,6 @@ export interface IDsmListOptions extends IZosFilesOptions {
      * Default: 1
      */
     maxConcurrentRequests?: number;
-
-    /**
-     * The indicator that we want to show less data sets or members
-     */
-    maxLength?: number;
-
-    /**
-     * An optional search parameter that specifies the first data set name to return in the response document
-     */
-    start?: string;
 
     /**
      * Task status object used by CLI handlers to create progress bars

--- a/packages/zosfiles/src/methods/search/Search.ts
+++ b/packages/zosfiles/src/methods/search/Search.ts
@@ -80,6 +80,7 @@ export class Search {
         try {
             const response = await List.dataSetsMatchingPattern(session, [searchOptions.pattern], {
                 ...searchOptions.listOptions,
+                attributes: true,
                 maxConcurrentRequests: searchOptions.maxConcurrentRequests
             });
             for (const resp of response.apiResponse) {


### PR DESCRIPTION
**What It Does**

Implements #2476 

- Adds support for the `attributes`, `recall`, and `volume` options to the `List.dataSetsMatchingPattern` function.
- Fixes broken system tests from adding regex support to Search DS

**How to Test**

Save the snippet below as a TypeScript file in `<your-zowe-cli-repo-folder>/packages/zosfiles`. Adjust the data set patterns and session properties as needed:

```ts
const imperative = require("@zowe/imperative");
const { List } = require("@zowe/zos-files-for-zowe-sdk");

(async () => {
    // substitute correct values for `port`, `hostname`, `user`, and `password`
    const session = new imperative.Session({
        port: 443,
        hostname: "<your_zosmf_host_here>",
        user: "<your_username>",
        password: "<your_password>",
        type: "basic"
    });

    // test listing without attributes:
    const response = await List.dataSetsMatchingPattern(session, ["trae.*"], { attributes: false });
    // expected result: matching data set entries in `response.apiResponse` only contain `dsname` property and no attributes
    console.log("Listing without attributes");
    console.log(JSON.stringify(response, null, 4));
    // test listing for specific volume (max length 2, attributes set to `true`):
    const respVol = await List.dataSetsMatchingPattern(session, ["trae.*", "sys1.*"], { attributes: true, volume: "USER01", maxLength: 2 });
    // expected result: returned data sets only exist on given volume USER01
    console.log("Listing by volume");
    console.log(JSON.stringify(respVol, null, 4));
})();
```

`cd` into this folder and run `npx tsx <name-of-script>.ts` to observe its output.

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [x] added/updated automated tests
- [x] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)