### PR TITLE
fix: Secrets SDK publish workflow & artifact fetching

### DIFF
--- a/.github/workflows/secrets-sdk-publish.yml
+++ b/.github/workflows/secrets-sdk-publish.yml
@@ -38,3 +38,4 @@ jobs:
         NPM_REGISTRY: "https://zowe.jfrog.io/zowe/api/npm/npm-local-release"
         NPM_SCOPE: "@zowe"
         SECRETS_BRANCH: ${{ github.ref_name }}
+        SECRETS_COMMIT: ${{ github.sha }}

--- a/.github/workflows/secrets-sdk.yml
+++ b/.github/workflows/secrets-sdk.yml
@@ -4,6 +4,14 @@ env:
   APP_NAME: keyring
   MACOSX_DEPLOYMENT_TARGET: 10.13
 on:
+  push:
+    branches:
+      - next
+      - master
+      - zowe-v?-lts
+    paths:
+      - "packages/secrets/**"
+      - ".github/workflows/secrets-sdk.yml"
   pull_request:
     paths:
       - "packages/secrets/**"

--- a/packages/secrets/scripts/prebuildify.sh
+++ b/packages/secrets/scripts/prebuildify.sh
@@ -1,10 +1,28 @@
 #!/bin/bash
-set -ex
+set -euo pipefail
+set -x
+
 rm -rf prebuilds && mkdir -p prebuilds
-if [ -z "$SECRETS_BRANCH" ]; then
+
+if [ -z "${SECRETS_BRANCH:-}" ]; then
     SECRETS_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 fi
-SECRETS_WORKFLOW_ID=$(gh run list -b $SECRETS_BRANCH --limit 1 --status success --workflow "Secrets SDK CI" --json databaseId --jq ".[0].databaseId")
-echo "Downloading Secrets SDK prebuilds from $SECRETS_BRANCH branch..."
-gh run download $SECRETS_WORKFLOW_ID --dir prebuilds --pattern "bindings-*"
+
+if [ -z "${SECRETS_COMMIT:-}" ]; then
+    SECRETS_COMMIT=$(git rev-parse HEAD)
+fi
+
+echo "Looking for Secrets SDK prebuilds for branch '${SECRETS_BRANCH}' (commit ${SECRETS_COMMIT})..."
+
+RUNS_JSON=$(gh run list --workflow "Secrets SDK CI" --status success --limit 50 --json databaseId,headSha,headBranch)
+SECRETS_WORKFLOW_ID=$(echo "$RUNS_JSON" | jq -r --arg sha "$SECRETS_COMMIT" 'map(select(.headSha == $sha)) | .[0].databaseId // empty')
+
+if [ -z "${SECRETS_WORKFLOW_ID}" ]; then
+    echo "Unable to find a successful 'Secrets SDK CI' workflow run for commit ${SECRETS_COMMIT}."
+    echo "Please trigger the workflow for this ref (e.g. 'gh workflow run secrets-sdk.yml --ref ${SECRETS_BRANCH}') before publishing."
+    exit 1
+fi
+
+echo "Downloading Secrets SDK prebuilds from workflow run ${SECRETS_WORKFLOW_ID}..."
+gh run download "${SECRETS_WORKFLOW_ID}" --dir prebuilds --pattern "bindings-*"
 mv prebuilds/*/* prebuilds && rm -r prebuilds/*/


### PR DESCRIPTION
**What It Does**

Secrets SDK CI only ran on pull requests before. When we merged the persistence flag work, no workflow on `master` rebuilt the Windows `.node` binaries for that commit. So since the prebuilds for publish are fetched from GH workflows running on the `master` branch, the prebuilds bundled into the npm tarball were still the old ones (without persistence support), even though cloning the repo and building locally regenerated the right binary.

**How to Test**

- Merge the change to `master`, verify that published Secrets SDK package contains correct pre-builds
  - During publish, the prebuildify script should print the SHA of the matching publish commit. That should ensure that the newest build is being packaged

**Review Checklist**
I certify that I have:
- [x] updated the changelog
- [ ] manually tested my changes
- [ ] added/updated automated unit/integration tests
- [ ] created/ran system tests (provide build number if applicable)
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)
