### PR TITLE
Remove error message displayed before valid JSON by the npm pack command

### DIFF
--- a/packages/imperative/CHANGELOG.md
+++ b/packages/imperative/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Imperative package will be documented in this file.
 
+## Recent Changes
+
+- BugFix: Removed text which is sometimes displayed by the `npm pack --dry-run --json` command before its valid JSON output, thus avoiding a Zowe error stating that a plugin cannot be installed. This problem occurs mostly in build pipelines. [#2713](https://github.com/zowe/zowe-cli/issues/2713)
+
 ## `8.31.3`
 
 - BugFix: Increased the max buffer size of output for `npm pack` command run during plug-in installation. [#2708](https://github.com/zowe/zowe-cli/pull/2708)

--- a/packages/imperative/src/imperative/__tests__/plugins/utilities/NpmFunctions.unit.test.ts
+++ b/packages/imperative/src/imperative/__tests__/plugins/utilities/NpmFunctions.unit.test.ts
@@ -126,7 +126,6 @@ describe("NpmFunctions", () => {
         });
 
         it("should discard error message text before valid JSON output", () => {
-            // zzz const errLoggerSpy = jest.spyOn(Logger, "getAppLogger").mockReturnValue({ level: "ERROR" } as any);
             let logMsg = "";
             jest.spyOn(Logger, "getImperativeLogger").mockReturnValueOnce({
                 error: jest.fn((errMsg) => {

--- a/packages/imperative/src/imperative/__tests__/plugins/utilities/NpmFunctions.unit.test.ts
+++ b/packages/imperative/src/imperative/__tests__/plugins/utilities/NpmFunctions.unit.test.ts
@@ -125,6 +125,34 @@ describe("NpmFunctions", () => {
             );
         });
 
+        it("should discard error message text before valid JSON output", () => {
+            // zzz const errLoggerSpy = jest.spyOn(Logger, "getAppLogger").mockReturnValue({ level: "ERROR" } as any);
+            let logMsg = "";
+            jest.spyOn(Logger, "getImperativeLogger").mockReturnValueOnce({
+                error: jest.fn((errMsg) => {
+                    logMsg = errMsg;
+                })
+            } as any);
+
+            const pkgSpec = "imperative.tgz";
+            expect(npmPackageArg(pkgSpec).type).toEqual("file");
+
+            const fakeErrText = "Fake error text that should be logged";
+            const spawnSpy = jest.spyOn(ExecUtils, "spawnAndGetOutput").mockReturnValueOnce(
+                fakeErrText + "\n" + JSON.stringify([expectedInfo])
+            );
+            const actualInfo = npmFunctions.getPackageInfo(pkgSpec);
+            expect(logMsg).toContain(
+                "The following errors were displayed by 'npm pack' before its JSON output:"
+            );
+            expect(logMsg).toContain(fakeErrText);
+            expect(actualInfo).toEqual(expectedInfo);
+            expect(spawnSpy).toHaveBeenCalledWith(npmCmd,
+                expect.arrayContaining(["pack", pkgSpec]),
+                expect.objectContaining({ maxBuffer: expect.any(Number) })
+            );
+        });
+
         it("should fetch info for package installed from Git URL", () => {
             const pkgSpec = "github:zowe/imperative";
             expect(npmPackageArg(pkgSpec).type).toEqual("git");
@@ -167,7 +195,11 @@ describe("NpmFunctions", () => {
                 throw new Error("Fake out an error thrown by cross-spawn.sync");
             });
             expect(() => npmFunctions.getPackageInfo(pkgSpec)).toThrow(
-                `npm pack command failed for package: '${pkgSpec}'`);
+                `Spawn of 'npm pack' command failed for package: '${pkgSpec}'` +
+                `\nSpawn error = Fake out an error thrown by cross-spawn.sync` +
+                `\nOutput of the spawn action:` +
+                `\nNo npm pack output was retrieved`
+            );
         });
 
         it("should throw error if npm pack output is not parsable JSON", () => {
@@ -176,7 +208,11 @@ describe("NpmFunctions", () => {
 
             jest.spyOn(ExecUtils, "spawnAndGetOutput").mockReturnValueOnce("[]");
             expect(() => npmFunctions.getPackageInfo(pkgSpec)).toThrow(
-                `Unable to parse the following package as JSON: '${pkgSpec}'`);
+                `Unable to parse the JSON output of 'npm pack' for this package: '${pkgSpec}'` +
+                `\nJSON.parse error = Cannot read properties of undefined (reading 'name')` +
+                `\nOutput of 'npm pack':` +
+                `\n[]`
+            );
         });
     });
 

--- a/packages/imperative/src/imperative/__tests__/plugins/utilities/NpmFunctions.unit.test.ts
+++ b/packages/imperative/src/imperative/__tests__/plugins/utilities/NpmFunctions.unit.test.ts
@@ -106,7 +106,10 @@ describe("NpmFunctions", () => {
             const spawnSpy = jest.spyOn(ExecUtils, "spawnAndGetOutput").mockReturnValueOnce(JSON.stringify([expectedInfo]));
             const actualInfo = npmFunctions.getPackageInfo(pkgSpec);
             expect(actualInfo).toEqual(expectedInfo);
-            expect(spawnSpy).toHaveBeenCalledWith(npmCmd, expect.arrayContaining(["pack", pkgSpec]), expect.objectContaining({ maxBuffer: expect.any(Number) }));
+            expect(spawnSpy).toHaveBeenCalledWith(npmCmd,
+                expect.arrayContaining(["pack", pkgSpec]),
+                expect.objectContaining({ maxBuffer: expect.any(Number) })
+            );
         });
 
         it("should fetch info for package installed from local TGZ", () => {
@@ -116,7 +119,10 @@ describe("NpmFunctions", () => {
             const spawnSpy = jest.spyOn(ExecUtils, "spawnAndGetOutput").mockReturnValueOnce(JSON.stringify([expectedInfo]));
             const actualInfo = npmFunctions.getPackageInfo(pkgSpec);
             expect(actualInfo).toEqual(expectedInfo);
-            expect(spawnSpy).toHaveBeenCalledWith(npmCmd, expect.arrayContaining(["pack", pkgSpec]), expect.objectContaining({ maxBuffer: expect.any(Number) }));
+            expect(spawnSpy).toHaveBeenCalledWith(npmCmd,
+                expect.arrayContaining(["pack", pkgSpec]),
+                expect.objectContaining({ maxBuffer: expect.any(Number) })
+            );
         });
 
         it("should fetch info for package installed from Git URL", () => {
@@ -126,7 +132,10 @@ describe("NpmFunctions", () => {
             const spawnSpy = jest.spyOn(ExecUtils, "spawnAndGetOutput").mockReturnValueOnce(JSON.stringify([expectedInfo]));
             const actualInfo = npmFunctions.getPackageInfo(pkgSpec);
             expect(actualInfo).toEqual(expectedInfo);
-            expect(spawnSpy).toHaveBeenCalledWith(npmCmd, expect.arrayContaining(["pack", pkgSpec]), expect.objectContaining({ maxBuffer: expect.any(Number) }));
+            expect(spawnSpy).toHaveBeenCalledWith(npmCmd,
+                expect.arrayContaining(["pack", pkgSpec]),
+                expect.objectContaining({ maxBuffer: expect.any(Number) })
+            );
         });
 
         it("should fetch info for package installed from remote TGZ", () => {
@@ -136,7 +145,10 @@ describe("NpmFunctions", () => {
             const spawnSpy = jest.spyOn(ExecUtils, "spawnAndGetOutput").mockReturnValueOnce(JSON.stringify([expectedInfo]));
             const actualInfo = npmFunctions.getPackageInfo(pkgSpec);
             expect(actualInfo).toEqual(expectedInfo);
-            expect(spawnSpy).toHaveBeenCalledWith(npmCmd, expect.arrayContaining(["pack", pkgSpec]), expect.objectContaining({ maxBuffer: expect.any(Number) }));
+            expect(spawnSpy).toHaveBeenCalledWith(npmCmd,
+                expect.arrayContaining(["pack", pkgSpec]),
+                expect.objectContaining({ maxBuffer: expect.any(Number) })
+            );
         });
 
         it("getScopeRegistry() should return registry for 'test' scope", () => {
@@ -152,7 +164,7 @@ describe("NpmFunctions", () => {
             expect(npmPackageArg(pkgSpec).type).toEqual("file");
 
             jest.spyOn(ExecUtils, "spawnAndGetOutput").mockImplementation(() => {
-                throw new Error("Fake out an error thrown by cross-spawn.sync")
+                throw new Error("Fake out an error thrown by cross-spawn.sync");
             });
             expect(() => npmFunctions.getPackageInfo(pkgSpec)).toThrow(
                 `npm pack command failed for package: '${pkgSpec}'`);

--- a/packages/imperative/src/imperative/src/plugins/utilities/NpmFunctions.ts
+++ b/packages/imperative/src/imperative/src/plugins/utilities/NpmFunctions.ts
@@ -121,18 +121,21 @@ export function getPackageInfo(pkgSpec: string): { name: string, version: string
             });
         }
 
-        // In test pipelines, parallel tests are using Git to retrieve source to compile and
-        // for CodeQL analysis. Some conflict causes <YourSourceCodeRootDirectory>/.git/config.lock
+        // In test pipelines, parallel tests use Git to retrieve source to compile and to
+        // run CodeQL analysis. Some conflict causes <YourSourceCodeRootDirectory>/.git/config.lock
         // to be left around. As a result, when the pipeline spawns 'npm pack' to get the contents
-        // of package.json, an error message that looks like this:
+        // of package.json, an error message that looks like the following may be displayed before
+        // the correct contents of package.json.
+        //
         //      "error: could not lock config file .git/config: File exists"
         //          or
         //      "warning: unable to access '.git/config': Permission denied"
-        // may be displayed before the correct contents of package.json.
-        // JSON.parse() throws an error because of that error text. A successful 'npm pack' command
-        // always displays its results in an array. The following code looks for the start of an array
-        // and removes any error messages that occurs before the array of valid JSON. This allows
-        // the JSON to be successfully parsed. Any error message is logged.
+        //
+        // JSON.parse() fails to parse the output because of that error message.
+        // A successful 'npm pack' command always displays its results in an array.
+        // The following code looks for the start of an array and removes any text
+        // that occurs before the array of valid JSON. This allows
+        // the JSON to be successfully parsed. Any removed text is logged.
         let startOfJsonInx = execOutput.indexOf("\n[");
         if (startOfJsonInx > 0) {
             // we had some text before a JSON array

--- a/packages/imperative/src/imperative/src/plugins/utilities/NpmFunctions.ts
+++ b/packages/imperative/src/imperative/src/plugins/utilities/NpmFunctions.ts
@@ -97,27 +97,66 @@ export function installPackages(npmPackage: string, npmArgs: INpmInstallArgs, ve
  */
 export function getPackageInfo(pkgSpec: string): { name: string, version: string, [key: string]: unknown } {
     const pkgInfo = npmPackageArg(pkgSpec);
-    // eslint-disable-next-line @typescript-eslint/no-magic-numbers
-    const maxBuffer = 1024 * 1024 * 10; // 10MB
     let packageName = pkgInfo.name;
+
     if (!pkgInfo.registry) {
         // Package name is unknown, so fetch it with 'npm pack' command
-        let execOutput: Buffer | string = "No Spawn output retrieved";
+        const maxOutputInx = 200;
+        let truncationMsg = "\n<Additional output not displayed>";
+        let execOutput:string = "No npm pack output was retrieved";
         try {
-            execOutput = ExecUtils.spawnAndGetOutput(npmCmd, ["pack", pkgSpec, "--dry-run", "--json"], { maxBuffer });
+            // eslint-disable-next-line @typescript-eslint/no-magic-numbers
+            const maxBuffer = 1024 * 1024 * 10; // 10MB
+            execOutput = ExecUtils.spawnAndGetOutput(
+                npmCmd, ["pack", pkgSpec, "--dry-run", "--json"], { maxBuffer }
+            ).toString();
         } catch (err) {
+            if (execOutput.length < maxOutputInx) {
+                truncationMsg = "";
+            }
             throw new ImperativeError({
-                msg: `npm pack command failed for package: '${pkgSpec}'`,
-                additionalDetails: "Reason = " + (err as Error).message
+                msg: `Spawn of 'npm pack' command failed for package: '${pkgSpec}'` +
+                    "\nSpawn error = " + (err as Error).message +
+                    "\nOutput of the spawn action:\n" + execOutput.substring(0, maxOutputInx) + truncationMsg
             });
         }
+
+        // In test pipelines, parallel tests are using Git to retrieve source to compile and
+        // for CodeQL analysis. Some conflict causes <YourSourceCodeRootDirectory>/.git/config.lock
+        // to be left around. As a result, when the pipeline spawns 'npm pack' to get the contents
+        // of package.json, an error message that looks like this:
+        //      "error: could not lock config file .git/config: File exists"
+        //          or
+        //      "warning: unable to access '.git/config': Permission denied"
+        // may be displayed before the correct contents of package.json.
+        // JSON.parse() throws an error because of that error text. A successful 'npm pack' command
+        // always displays its results in an array. The following code looks for the start of an array
+        // and removes any error messages that occurs before the array of valid JSON. This allows
+        // the JSON to be successfully parsed. Any error message is logged.
+        let startOfJsonInx = execOutput.indexOf("\n[");
+        if (startOfJsonInx > 0) {
+            // we had some text before a JSON array
+            Logger.getImperativeLogger().error(
+                "The following errors were displayed by 'npm pack' before its JSON output:\n" +
+                execOutput.substring(0, startOfJsonInx)
+            );
+
+            // discard the errors, and keep the JSON array
+            startOfJsonInx++;
+            execOutput = execOutput.substring(startOfJsonInx);
+        }
+
         // parse the json output of the npm pack command
         try {
-            packageName = JSON.parse(execOutput.toString())[0].name;
+            packageName = JSON.parse(execOutput)[0].name;
         } catch (err) {
+            if (execOutput.length < maxOutputInx) {
+                truncationMsg = "";
+            }
             throw new ImperativeError({
-                msg: `Unable to parse the following package as JSON: '${pkgSpec}'`,
-                additionalDetails: "Reason = " + (err as Error).message
+                msg: `Unable to parse the JSON output of 'npm pack' for this package: '${pkgSpec}'` +
+                    "\nJSON.parse error = " + (err as Error).message +
+                    "\nOutput of 'npm pack':\n" + execOutput.substring(0, maxOutputInx) + truncationMsg
             });
         }
     }


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->

In test pipelines, parallel tests use Git to retrieve source to compile and to run CodeQL analysis. Some conflict causes <YourSourceCodeRootDirectory>/.git/config.lock to be left around. As a result, when the pipeline spawns 'npm pack' to get the contents of package.json, an error message that looks like the following may be displayed before the correct contents of package.json.
```
"error: could not lock config file .git/config: File exists"
    or
"warning: unable to access '.git/config': Permission denied"
```
JSON.parse() fails to parse the output because of that error message. The typical result is that Zowe reports that it cannot install a plugin.

A successful 'npm pack' command always displays its results in an array. This pull request looks for the start of an array and removes any text that occurs before the array of valid JSON. This allows the JSON to be successfully parsed. The removed text is logged.

Fixes  #2713

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->

Because this problems occurs as an edge-case involving parallel operations, the only reliable way to create the problem is to hack the code in NpmFunctions.getPackageInfo to display an arbitrary message before the expected JSON output. The logic of this pull request will then remove that arbitrary message before the output of the `npm pack` command, allowing that output to be successfully parsed as JSON.

The real-world observation of this fix would be in the build pipeline of the Zowe sample plug-in, in which three to five jobs routinely fail. Currently, you can only make the sample plug-in pipeline succeed by repeatedly re-running each pipeline job. Unfortunately, the changes of this PR will not be included in the sample plug-in pipeline until this PR has been merged into the master branch of Zowe CLI.

**Review Checklist**
I certify that I have:
- [x] updated the changelog
- [x] manually tested my changes
- [x] added/updated automated unit/integration tests
- [x] created/ran system tests (provide build number if applicable)
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
