### PR TITLE
feat(config): add --merge and --dry-run flags to zowe config import

### DIFF
--- a/packages/imperative/__tests__/__integration__/imperative/__tests__/__integration__/cli/config/import/__resources__/test.config.for.merge.json
+++ b/packages/imperative/__tests__/__integration__/imperative/__tests__/__integration__/cli/config/import/__resources__/test.config.for.merge.json
@@ -1,0 +1,28 @@
+{
+    "profiles": {
+        "base": {
+            "type": "base",
+            "properties": {
+                "host": "team-host.com",
+                "port": 443,
+                "rejectUnauthorized": true
+            },
+            "secure": [
+                "user",
+                "password"
+            ]
+        },
+        "zosmf": {
+            "type": "zosmf",
+            "properties": {
+                "host": "zosmf.team.com"
+            },
+            "secure": []
+        }
+    },
+    "defaults": {
+        "base": "base",
+        "zosmf": "zosmf"
+    },
+    "autoStore": true
+}

--- a/packages/imperative/__tests__/__integration__/imperative/__tests__/__integration__/cli/config/import/cli.imperative-test-cli.config.import.integration.subtest.ts
+++ b/packages/imperative/__tests__/__integration__/imperative/__tests__/__integration__/cli/config/import/cli.imperative-test-cli.config.import.integration.subtest.ts
@@ -85,7 +85,9 @@ describe("imperative-test-cli config import", () => {
                 "File path or URL to import from.",
                 "Target the global config files.",
                 "Target the user config files.",
-                "Overwrite config file if one already exists."
+                "Overwrite config file if one already exists.",
+                "--merge",
+                "--dry-run"
             ];
             expectedLines.forEach((line: string) => expect(response.output.toString()).toContain(line));
             expect(response.error).toBeFalsy();
@@ -211,6 +213,120 @@ describe("imperative-test-cli config import", () => {
                 expect(fs.existsSync(path.join(TEST_ENVIRONMENT.workingDir, "test", "test.schema.good.json"))).toEqual(false);
             });
         });
+    });
+
+    describe("--dry-run scenarios", () => {
+
+        it("should print a preview and not write any files when --dry-run is used", () => {
+            const response = runCliScript(path.join(__dirname, "/__scripts__/import_config.sh"), TEST_ENVIRONMENT.workingDir, [
+                path.join(__dirname, "__resources__", "test.config.good.without.schema.json"),
+                "--user-config false --global-config false --dry-run"
+            ]);
+
+            expect(response.stderr.toString()).toEqual("");
+            expect(response.stdout.toString()).toContain("[Dry Run]");
+            expect(response.stdout.toString()).toContain("No changes were written to disk");
+            expect(response.status).toEqual(0);
+            expect(fs.existsSync(path.join(TEST_ENVIRONMENT.workingDir, "test", "imperative-test-cli.config.json"))).toBe(false);
+        });
+
+        it("should not download schema when --dry-run is used with a config that has a schema", () => {
+            const response = runCliScript(path.join(__dirname, "/__scripts__/import_config.sh"), TEST_ENVIRONMENT.workingDir, [
+                path.join(__dirname, "__resources__", "test.config.good.with.schema.json"),
+                "--user-config false --global-config false --dry-run"
+            ]);
+
+            expect(response.stderr.toString()).toEqual("");
+            expect(response.stdout.toString()).toContain("[Dry Run]");
+            expect(response.status).toEqual(0);
+            expect(fs.existsSync(path.join(TEST_ENVIRONMENT.workingDir, "test", "imperative-test-cli.config.json"))).toBe(false);
+            expect(fs.existsSync(path.join(TEST_ENVIRONMENT.workingDir, "test", "test.schema.good.json"))).toBe(false);
+        });
+
+        it("should print a preview of the merged result when --merge --dry-run is used", () => {
+            // First import a base config
+            runCliScript(path.join(__dirname, "/__scripts__/import_config.sh"), TEST_ENVIRONMENT.workingDir, [
+                path.join(__dirname, "__resources__", "test.config.good.without.schema.json"),
+                "--user-config false --global-config false"
+            ]);
+
+            const originalContent = fs.readFileSync(
+                path.join(TEST_ENVIRONMENT.workingDir, "test", "imperative-test-cli.config.json"), "utf-8"
+            );
+
+            // Preview a merge — should not modify the file
+            const response = runCliScript(path.join(__dirname, "/__scripts__/import_config_no_mkdir.sh"), TEST_ENVIRONMENT.workingDir, [
+                path.join(__dirname, "__resources__", "test.config.for.merge.json"),
+                "--user-config false --global-config false --merge --dry-run"
+            ]);
+
+            expect(response.stderr.toString()).toEqual("");
+            expect(response.stdout.toString()).toContain("[Dry Run]");
+            expect(response.stdout.toString()).toContain("No changes were written to disk");
+            expect(response.status).toEqual(0);
+
+            // File on disk must be unchanged
+            const afterContent = fs.readFileSync(
+                path.join(TEST_ENVIRONMENT.workingDir, "test", "imperative-test-cli.config.json"), "utf-8"
+            );
+            expect(afterContent).toEqual(originalContent);
+        });
+
+    });
+
+    describe("--merge scenarios", () => {
+
+        it("should merge new profiles from imported config without overwriting existing values", () => {
+            // First import the base config (has 'secured' and 'base' profiles, empty defaults)
+            runCliScript(path.join(__dirname, "/__scripts__/import_config.sh"), TEST_ENVIRONMENT.workingDir, [
+                path.join(__dirname, "__resources__", "test.config.good.without.schema.json"),
+                "--user-config false --global-config false"
+            ]);
+
+            // Then merge in a config that adds a 'zosmf' profile and new defaults, and tries to change 'base'
+            const response = runCliScript(path.join(__dirname, "/__scripts__/import_config_no_mkdir.sh"), TEST_ENVIRONMENT.workingDir, [
+                path.join(__dirname, "__resources__", "test.config.for.merge.json"),
+                "--user-config false --global-config false --merge"
+            ]);
+
+            expect(response.stderr.toString()).toEqual("");
+            expect(response.stdout.toString()).toContain("Merged config");
+            expect(response.status).toEqual(0);
+
+            const merged = JSON.parse(fs.readFileSync(
+                path.join(TEST_ENVIRONMENT.workingDir, "test", "imperative-test-cli.config.json"), "utf-8"
+            ));
+
+            // Existing base profile properties must not be overwritten
+            expect(merged.profiles.base.properties.host).toBe("fakeHost");
+            expect(merged.profiles.base.properties.port).toBe(1234);
+            // New property from import should be added to existing profile
+            expect(merged.profiles.base.properties.rejectUnauthorized).toBe(true);
+            // New profile from import should be present
+            expect(merged.profiles.zosmf).toBeDefined();
+            expect(merged.profiles.zosmf.properties.host).toBe("zosmf.team.com");
+            // New defaults from import should be present
+            expect(merged.defaults.zosmf).toBe("zosmf");
+            // autoStore was not set in existing — should be added from import
+            expect(merged.autoStore).toBe(true);
+        });
+
+        it("should write imported config as-is when no existing config file is present", () => {
+            const response = runCliScript(path.join(__dirname, "/__scripts__/import_config.sh"), TEST_ENVIRONMENT.workingDir, [
+                path.join(__dirname, "__resources__", "test.config.for.merge.json"),
+                "--user-config false --global-config false --merge"
+            ]);
+
+            expect(response.stderr.toString()).toEqual("");
+            expect(response.stdout.toString()).toContain("Imported config");
+            expect(response.status).toEqual(0);
+
+            expectFilesAreEqual(
+                path.join(TEST_ENVIRONMENT.workingDir, "test", "imperative-test-cli.config.json"),
+                path.join(__dirname, "__resources__", "test.config.for.merge.json")
+            );
+        });
+
     });
 
     describe("failure scenarios", () => {

--- a/packages/imperative/src/imperative/__tests__/config/cmd/import/import.handler.unit.test.ts
+++ b/packages/imperative/src/imperative/__tests__/config/cmd/import/import.handler.unit.test.ts
@@ -185,6 +185,243 @@ describe("Configuration Import command handler", () => {
             expect(readFileSyncSpy).not.toHaveBeenCalled();
             expect(writeFileSyncSpy).not.toHaveBeenCalled();
         });
+
+        it("should mention --merge and --dry-run in skip message when file already exists", async () => {
+            jest.spyOn(fs, "existsSync").mockReturnValueOnce(true);
+
+            const params: IHandlerParameters = getIHandlerParametersObject();
+            params.arguments.location = __dirname + "/fakeapp.config.json";
+            teamConfig.layerActive().exists = true;
+            await new ImportHandler().process(params);
+
+            const logOutput = (params.response.console.log as jest.Mock).mock.calls.join("\n");
+            expect(logOutput).toContain("--overwrite");
+            expect(logOutput).toContain("--merge");
+            expect(logOutput).toContain("--dry-run");
+            expect(writeFileSyncSpy).not.toHaveBeenCalled();
+        });
+
+        it("should throw an error when both --merge and --overwrite are specified", async () => {
+            jest.spyOn(fs, "existsSync").mockReturnValueOnce(true);
+
+            const params: IHandlerParameters = getIHandlerParametersObject();
+            params.arguments.location = __dirname + "/fakeapp.config.json";
+            params.arguments.merge = true;
+            params.arguments.overwrite = true;
+            teamConfig.layerActive().exists = true;
+
+            let error: any;
+            try {
+                await new ImportHandler().process(params);
+            } catch (err) {
+                error = err;
+            }
+
+            expect(error).toBeDefined();
+            expect(error.message).toContain("mutually exclusive");
+            expect(writeFileSyncSpy).not.toHaveBeenCalled();
+        });
+
+        describe("--dry-run", () => {
+
+            it("should print a preview and not write when --dry-run is used on a new location", async () => {
+                jest.spyOn(fs, "existsSync").mockReturnValueOnce(true);
+                readFileSyncSpy.mockReturnValueOnce(expectedConfigTextWithoutSchema);
+
+                const params: IHandlerParameters = getIHandlerParametersObject();
+                params.arguments.location = __dirname + "/fakeapp.config.json";
+                params.arguments.dryRun = true;
+                await new ImportHandler().process(params);
+
+                expect(readFileSyncSpy).toHaveBeenCalled();
+                expect(writeFileSyncSpy).not.toHaveBeenCalled();
+                expect(downloadSchemaSpy).not.toHaveBeenCalled();
+                const logOutput = (params.response.console.log as jest.Mock).mock.calls.join("\n");
+                expect(logOutput).toContain("[Dry Run]");
+                expect(logOutput).toContain("No changes were written to disk");
+            });
+
+            it("should print a preview and not write when --dry-run is used on an existing config", async () => {
+                jest.spyOn(fs, "existsSync").mockReturnValueOnce(true);
+                readFileSyncSpy.mockReturnValueOnce(expectedConfigTextWithoutSchema);
+
+                const params: IHandlerParameters = getIHandlerParametersObject();
+                params.arguments.location = __dirname + "/fakeapp.config.json";
+                params.arguments.dryRun = true;
+                teamConfig.layerActive().exists = true;
+                await new ImportHandler().process(params);
+
+                expect(writeFileSyncSpy).not.toHaveBeenCalled();
+                const logOutput = (params.response.console.log as jest.Mock).mock.calls.join("\n");
+                expect(logOutput).toContain("[Dry Run]");
+                expect(logOutput).toContain("No changes were written to disk");
+            });
+
+            it("should not download schema during --dry-run", async () => {
+                jest.spyOn(fs, "existsSync").mockReturnValueOnce(true);
+                readFileSyncSpy.mockReturnValueOnce(expectedConfigText);
+
+                const params: IHandlerParameters = getIHandlerParametersObject();
+                params.arguments.location = __dirname + "/fakeapp.config.json";
+                params.arguments.dryRun = true;
+                await new ImportHandler().process(params);
+
+                expect(downloadSchemaSpy).not.toHaveBeenCalled();
+                expect(writeFileSyncSpy).not.toHaveBeenCalled();
+            });
+
+        });
+
+        describe("--merge", () => {
+
+            const existingConfig: IConfig = {
+                profiles: {
+                    base: {
+                        type: "base",
+                        properties: { host: "my-host.com", port: 10443 },
+                        secure: ["user", "password"]
+                    }
+                },
+                defaults: { base: "base" },
+                autoStore: false
+            };
+
+            const importedConfig: IConfig = {
+                profiles: {
+                    base: {
+                        type: "base",
+                        properties: { host: "team-host.com", port: 443, rejectUnauthorized: true },
+                        secure: ["user", "password"]
+                    },
+                    zosmf: {
+                        type: "zosmf",
+                        properties: { host: "zosmf-host.com" },
+                        secure: []
+                    }
+                },
+                defaults: { base: "base", zosmf: "zosmf" },
+                autoStore: true,
+                plugins: ["@zowe/cics-for-zowe-cli"]
+            };
+
+            it("should merge imported config into existing, existing values win", async () => {
+                jest.spyOn(fs, "existsSync").mockReturnValueOnce(true);
+                readFileSyncSpy.mockReturnValueOnce(JSONC.stringify(importedConfig, null, ConfigConstants.INDENT));
+                writeFileSyncSpy.mockReturnValueOnce();
+
+                // Seed the active layer with existing config
+                teamConfig.api.layers.set(existingConfig);
+                teamConfig.layerActive().exists = true;
+
+                const params: IHandlerParameters = getIHandlerParametersObject();
+                params.arguments.location = __dirname + "/fakeapp.config.json";
+                params.arguments.merge = true;
+                await new ImportHandler().process(params);
+
+                expect(writeFileSyncSpy).toHaveBeenCalled();
+                const written = JSONC.parse(writeFileSyncSpy.mock.calls[0][1] as string) as unknown as IConfig;
+
+                // Existing host/port must not be overwritten
+                expect(written.profiles.base.properties.host).toBe("my-host.com");
+                expect(written.profiles.base.properties.port).toBe(10443);
+                // New property from import should be added
+                expect(written.profiles.base.properties.rejectUnauthorized).toBe(true);
+                // New profile from import should be added
+                expect(written.profiles.zosmf).toBeDefined();
+                expect(written.profiles.zosmf.properties.host).toBe("zosmf-host.com");
+                // Existing default must not be overwritten; new default added
+                expect(written.defaults.base).toBe("base");
+                expect(written.defaults.zosmf).toBe("zosmf");
+                // autoStore already false in existing — must stay false
+                expect(written.autoStore).toBe(false);
+                // Plugin from import should be added
+                expect(written.plugins).toContain("@zowe/cics-for-zowe-cli");
+
+                const logOutput = (params.response.console.log as jest.Mock).mock.calls.join("\n");
+                expect(logOutput).toContain("Merged config");
+            });
+
+            it("should write imported config as-is when no existing file", async () => {
+                jest.spyOn(fs, "existsSync").mockReturnValueOnce(true);
+                readFileSyncSpy.mockReturnValueOnce(expectedConfigTextWithoutSchema);
+                writeFileSyncSpy.mockReturnValueOnce();
+
+                const params: IHandlerParameters = getIHandlerParametersObject();
+                params.arguments.location = __dirname + "/fakeapp.config.json";
+                params.arguments.merge = true;
+                // layer.exists is false by default
+                await new ImportHandler().process(params);
+
+                expect(writeFileSyncSpy).toHaveBeenCalledWith(
+                    path.join(process.cwd(), "fakeapp.config.json"),
+                    expectedConfigTextWithoutSchema
+                );
+                const logOutput = (params.response.console.log as jest.Mock).mock.calls.join("\n");
+                expect(logOutput).toContain("Imported config");
+            });
+
+            it("should preview merge without writing when --merge --dry-run", async () => {
+                jest.spyOn(fs, "existsSync").mockReturnValueOnce(true);
+                readFileSyncSpy.mockReturnValueOnce(JSONC.stringify(importedConfig, null, ConfigConstants.INDENT));
+
+                teamConfig.api.layers.set(existingConfig);
+                teamConfig.layerActive().exists = true;
+
+                const params: IHandlerParameters = getIHandlerParametersObject();
+                params.arguments.location = __dirname + "/fakeapp.config.json";
+                params.arguments.merge = true;
+                params.arguments.dryRun = true;
+                await new ImportHandler().process(params);
+
+                expect(writeFileSyncSpy).not.toHaveBeenCalled();
+                const logOutput = (params.response.console.log as jest.Mock).mock.calls.join("\n");
+                expect(logOutput).toContain("[Dry Run]");
+                expect(logOutput).toContain("No changes were written to disk");
+                // Preview should show merged result with existing values preserved
+                expect(logOutput).toContain("my-host.com");
+            });
+
+            it("should not duplicate existing plugins when merging", async () => {
+                const existingWithPlugin: IConfig = {
+                    ...existingConfig,
+                    plugins: ["@zowe/cics-for-zowe-cli"]
+                };
+                jest.spyOn(fs, "existsSync").mockReturnValueOnce(true);
+                readFileSyncSpy.mockReturnValueOnce(JSONC.stringify(importedConfig, null, ConfigConstants.INDENT));
+                writeFileSyncSpy.mockReturnValueOnce();
+
+                teamConfig.api.layers.set(existingWithPlugin);
+                teamConfig.layerActive().exists = true;
+
+                const params: IHandlerParameters = getIHandlerParametersObject();
+                params.arguments.location = __dirname + "/fakeapp.config.json";
+                params.arguments.merge = true;
+                await new ImportHandler().process(params);
+
+                expect(writeFileSyncSpy).toHaveBeenCalled();
+                const written = JSONC.parse(writeFileSyncSpy.mock.calls[0][1] as string) as unknown as IConfig;
+                const pluginCount = written.plugins.filter((p: string) => p === "@zowe/cics-for-zowe-cli").length;
+                expect(pluginCount).toBe(1);
+            });
+
+            it("should not overwrite autoStore when it is already defined as false", async () => {
+                jest.spyOn(fs, "existsSync").mockReturnValueOnce(true);
+                readFileSyncSpy.mockReturnValueOnce(JSONC.stringify(importedConfig, null, ConfigConstants.INDENT));
+                writeFileSyncSpy.mockReturnValueOnce();
+
+                teamConfig.api.layers.set({ ...existingConfig, autoStore: false });
+                teamConfig.layerActive().exists = true;
+
+                const params: IHandlerParameters = getIHandlerParametersObject();
+                params.arguments.location = __dirname + "/fakeapp.config.json";
+                params.arguments.merge = true;
+                await new ImportHandler().process(params);
+
+                const written = JSONC.parse(writeFileSyncSpy.mock.calls[0][1] as string) as unknown as IConfig;
+                expect(written.autoStore).toBe(false);
+            });
+
+        });
     });
 
     describe("fetch config", () => {

--- a/packages/imperative/src/imperative/src/config/cmd/import/CHANGES.md
+++ b/packages/imperative/src/imperative/src/config/cmd/import/CHANGES.md
@@ -1,0 +1,82 @@
+# Changes to `zowe config import`
+
+## Summary
+
+The `zowe config import` command has been enhanced with two new flags (`--merge` and `--dry-run`) and a safer conflict-resolution strategy when merging into an existing `zowe.config.json`.
+
+---
+
+## New Flags
+
+### `--merge` / `--mg`
+
+Merges properties from the imported config into the existing `zowe.config.json` instead of overwriting it.
+
+- **Existing values always win.** If a key exists in both the target file and the imported file, the target's value is kept unchanged.
+- If no config file exists yet at the target location, the imported config is written as-is (same behaviour as a normal first-time import).
+- Cannot be combined with `--overwrite` (mutually exclusive — the handler raises a clear error if both are passed).
+
+### `--dry-run` / `--dr`
+
+Previews what the resulting config would look like without writing any changes to disk.
+
+- Works independently of `--merge`: use alone to preview a full overwrite, or combine with `--merge` to preview a merge.
+- Prints a `[Dry Run]` header, the full JSON that would be written, and a reminder that no changes were made.
+- Schema download is skipped during a dry run (no side effects of any kind).
+
+---
+
+## Behaviour Matrix
+
+| Scenario | Result |
+|---|---|
+| File does not exist | Import as normal (write the incoming config) |
+| File exists, no flags | Skip with a message listing all available options |
+| File exists, `--overwrite` | Full replace (existing behaviour, unchanged) |
+| File exists, `--merge` | Safe merge — existing values win; missing keys are added from import |
+| Any scenario, `--dry-run` | Print the would-be result; nothing written to disk |
+| `--merge --dry-run` | Print the merged preview; nothing written to disk |
+| `--overwrite --dry-run` | Print the overwrite preview; nothing written to disk |
+| `--merge --overwrite` | Error — options are mutually exclusive |
+
+---
+
+## Merge Semantics (field-by-field)
+
+When `--merge` is used against an existing file, each top-level field is handled as follows:
+
+| Field | Rule |
+|---|---|
+| `profiles` | Deep-merged. For every nested property, the existing target value wins on conflict. New profiles present only in the import are added. |
+| `profiles.*.properties` (arrays) | Existing arrays are kept entirely as-is — no elements are removed or reordered. |
+| `defaults` | Shallow merge. Existing default entries win on conflict. Only keys absent from the target are added from the import. |
+| `plugins` | Additive only. New plugin names from the import are appended if not already in the list. Existing plugins are never removed. |
+| `autoStore` | Only set from the import if the target does not already define the property (even an explicit `false` in the target is respected). |
+
+---
+
+## Skip Message Update
+
+When an existing file is found and no relevant flag is passed, the skip message now lists all three escape hatches:
+
+```
+Skipping import because <path> already exists.
+Rerun the command with --overwrite to replace it, --merge to add missing
+properties, or --dry-run to preview what would happen.
+```
+
+---
+
+## Files Changed
+
+| File | Change |
+|---|---|
+| `import.definition.ts` | Added `--merge` and `--dry-run` option definitions; added three new usage examples |
+| `import.handler.ts` | Rewrote `process()` to support merge, dry-run, and safe field-level conflict resolution; added `lodash` import for merge logic |
+
+---
+
+## Implementation Notes
+
+- The merge logic is implemented directly in `import.handler.ts` rather than delegating to `ConfigLayers.merge()`. This is intentional: the framework's `merge()` method has argument-order subtleties with `lodash.merge` that can cause imported `defaults` to overwrite existing ones, and it unconditionally overwrites `autoStore`. The handler's own merge makes the "existing wins" guarantee explicit for every field.
+- Schema import is unchanged for normal and `--overwrite` modes. It is intentionally skipped during `--dry-run` to ensure the operation has no side effects.

--- a/packages/imperative/src/imperative/src/config/cmd/import/import.definition.ts
+++ b/packages/imperative/src/imperative/src/config/cmd/import/import.definition.ts
@@ -56,6 +56,24 @@ export const importDefinition: ICommandDefinition = {
             defaultValue: false
         },
         {
+            name: "merge",
+            description: "Merge properties from the imported config into the existing config file " +
+                "instead of overwriting it. Existing values take priority over imported values. " +
+                "If no config file exists yet, the imported config is written as-is.",
+            aliases: ["mg"],
+            type: "boolean",
+            defaultValue: false
+        },
+        {
+            name: "dry-run",
+            description: "Preview the config that would result from the import without writing " +
+                "any changes to disk. Combine with --merge to preview a merge, or use alone to " +
+                "preview a full overwrite.",
+            aliases: ["dr"],
+            type: "boolean",
+            defaultValue: false
+        },
+        {
             name: "user",
             aliases: ["u"],
             description: "User name if authentication is required to download the config from a URL.",
@@ -88,6 +106,18 @@ export const importDefinition: ICommandDefinition = {
         {
             description: "Import global config from Internet URL",
             options: "https://example.com/zowe.config.json --global-config"
+        },
+        {
+            description: "Merge a downloaded team config into the existing project config, adding only missing properties",
+            options: "https://example.com/zowe.config.json --merge"
+        },
+        {
+            description: "Preview what the project config would look like after merging a remote config, without writing any changes",
+            options: "https://example.com/zowe.config.json --merge --dry-run"
+        },
+        {
+            description: "Preview what a full overwrite would produce without writing any changes",
+            options: "~/Downloads/zowe.config.json --overwrite --dry-run"
         }
     ]
 };

--- a/packages/imperative/src/imperative/src/config/cmd/import/import.handler.ts
+++ b/packages/imperative/src/imperative/src/config/cmd/import/import.handler.ts
@@ -16,7 +16,8 @@ import * as JSONC from "comment-json";
 import { ICommandHandler, IHandlerParameters } from "../../../../../cmd";
 import { ImperativeError } from "../../../../../error";
 import { ImperativeConfig, TextUtils } from "../../../../../utilities";
-import { IConfig } from "../../../../../config";
+import * as lodash from "lodash";
+import { ConfigConstants, IConfig, IConfigLayer } from "../../../../../config";
 import { AuthOrder, RestClient, Session, SessConstants } from "../../../../../rest";
 
 /**
@@ -41,9 +42,25 @@ export default class ImportHandler implements ICommandHandler {
         config.api.layers.activate(params.arguments.userConfig, params.arguments.globalConfig, configDir);
         const layer = config.api.layers.get();
 
-        if (layer.exists && !params.arguments.overwrite) {
-            params.response.console.log(`Skipping import because ${layer.path} already exists.\n` +
-                `Rerun the command with the --overwrite flag to import anyway.`);
+        const isDryRun = params.arguments.dryRun as boolean;
+        const isMerge = params.arguments.merge as boolean;
+        const isOverwrite = params.arguments.overwrite as boolean;
+
+        if (isMerge && isOverwrite) {
+            throw new ImperativeError({
+                msg: "The --merge and --overwrite options are mutually exclusive. " +
+                    "Use --merge to add missing properties to an existing config, " +
+                    "or --overwrite to replace it entirely."
+            });
+        }
+
+        // Guard: skip when the file already exists and neither --overwrite, --merge, nor --dry-run is given
+        if (layer.exists && !isOverwrite && !isMerge && !isDryRun) {
+            params.response.console.log(
+                `Skipping import because ${layer.path} already exists.\n` +
+                `Rerun the command with --overwrite to replace it, --merge to add missing ` +
+                `properties, or --dry-run to preview what would happen.`
+            );
             return;
         }
 
@@ -53,10 +70,66 @@ export default class ImportHandler implements ICommandHandler {
         const configJson: IConfig = isConfigLocal ?
             JSONC.parse(fs.readFileSync(configFilePath, "utf-8")) as any :
             await this.fetchConfig(new URL(params.arguments.location));
-        config.api.layers.set(configJson);
 
+        // Apply the incoming config to the active layer
+        let previewLayer: IConfigLayer | undefined;
+        if (isMerge && layer.exists) {
+            // Safe merge: existing target values always win over incoming imported values.
+            // We operate on a clone for dry-run so nothing is mutated on disk.
+            const target: IConfigLayer = isDryRun
+                ? JSONC.parse(JSONC.stringify(layer, null, ConfigConstants.INDENT)) as unknown as IConfigLayer
+                : config.api.layers.get();
+
+            // profiles: deep-merge with existing winning — lodash.mergeWith(existing, incoming)
+            target.properties.profiles = lodash.mergeWith(
+                {},
+                configJson.profiles,       // imported (lower priority, applied first)
+                target.properties.profiles, // existing (higher priority, applied second — wins)
+                (existingVal: any, _importedVal: any) => {
+                    // For arrays, keep the existing array as-is
+                    if (lodash.isArray(existingVal)) { return existingVal; }
+                }
+            );
+
+            // defaults: existing key/value pairs win; only add keys missing from target
+            target.properties.defaults = {
+                ...configJson.defaults,        // imported base
+                ...target.properties.defaults  // existing overrides (wins on conflict)
+            };
+
+            // plugins: add any new plugins from the import not already present
+            for (const plugin of configJson.plugins ?? []) {
+                if (target.properties.plugins == null) {
+                    target.properties.plugins = [plugin];
+                } else if (!target.properties.plugins.includes(plugin)) {
+                    target.properties.plugins.push(plugin);
+                }
+            }
+
+            // autoStore: only set if target does not already define it
+            if (target.properties.autoStore == null && configJson.autoStore != null) {
+                target.properties.autoStore = configJson.autoStore;
+            }
+
+            if (isDryRun) {
+                previewLayer = target;
+            } else {
+                config.api.layers.set(target.properties);
+            }
+        } else if (isDryRun) {
+            // Overwrite dry-run: build a clone of the layer with the incoming config applied
+            previewLayer = JSONC.parse(JSONC.stringify(layer, null, ConfigConstants.INDENT)) as unknown as IConfigLayer;
+            previewLayer.properties = configJson;
+            previewLayer.properties.defaults = previewLayer.properties.defaults ?? {};
+            previewLayer.properties.profiles = previewLayer.properties.profiles ?? {};
+        } else {
+            // Normal import (first-time or --overwrite)
+            config.api.layers.set(configJson);
+        }
+
+        // Import schema alongside the config (skip during dry-run — no side effects)
         let schemaImported = false;
-        if (configJson.$schema?.startsWith("./")) {  // Only import schema if relative path
+        if (!isDryRun && configJson.$schema?.startsWith("./")) {  // Only import schema if relative path
             const schemaUri = new URL(configJson.$schema,
                 isConfigLocal ? pathToFileURL(configFilePath) : params.arguments.location);
             const schemaFilePath = path.resolve(path.dirname(layer.path), configJson.$schema);
@@ -69,10 +142,22 @@ export default class ImportHandler implements ICommandHandler {
             }
         }
 
-        // Write the active created/updated config layer
-        config.api.layers.write();
-
-        params.response.console.log(`Imported config${schemaImported ? " and schema" : ""} to ${layer.path}`);
+        if (isDryRun) {
+            // Print a preview of the would-be result without touching disk
+            params.response.console.log(
+                TextUtils.chalk.yellow("[Dry Run]") +
+                ` The following config would be written to ${layer.path}:\n`
+            );
+            params.response.console.log(
+                JSONC.stringify((previewLayer as IConfigLayer).properties, null, ConfigConstants.INDENT)
+            );
+            params.response.console.log("\nNo changes were written to disk. Remove --dry-run to apply.");
+        } else {
+            // Write the active created/updated config layer
+            config.api.layers.write();
+            const action = isMerge && layer.exists ? "Merged config" : "Imported config";
+            params.response.console.log(`${action}${schemaImported ? " and schema" : ""} to ${layer.path}`);
+        }
     }
 
     /**


### PR DESCRIPTION
## Summary

- **`--merge` (`-mg`)**: Merges properties from an imported config into the existing `zowe.config.json` instead of overwriting it. Existing values win on all conflicts — profiles are deep-merged, defaults use existing keys, plugins are appended without duplication, and `autoStore` is only set if not already defined.
- **`--dry-run` (`-dr`)**: Previews the resulting config without writing anything to disk. Works standalone (preview a full overwrite) or combined with `--merge` (preview a safe merge). Schema download is skipped during dry runs.
- Updated the "file already exists" skip message to advertise `--merge` and `--dry-run` alongside the existing `--overwrite` hint.
- Added `CHANGES.md` documenting the new behaviour, merge semantics, and a behaviour matrix.

## Motivation

`zowe config import` previously offered only two modes: skip (if the target file already existed) or overwrite (`--overwrite`). Users with an existing `zowe.config.json` had no safe way to adopt new defaults or profiles from a shared/team configuration without losing their own settings. This PR closes that gap.

## Behaviour matrix

| Flag(s) | File exists? | Result |
|---|---|---|
| _(none)_ | No | Write imported config as-is |
| _(none)_ | Yes | Skip (no change) |
| `--overwrite` | Yes | Overwrite existing file |
| `--merge` | No | Write imported config as-is |
| `--merge` | Yes | Deep-merge; **existing values win** |
| `--dry-run` | Any | Print result to console, no disk write |
| `--merge --dry-run` | Yes | Print merge preview, no disk write |
| `--merge --overwrite` | Any | Error (mutually exclusive) |

## Merge semantics (field-by-field)

| Field | Rule |
|---|---|
| `profiles` | Deep-merged via `lodash.mergeWith`; existing property values and arrays are preserved |
| `defaults` | Shallow spread — existing keys are never overwritten; only missing keys are added |
| `plugins` | Additive — new plugin names appended only if not already in the list |
| `autoStore` | Only set from imported config if the target does not already define it |

## Test plan

- [x] 10 new unit tests in `import.handler.unit.test.ts` covering all flag combinations, mutual exclusion, skip message text, dry-run output, and field-level merge correctness
- [x] 5 new integration tests in the CLI config import subtest file covering help output, `--dry-run`, `--merge --dry-run`, `--merge` on existing file, and `--merge` first-time import
- [x] New fixture `test.config.for.merge.json` with overlapping and new profiles/defaults used by integration tests
- [ ] Manual smoke test: `zowe config import <url> --merge --dry-run` against a live profile

## Files changed

| File | Change |
|---|---|
| `src/config/cmd/import/import.definition.ts` | Added `--merge` and `--dry-run` options and three new usage examples |
| `src/config/cmd/import/import.handler.ts` | Implemented safe merge logic, dry-run preview, mutual exclusion guard, updated skip message |
| `src/config/cmd/import/CHANGES.md` | New — documents all changes |
| `__tests__/config/cmd/import/import.handler.unit.test.ts` | 10 new unit tests |
| `__tests__/__integration__/.../cli/config/import/cli.imperative-test-cli.config.import.integration.subtest.ts` | 5 new integration tests + updated help assertion |
| `__tests__/__integration__/.../cli/config/import/__resources__/test.config.for.merge.json` | New integration test fixture |


Made with [Cursor](https://cursor.com)