### PR TITLE
Update merge-by-comments workflow to fail silently

### DIFF
--- a/.github/workflows/merge-by-comments.yml
+++ b/.github/workflows/merge-by-comments.yml
@@ -11,5 +11,6 @@ jobs:
             pull-requests: write
         steps:
             - uses: zowe-actions/shared-actions/merge-by@main
+              continue-on-error: true
               with:
                 operation: "bump-dates"


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->

The `merge-by-comments` workflow fails on pull requests on forks, as it doesn't have write permissions to comments on the PR. Fix it so it "fails silently" i.e. does not fail checks just because it can't write the comment.

Same change as this in ZE: https://github.com/zowe/zowe-explorer-vscode/pull/3650/files#diff-072f8c2deed9e1b8c29ead3ba575196262d9de91c2f159761a7df759b202b783

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
