### PR TITLE
Fix invalid npm log level when --verbose option is used

### DIFF
--- a/packages/imperative/CHANGELOG.md
+++ b/packages/imperative/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Imperative package will be documented in this file.
 
+## Recent Changes
+
+- BugFix: Fixed invalid value for npm log level when `--verbose` option is true on the `zowe plugins install` command. [#2571](https://github.com/zowe/zowe-cli/pull/2571)
+
 ## `8.25.0`
 
 - Enhancement: Added `--verbose` option to the `zowe plugins install` command to make debugging easier. [#2562](https://github.com/zowe/zowe-cli/pull/2562)

--- a/packages/imperative/src/imperative/__tests__/plugins/utilities/NpmFunctions.unit.test.ts
+++ b/packages/imperative/src/imperative/__tests__/plugins/utilities/NpmFunctions.unit.test.ts
@@ -16,6 +16,7 @@ import * as pacote from "pacote";
 import * as npmFunctions from "../../../src/plugins/utilities/NpmFunctions";
 import { PMFConstants } from "../../../src/plugins/utilities/PMFConstants";
 import { DaemonRequest, ExecUtils, ImperativeConfig } from "../../../../utilities";
+import { Logger } from "../../../../logger";
 
 jest.mock("cross-spawn");
 jest.mock("jsonfile");
@@ -169,7 +170,67 @@ describe("NpmFunctions", () => {
                     "samplePlugin",
                     "-g",
                     "--legacy-peer-deps",
+                    "--loglevel=info",
+                    "--foreground-scripts",
+                    "--prefix",
+                    "fakePrefix",
+                    "--registry",
+                    fakeRegistry
+                ]),
+                expect.objectContaining({
+                    cwd: __dirname
+                })
+            );
+            expect(result).toBeFalsy();
+        });
+
+        it("should run npm install with verbose flags when verbose=true and CLI log level is DEBUG", () => {
+            const spawnSpy = jest.spyOn(ExecUtils, "spawnWithInheritedStdio").mockReturnValue();
+            jest.spyOn(Logger, "getAppLogger").mockReturnValue({ level: "DEBUG" } as any);
+
+            const result = npmFunctions.installPackages("samplePlugin", {
+                prefix: "fakePrefix",
+                registry: fakeRegistry
+            }, true);
+
+            expect(spawnSpy).toHaveBeenCalledWith(
+                npmCmd,
+                expect.arrayContaining([
+                    "install",
+                    "samplePlugin",
+                    "-g",
+                    "--legacy-peer-deps",
                     "--loglevel=verbose",
+                    "--foreground-scripts",
+                    "--prefix",
+                    "fakePrefix",
+                    "--registry",
+                    fakeRegistry
+                ]),
+                expect.objectContaining({
+                    cwd: __dirname
+                })
+            );
+            expect(result).toBeFalsy();
+        });
+
+        it("should run npm install with verbose flags when verbose=true and CLI log level is TRACE", () => {
+            const spawnSpy = jest.spyOn(ExecUtils, "spawnWithInheritedStdio").mockReturnValue();
+            jest.spyOn(Logger, "getAppLogger").mockReturnValue({ level: "TRACE" } as any);
+
+            const result = npmFunctions.installPackages("samplePlugin", {
+                prefix: "fakePrefix",
+                registry: fakeRegistry
+            }, true);
+
+            expect(spawnSpy).toHaveBeenCalledWith(
+                npmCmd,
+                expect.arrayContaining([
+                    "install",
+                    "samplePlugin",
+                    "-g",
+                    "--legacy-peer-deps",
+                    "--loglevel=silly",
                     "--foreground-scripts",
                     "--prefix",
                     "fakePrefix",
@@ -193,7 +254,7 @@ describe("NpmFunctions", () => {
 
             expect(spawnSpy).toHaveBeenCalledWith(
                 npmCmd,
-                expect.not.arrayContaining(["--loglevel=verbose", "--foreground-scripts"]),
+                expect.not.arrayContaining(["--loglevel=info", "--foreground-scripts"]),
                 expect.objectContaining({
                     cwd: __dirname,
                     stdio: ["pipe", "pipe", "pipe"]
@@ -211,7 +272,7 @@ describe("NpmFunctions", () => {
             });
 
             const calledArgs = spawnSpy.mock.calls[0]?.[1];
-            expect(calledArgs).not.toContain("--loglevel=verbose");
+            expect(calledArgs).not.toContain("--loglevel=info");
             expect(calledArgs).not.toContain("--foreground-scripts");
             expect(spawnSpy.mock.calls[0]?.[2]?.stdio).toEqual(["pipe", "pipe", "pipe"]);
             expect(result).toBe(stdoutBuffer.toString());
@@ -304,7 +365,7 @@ describe("NpmFunctions", () => {
                     "@scope/samplePlugin",
                     "-g",
                     "--legacy-peer-deps",
-                    "--loglevel=verbose",
+                    "--loglevel=info",
                     "--foreground-scripts",
                     "--prefix",
                     "fakePrefix",

--- a/packages/imperative/src/imperative/__tests__/plugins/utilities/NpmFunctions.unit.test.ts
+++ b/packages/imperative/src/imperative/__tests__/plugins/utilities/NpmFunctions.unit.test.ts
@@ -169,7 +169,7 @@ describe("NpmFunctions", () => {
                     "samplePlugin",
                     "-g",
                     "--legacy-peer-deps",
-                    "--loglevel=debug",
+                    "--loglevel=verbose",
                     "--foreground-scripts",
                     "--prefix",
                     "fakePrefix",
@@ -193,7 +193,7 @@ describe("NpmFunctions", () => {
 
             expect(spawnSpy).toHaveBeenCalledWith(
                 npmCmd,
-                expect.not.arrayContaining(["--loglevel=debug", "--foreground-scripts"]),
+                expect.not.arrayContaining(["--loglevel=verbose", "--foreground-scripts"]),
                 expect.objectContaining({
                     cwd: __dirname,
                     stdio: ["pipe", "pipe", "pipe"]
@@ -211,7 +211,7 @@ describe("NpmFunctions", () => {
             });
 
             const calledArgs = spawnSpy.mock.calls[0]?.[1];
-            expect(calledArgs).not.toContain("--loglevel=debug");
+            expect(calledArgs).not.toContain("--loglevel=verbose");
             expect(calledArgs).not.toContain("--foreground-scripts");
             expect(spawnSpy.mock.calls[0]?.[2]?.stdio).toEqual(["pipe", "pipe", "pipe"]);
             expect(result).toBe(stdoutBuffer.toString());
@@ -304,7 +304,7 @@ describe("NpmFunctions", () => {
                     "@scope/samplePlugin",
                     "-g",
                     "--legacy-peer-deps",
-                    "--loglevel=debug",
+                    "--loglevel=verbose",
                     "--foreground-scripts",
                     "--prefix",
                     "fakePrefix",

--- a/packages/imperative/src/imperative/src/plugins/utilities/NpmFunctions.ts
+++ b/packages/imperative/src/imperative/src/plugins/utilities/NpmFunctions.ts
@@ -48,7 +48,7 @@ export function installPackages(npmPackage: string, npmArgs: INpmInstallArgs, ve
     const pipe: StdioOptions = ["pipe", "pipe", "pipe"];
     const args = ["install", npmPackage, "-g", "--legacy-peer-deps"];
     if (verbose) {
-        const logLevel = Logger.getAppLogger().level === "TRACE" ? "silly" : "debug";
+        const logLevel = Logger.getAppLogger().level === "TRACE" ? "silly" : "verbose";
         args.push(`--loglevel=${logLevel}`, "--foreground-scripts");
     }
     for (const [k, v] of Object.entries(npmArgs)) {

--- a/packages/imperative/src/imperative/src/plugins/utilities/NpmFunctions.ts
+++ b/packages/imperative/src/imperative/src/plugins/utilities/NpmFunctions.ts
@@ -48,7 +48,13 @@ export function installPackages(npmPackage: string, npmArgs: INpmInstallArgs, ve
     const pipe: StdioOptions = ["pipe", "pipe", "pipe"];
     const args = ["install", npmPackage, "-g", "--legacy-peer-deps"];
     if (verbose) {
-        const logLevel = Logger.getAppLogger().level === "TRACE" ? "silly" : "verbose";
+        const logLevel = ((logger: Logger) => {
+            switch (logger.level) {
+                case "TRACE": return "silly";
+                case "DEBUG": return "verbose";
+                default: return "info";
+            }
+        })(Logger.getAppLogger());
         args.push(`--loglevel=${logLevel}`, "--foreground-scripts");
     }
     for (const [k, v] of Object.entries(npmArgs)) {

--- a/packages/imperative/src/imperative/src/plugins/utilities/npm-interface/install.ts
+++ b/packages/imperative/src/imperative/src/plugins/utilities/npm-interface/install.ts
@@ -189,16 +189,15 @@ export async function install(packageLocation: string, registryInfo: INpmRegistr
 
                     // Only update global schema if we were able to load it from disk
                     if (loadedSchema != null) {
-                        const existingTypes = loadedSchema.map((obj) => obj.type);
                         const extendersJson = ConfigUtils.readExtendersJson();
 
                         // Determine new profile types to add to schema
                         let shouldUpdate = false;
                         for (const profile of pluginImpConfig.profiles) {
-                            if (!existingTypes.includes(profile.type)) {
+                            const existingType = loadedSchema.find((obj) => obj.type === profile.type);
+                            if (existingType == null) {
                                 loadedSchema.push(profile);
                             } else {
-                                const existingType = loadedSchema.find((obj) => obj.type === profile.type);
                                 if (semver.valid(existingType.schema.version)) {
                                     if (semver.valid(profile.schema.version) && semver.gt(profile.schema.version, existingType.schema.version)) {
                                         existingType.schema = profile.schema;


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->
Run `zowe plugins install <pluginName> --verbose` and make sure the following message is _not_ shown:
```
npm warn invalid config loglevel="debug" set in command line options
npm warn invalid config Must be one of: silent, error, warn, notice, http, info, verbose, silly
```

**Review Checklist**
I certify that I have:
- [x] updated the changelog
- [x] manually tested my changes
- [x] added/updated automated unit/integration tests
- [ ] created/ran system tests (provide build number if applicable)
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
