### PR TITLE
Fix integration tests in CI for Windows + Node 22

### DIFF
--- a/.github/workflows/zowe-cli.yml
+++ b/.github/workflows/zowe-cli.yml
@@ -128,8 +128,7 @@ jobs:
 
     - name: Integration Tests (Daemon)
       if: ${{ always() && steps.build.outcome == 'success' && github.event.inputs.test-type != 'nodejs' }}
-      # Use double double hyphen to work around Windows + Node 22 bug: https://github.com/npm/cli/issues/7375
-      run: npm run test:integration -- ${{ (matrix.os == 'windows-latest' && matrix.node-version == '22.x') && '--' || '' }} --runInBand
+      run: npm run test:integration -- --runInBand
 
     - name: Archive Results
       if: ${{ always() && steps.build.outcome == 'success' }}


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->
Thanks @gejohnston for helping to diagnose the issue 🙂 

Previously there was a bug in npm that required using non-standard syntax to pass the `--runInBand` arg to Jest on Windows. Now that https://github.com/npm/cli/issues/7375 has been fixed, we need to revert the temporary workaround.

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->

**Review Checklist**
I certify that I have:
- [ ] updated the changelog
- [ ] manually tested my changes
- [ ] added/updated automated unit/integration tests
- [ ] created/ran system tests (provide build number if applicable)
- [ ] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
