### PR TITLE
fix(secrets): Resolve error accessing secrets on MacOS

### DIFF
--- a/packages/secrets/CHANGELOG.md
+++ b/packages/secrets/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Zowe Secrets SDK package will be documented in this file.
 
+## Recent Changes
+
+- BugFix: Fixed an error when accessing secrets on MacOS caused by socket file paths exceeding the maximum allowed length. [#2482](https://github.com/zowe/zowe-cli/pull/2482)
+
 ## `8.10.4`
 
 - BugFix: Reduced number of keychain unlock prompts on MacOS for simultaneous access to secrets by multiple instances of the same application. [#2394](https://github.com/zowe/zowe-cli/pull/2394)

--- a/packages/secrets/core/Cargo.lock
+++ b/packages/secrets/core/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -354,6 +360,7 @@ dependencies = [
 name = "secrets_core"
 version = "0.1.0"
 dependencies = [
+ "adler",
  "cfg-if",
  "core-foundation",
  "core-foundation-sys",

--- a/packages/secrets/core/Cargo.toml
+++ b/packages/secrets/core/Cargo.toml
@@ -20,6 +20,7 @@ features = [
 version = "0.48.0"
 
 [target.'cfg(target_os = "macos")'.dependencies]
+adler = "1.0.2"
 core-foundation = "0.9.3"
 core-foundation-sys = "0.8.4"
 fmutex = "0.1.0"

--- a/packages/secrets/core/src/os/mac/mod.rs
+++ b/packages/secrets/core/src/os/mac/mod.rs
@@ -61,7 +61,7 @@ pub fn set_password(
     password: &String,
 ) -> Result<bool, KeyringError> {
     let keychain = SecKeychain::default().unwrap();
-    let _lock = keyring_mutex().unwrap();
+    let _lock = keyring_mutex()?;
     match keychain.set_password(service.as_str(), account.as_str(), password.as_bytes()) {
         Ok(()) => Ok(true),
         Err(err) => Err(KeyringError::from(err)),
@@ -80,7 +80,7 @@ pub fn set_password(
 ///
 pub fn get_password(service: &String, account: &String) -> Result<Option<String>, KeyringError> {
     let keychain = SecKeychain::default().unwrap();
-    let _lock = keyring_mutex().unwrap();
+    let _lock = keyring_mutex()?;
     match keychain.find_password(service.as_str(), account.as_str()) {
         Ok((pw, _)) => Ok(Some(String::from_utf8(pw.to_owned())?)),
         Err(err) if err.code() == ERR_SEC_ITEM_NOT_FOUND => Ok(None),
@@ -108,7 +108,7 @@ pub fn find_password(service: &String) -> Result<Option<String>, KeyringError> {
     }
 
     let keychain = SecKeychain::default().unwrap();
-    let _lock = keyring_mutex().unwrap();
+    let _lock = keyring_mutex()?;
     match keychain.find_password(cred_attrs[0], cred_attrs[1]) {
         Ok((pw, _)) => {
             let pw_str = String::from_utf8(pw.to_owned())?;
@@ -130,7 +130,7 @@ pub fn find_password(service: &String) -> Result<Option<String>, KeyringError> {
 ///
 pub fn delete_password(service: &String, account: &String) -> Result<bool, KeyringError> {
     let keychain = SecKeychain::default().unwrap();
-    let _lock = keyring_mutex().unwrap();
+    let _lock = keyring_mutex()?;
     match keychain.find_password(service.as_str(), account.as_str()) {
         Ok((_, item)) => {
             item.delete()?;
@@ -155,7 +155,7 @@ pub fn find_credentials(
     service: &String,
     credentials: &mut Vec<(String, String)>,
 ) -> Result<bool, KeyringError> {
-    let _lock = keyring_mutex().unwrap();
+    let _lock = keyring_mutex()?;
     match KeychainSearch::new()
         .label(service.as_str())
         .with_attrs()

--- a/packages/secrets/src/keyring/Cargo.lock
+++ b/packages/secrets/src/keyring/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "aho-corasick"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -488,6 +494,7 @@ checksum = "e5ea92a5b6195c6ef2a0295ea818b312502c6fc94dde986c5553242e18fd4ce2"
 name = "secrets_core"
 version = "0.1.0"
 dependencies = [
+ "adler",
  "cfg-if",
  "core-foundation",
  "core-foundation-sys",


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->
Fixes an error where if the parent process path is long, then the Secrets SDK attempts to create a socket file that exceeds the max path length for IPC sockets (103 chars on MacOS).

The Adler32 algorithm is not immune to hash collision (as pointed out by Copilot). However I think it's a good balance between speed and uniqueness for our use case. The worst that can happen in the rare case of a hash collision is that users see multiple keyring unlock prompts instead of just one.

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->

**Review Checklist**
I certify that I have:
- [ ] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [ ] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
