### PR TITLE
Make 'npm run package' work

### DIFF
--- a/scripts/bundleCliTgz.js
+++ b/scripts/bundleCliTgz.js
@@ -30,8 +30,9 @@ try {
         const srcDir = path.join("node_modules", "@zowe", zowePkgDir);
         const destDir = path.join(cliPkgDir, srcDir);
         fs.rmSync(destDir, { recursive: true, force: true });
-        fs.copySync(fs.realpathSync(srcDir), destDir);
+        fs.cpSync(fs.realpathSync(srcDir), destDir, {recursive: true});
     }
+    fs.rmSync(path.join(cliPkgDir, "node_modules", "cpu-features"), { recursive: true, force: true });
 
     // Define bundled dependencies in package.json and package the TGZ
     const pkgJson = JSON.parse(fs.readFileSync(pkgJsonFile, "utf-8"));


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->

Eliminates one error when 'npm run package' is run, and another error when you run 'npm install' with the resulting .tgz file.

Replaced the non-existent copySync function. Removed cpu-features from the bundle.

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->

- Run 'npm run package' 
- Run 'npm install -g zowe-cli-file-that-you-created.tgz'
- Execute Zowe commands.

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [N/A] added/updated automated tests
- [N/A] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
