### PR TITLE
fix(zowex): update lockfile to accurate `zowe` version

### DIFF
--- a/zowex/Cargo.lock
+++ b/zowex/Cargo.lock
@@ -811,7 +811,7 @@ checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
 
 [[package]]
 name = "zowe"
-version = "1.2.4"
+version = "1.2.5"
 dependencies = [
  "base64",
  "fslock",


### PR DESCRIPTION
**What It Does**

Fixes an issue where the `Cargo.lock` file was last updated for `zowe 1.2.4`, rather than the latest version `1.2.5`. 

**How to Test**

`cargo build` in `zowex` folder should succeed without error and lockfile should remain the same

**Review Checklist**
I certify that I have:
- [ ] updated the changelog
- [x] manually tested my changes
- [ ] added/updated automated unit/integration tests
- [ ] created/ran system tests (provide build number if applicable)
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)
