### PR TITLE
Fix misleading error message when installing plug-in

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to the Zowe CLI package will be documented in this file.
 
+## Recent Changes
+
+- BugFix: Updated the error handling for plugin installation to report the first failure that occurs. [#2722](https://github.com/zowe/zowe-cli/pull/2722)
+- BugFix: Updated the display of failures from 3rd party programs to include more diagnostic information while avoiding repeated text. [#2722](https://github.com/zowe/zowe-cli/pull/2722)
+
 ## `8.32.0`
 
 - Enhancement: Added `certAccount` option to z/OSMF profile type to support client certificate authentication using certificates stored in system keystores (macOS Keychain or Windows Certificate Store). This enables secure authentication with both exportable and non-exportable private keys on macOS and Windows platforms. [#2325](https://github.com/zowe/zowe-cli/issues/2325)

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -4,8 +4,8 @@ All notable changes to the Zowe CLI package will be documented in this file.
 
 ## Recent Changes
 
-- BugFix: Updated the error handling for plugin installation to report the first failure that occurs. [#2722](https://github.com/zowe/zowe-cli/pull/2722)
-- BugFix: Updated the display of failures from 3rd party programs to include more diagnostic information while avoiding repeated text. [#2722](https://github.com/zowe/zowe-cli/pull/2722)
+- BugFix: Updated the error handling for plug-in installation to report the first failure that occurs. [#2722](https://github.com/zowe/zowe-cli/pull/2722)
+- BugFix: Updated the display of failures from third party programs to include more diagnostic information while avoiding repeated text. [#2722](https://github.com/zowe/zowe-cli/pull/2722)
 
 ## `8.32.1`
 

--- a/packages/imperative/CHANGELOG.md
+++ b/packages/imperative/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the Imperative package will be documented in this file.
 
+## Recent Changes
+
+- BugFix: Updated the NpmFunctions.installPackages function to throw an error when a launched NPM program fails. [#2722](https://github.com/zowe/zowe-cli/pull/2722)
+- BugFix: Updated the ExecUtils.handleSpawnResult function to display more detailed failure information from 3rd party programs. [#2722](https://github.com/zowe/zowe-cli/pull/2722)
+- BugFix: Added the ImperativeError.newImpErrorFromExistingError function and used it to display failures from 3rd party programs with more diagnostic information while avoiding repeated text. [#2722](https://github.com/zowe/zowe-cli/pull/2722)
+
 ## `8.32.0`
 
 - Enhancement: Added support for client certificate authentication using certificates stored in system keystores. Added `certAccount` profile property to specify certificate subject name for authentication. Implemented cross-platform native HTTPS clients (macOS and Windows) that support certificate-based authentication with both exportable and non-exportable private keys. Updated `AbstractRestClient` to use native HTTPS clients when `certAccount` is specified on macOS or Windows platforms. [#2325](https://github.com/zowe/zowe-cli/issues/2325)

--- a/packages/imperative/CHANGELOG.md
+++ b/packages/imperative/CHANGELOG.md
@@ -4,9 +4,9 @@ All notable changes to the Imperative package will be documented in this file.
 
 ## Recent Changes
 
-- BugFix: Updated the NpmFunctions.installPackages function to throw an error when a launched NPM program fails. [#2722](https://github.com/zowe/zowe-cli/pull/2722)
-- BugFix: Updated the ExecUtils.handleSpawnResult function to display more detailed failure information from 3rd party programs. [#2722](https://github.com/zowe/zowe-cli/pull/2722)
-- BugFix: Added the ImperativeError.newImpErrorFromExistingError function and used it to display failures from 3rd party programs with more diagnostic information while avoiding repeated text. [#2722](https://github.com/zowe/zowe-cli/pull/2722)
+- BugFix: Updated the `NpmFunctions.installPackages` function to throw an error when a launched NPM program fails. [#2722](https://github.com/zowe/zowe-cli/pull/2722)
+- BugFix: Updated the `ExecUtils.handleSpawnResult` function to display more detailed failure information from third party programs. [#2722](https://github.com/zowe/zowe-cli/pull/2722)
+- BugFix: Added the `ImperativeError.newImpErrorFromExistingError` function and used it to display failures from third party programs with more diagnostic information while avoiding repeated text. [#2722](https://github.com/zowe/zowe-cli/pull/2722)
 
 ## `8.32.0`
 

--- a/packages/imperative/__tests__/src/packages/imperative/plugins/suites/InstallingPlugins.ts
+++ b/packages/imperative/__tests__/src/packages/imperative/plugins/suites/InstallingPlugins.ts
@@ -117,7 +117,7 @@ describe("Installing Plugins", () => {
     const defaultCredMgrDisplayNm = "TestCLI";
     const knownCredMgr = CredentialManagerOverride.getKnownCredMgrs()[1];
     const knownCredMgrDisplayNm = knownCredMgr.credMgrDisplayName as string;
-    const knownCredMgrPluginNm = knownCredMgr.credMgrPluginName as string;
+    const knownCredMgrPluginNm = knownCredMgr.credMgrPluginName;
 
     /**
      * Change the pluginLifeCycle property in a plugin's Imperative configuration

--- a/packages/imperative/__tests__/src/packages/imperative/plugins/suites/InstallingPlugins.ts
+++ b/packages/imperative/__tests__/src/packages/imperative/plugins/suites/InstallingPlugins.ts
@@ -307,11 +307,18 @@ describe("Installing Plugins", () => {
         // Now that we have installed, remove lifecycle option for future tests
         changeLifeCycleInPkgJson(plugins.override.location, "remove");
 
-        expect(result.stderr).toContain(
-            `Unable to perform the post-install action for plugin '${plugins.override.name}'.`
-        );
-        expect(result.stderr).toContain("Reason: The credential manager name");
+        expect(result.stderr).toContain("Unable to perform this operation due to the following problem");
+        expect(result.stderr).toContain("Plug-in installation failed");
+        expect(result.stderr).toContain("Response From Service");
+        expect(result.stderr).toContain(`The plug-in '${plugins.override.name}' was installed, but the plug-in's post-install action failed.`);
+        expect(result.stderr).toContain("Diagnostic Information");
+        expect(result.stderr).toContain("The credential manager name");
         expect(result.stderr).toContain("is an unknown credential manager.");
+        expect(result.stderr).toContain("The previous credential manager will NOT be overridden. Valid credential managers are:");
+        expect(result.stderr).toContain("@zowe/cli");
+        expect(result.stderr).toContain("Secrets for Kubernetes");
+        expect(result.stderr).toContain("false");
+        expect(result.stderr).toContain("No further details are available");
 
         // settings/imperative.json should still contain the default credMgr
         expect(getCurrCredMgr()).toEqual(defaultCredMgrDisplayNm);
@@ -337,9 +344,12 @@ describe("Installing Plugins", () => {
         // Now that we have installed, remove lifecycle option for future tests
         changeLifeCycleInPkgJson(plugins.override.location, "remove");
 
-        expect(result.stderr).toContain("Install Failed");
-        expect(result.stderr).toContain(`Unable to perform the post-install action for plugin '${plugins.override.name}'.`);
-        expect(result.stderr).toContain("Reason: lifeCycleInstance.postInstall is not a function");
+        expect(result.stderr).toContain("Unable to perform this operation due to the following problem");
+        expect(result.stderr).toContain("Plug-in installation failed");
+        expect(result.stderr).toContain("Response From Service");
+        expect(result.stderr).toContain(`The plug-in '${plugins.override.name}' was installed, but the plug-in's post-install action failed`);
+        expect(result.stderr).toContain("Diagnostic Information");
+        expect(result.stderr).toContain("lifeCycleInstance.postInstall is not a function");
 
         // settings/imperative.json should still contain the default credMgr
         expect(getCurrCredMgr()).toEqual(defaultCredMgrDisplayNm);

--- a/packages/imperative/src/error/__tests__/ImperativeError.unit.test.ts
+++ b/packages/imperative/src/error/__tests__/ImperativeError.unit.test.ts
@@ -27,4 +27,95 @@ describe("ImperativeError", () => {
         (console.warn as any).mockRestore();
         /* eslint-enable no-console */
     });
+
+    describe("newImpErrorFromExistingError", () => {
+        it("should reject a null existing error", () => {
+            const newImpErr: ImperativeError = ImperativeError.newImpErrorFromExistingError(
+                null, "first parm cannot be null"
+            )
+            expect(newImpErr.message).toBe(
+                "The supplied parameter 'existingErr' was incorrectly null or undefined"
+            );
+        });
+
+        it("should tolerate a missing mainMsg", () => {
+            const existingErr = {
+                causeErrors: "Fake cause error",
+                additionalDetails: "Fake additional details"
+            };
+            const newImpErr: ImperativeError = ImperativeError.newImpErrorFromExistingError(existingErr)
+            expect(newImpErr.message).toBe(
+                "No problem text was supplied."
+            );
+        });
+
+        it("should resort to existingErr's causeErrors.mMessage as the new causeError", () => {
+            const mMessageInCause = "With no existingErr.mMessage or existingErr.message, " +
+                "use existingErr.causeErrors.mMessage";
+            const existingErr = {
+                causeErrors: {
+                    mMessage: mMessageInCause
+                },
+                additionalDetails: "Fake additional details"
+            };
+            const newImpErr: ImperativeError = ImperativeError.newImpErrorFromExistingError(
+                existingErr, "Fake main message")
+            expect(newImpErr.causeErrors).toBe(mMessageInCause);
+        });
+
+        it("should resort to existingErr's causeErrors.message as the new causeError", () => {
+            const messageInCause = "With no existingErr.mMessage or existingErr.message or " +
+                "existingErr.causeErrors.mMessage, use existingErr.cause.message";
+            const existingErr = {
+                cause: {
+                    message: messageInCause
+                },
+                additionalDetails: "Fake additional details"
+            };
+            const newImpErr: ImperativeError = ImperativeError.newImpErrorFromExistingError(
+                existingErr, "Fake main message")
+            expect(newImpErr.causeErrors).toBe(messageInCause);
+        });
+    });
+
+    describe("recordPropForOutput", () => {
+        it("should return false when a string propertyVal contains stringified raw data", () => {
+            const RAW_ERR_MSG = "Raw error data from operation:\n";
+            const errOutputData = {
+                stringVal: "",
+                rawVal: {}
+            }
+            const result = ImperativeError["recordPropForOutput"](
+                RAW_ERR_MSG + "Already stringified property", errOutputData
+            );
+            expect(result).toBe(false);
+        });
+
+        it("should append a string propertyVal to existing errOutputData.stringVal", () => {
+            const errOutputData = {
+                stringVal: "Some existing text",
+                rawVal: {}
+            }
+            const result = ImperativeError["recordPropForOutput"](
+                "Some new text", errOutputData
+            );
+            expect(result).toBe(true);
+
+            const os = require("os");
+            expect(errOutputData.stringVal).toBe("Some existing text" + os.EOL + "Some new text");
+        });
+
+        it("should return false when propertyVal is an object and errOutputData.rawValue already contains an object", () => {
+            const errOutputData = {
+                stringVal: "",
+                rawVal: {
+                    objProp: "rawVal already contains an object"
+                }
+            }
+            const result = ImperativeError["recordPropForOutput"](
+                {newVal: "some new object"}, errOutputData
+            );
+            expect(result).toBe(false);
+        });
+    });
 });

--- a/packages/imperative/src/error/__tests__/ImperativeError.unit.test.ts
+++ b/packages/imperative/src/error/__tests__/ImperativeError.unit.test.ts
@@ -32,7 +32,7 @@ describe("ImperativeError", () => {
         it("should reject a null existing error", () => {
             const newImpErr: ImperativeError = ImperativeError.newImpErrorFromExistingError(
                 null, "first parm cannot be null"
-            )
+            );
             expect(newImpErr.message).toBe(
                 "The supplied parameter 'existingErr' was incorrectly null or undefined"
             );
@@ -43,7 +43,7 @@ describe("ImperativeError", () => {
                 causeErrors: "Fake cause error",
                 additionalDetails: "Fake additional details"
             };
-            const newImpErr: ImperativeError = ImperativeError.newImpErrorFromExistingError(existingErr)
+            const newImpErr: ImperativeError = ImperativeError.newImpErrorFromExistingError(existingErr);
             expect(newImpErr.message).toBe(
                 "No problem text was supplied."
             );
@@ -59,7 +59,8 @@ describe("ImperativeError", () => {
                 additionalDetails: "Fake additional details"
             };
             const newImpErr: ImperativeError = ImperativeError.newImpErrorFromExistingError(
-                existingErr, "Fake main message")
+                existingErr, "Fake main message"
+            );
             expect(newImpErr.causeErrors).toBe(mMessageInCause);
         });
 
@@ -73,7 +74,8 @@ describe("ImperativeError", () => {
                 additionalDetails: "Fake additional details"
             };
             const newImpErr: ImperativeError = ImperativeError.newImpErrorFromExistingError(
-                existingErr, "Fake main message")
+                existingErr, "Fake main message"
+            );
             expect(newImpErr.causeErrors).toBe(messageInCause);
         });
     });
@@ -84,7 +86,7 @@ describe("ImperativeError", () => {
             const errOutputData = {
                 stringVal: "",
                 rawVal: {}
-            }
+            };
             const result = ImperativeError["recordPropForOutput"](
                 RAW_ERR_MSG + "Already stringified property", errOutputData
             );
@@ -95,7 +97,7 @@ describe("ImperativeError", () => {
             const errOutputData = {
                 stringVal: "Some existing text",
                 rawVal: {}
-            }
+            };
             const result = ImperativeError["recordPropForOutput"](
                 "Some new text", errOutputData
             );
@@ -111,7 +113,7 @@ describe("ImperativeError", () => {
                 rawVal: {
                     objProp: "rawVal already contains an object"
                 }
-            }
+            };
             const result = ImperativeError["recordPropForOutput"](
                 {newVal: "some new object"}, errOutputData
             );

--- a/packages/imperative/src/error/src/ImperativeError.ts
+++ b/packages/imperative/src/error/src/ImperativeError.ts
@@ -9,7 +9,7 @@
 *
 */
 
-const os = require("os");
+const os = require("node:os");
 import { IImperativeError } from "./doc/IImperativeError";
 import { IImperativeErrorParms } from "./doc/IImperativeErrorParms";
 

--- a/packages/imperative/src/error/src/ImperativeError.ts
+++ b/packages/imperative/src/error/src/ImperativeError.ts
@@ -9,8 +9,18 @@
 *
 */
 
+const os = require("os");
 import { IImperativeError } from "./doc/IImperativeError";
 import { IImperativeErrorParms } from "./doc/IImperativeErrorParms";
+
+/**
+ * This private interface is used to hold the string or object value of
+ * various ImperativeError properties. Used by function recordPropForOutput().
+ */
+interface IErrOutputData {
+    stringVal: string;
+    rawVal: any;
+}
 
 /**
  *
@@ -19,6 +29,8 @@ import { IImperativeErrorParms } from "./doc/IImperativeErrorParms";
  * @extends {Error}
  */
 export class ImperativeError extends Error {
+    private static readonly RAW_ERR_MSG = "Raw error data from operation:\n";
+
     /**
      * The message generated/specified for the error - used for display/message/diagnostic purposes
      * @private
@@ -48,6 +60,148 @@ export class ImperativeError extends Error {
                 this.mMessage = parms.tag + ": " + this.mMessage;
             }
         }
+    }
+
+    /**
+     * Within the Zowe client SDK, errors are often thrown, caught, modified, and re-thrown.
+     * Sometimes the error that we catch is a standard JavaScript Error. Other times the
+     * error is already an ImperativeError (which can contain more details). A hard-coded
+     * reliance on ImperativeError properties like causeErrors and additionalDetails will not
+     * work if the existingErr is a standard JavaScript Error. Also, the properties of an
+     * ImperativeError can be nested under various properties within its causeErrors property.
+     *
+     * The purpose of this utility function is to interrogate the existing error to form the
+     * most meaningful ImperativeError possible.
+     *
+     * @param {string} existingErr
+     *      An existing error to be incorporated into the resulting ImperativeError.
+     *
+     * @param {string} mainMsg
+     *      The main message text for the resulting ImperativeError. If not supplied,
+     *      the existingErr.message value will be used.
+     *
+     * @returns A newly created ImperativeError
+     * @memberof ImperativeError
+     */
+    public static newImpErrorFromExistingError(existingErr: any, mainMsg: string = "") : ImperativeError {
+        if (!existingErr) {
+            return new ImperativeError({
+                msg: "The supplied parameter 'existingErr' was incorrectly null or undefined",
+                causeErrors: "Stupid programming error",
+                additionalDetails: "Fix your program"
+            });
+        }
+
+        // set a mainMsg if one is not supplied as a parm
+        let existingErrMsgUsed = false;
+        if (!mainMsg) {
+            if (existingErr.mMessage) {
+                mainMsg = existingErr.mMessage;
+                existingErrMsgUsed = true;
+            }
+            else if (existingErr.message) {
+                mainMsg = existingErr.message;
+                existingErrMsgUsed = true;
+            } else {
+                mainMsg = "No problem text was supplied.";
+            }
+        }
+
+        // use the existingErr's message text as the cause (unless we already used that message)
+        let causeToUse = "";
+        if (existingErr.mMessage && !existingErrMsgUsed) {
+            causeToUse = existingErr.mMessage;
+        }
+        else if (existingErr.message && !existingErrMsgUsed) {
+            causeToUse = existingErr.message;
+        }
+        else if (existingErr.causeErrors?.mMessage) {
+            causeToUse = existingErr.causeErrors.mMessage;
+        }
+        else if (existingErr.cause?.message) {
+            causeToUse = existingErr.cause.message;
+        }
+
+        const detailsOutput: IErrOutputData = {
+            stringVal: "",
+            rawVal: {}
+        };
+
+        // Record existingErr's causeErrors property as a string or as raw data.
+        // Sometimes causeErrors are nested. Try the nested one first.
+        if (!ImperativeError.recordPropForOutput(existingErr.mDetails?.causeErrors?.mDetails?.causeErrors, detailsOutput)) {
+            ImperativeError.recordPropForOutput(existingErr.mDetails?.causeErrors, detailsOutput);
+        }
+
+        // Append existingErr's additionalDetails-like property if it is a string, or record it as an object
+        if (!ImperativeError.recordPropForOutput(existingErr.additionalDetails, detailsOutput)) {
+            if (!ImperativeError.recordPropForOutput(existingErr.causeErrors?.additionalDetails, detailsOutput)) {
+                if (!ImperativeError.recordPropForOutput(existingErr.cause, detailsOutput)) {
+                    if (!(existingErr instanceof ImperativeError)) {
+                        // only record the entire existingErr for other people's errors
+                        ImperativeError.recordPropForOutput(existingErr, detailsOutput);
+                    }
+                }
+            }
+        }
+
+        // if we could not discover a text message, dump the recorded raw data
+        if (detailsOutput.stringVal.length === 0) {
+            if (Object.keys(detailsOutput.rawVal).length > 0) {
+                detailsOutput.stringVal = ImperativeError.RAW_ERR_MSG + JSON.stringify(detailsOutput.rawVal, null, 2);
+            }
+        }
+        if (detailsOutput.stringVal.length === 0) {
+            detailsOutput.stringVal = "No further details are available.";
+        }
+
+        const impErrProps: IImperativeError = {
+            msg: mainMsg,
+            additionalDetails: detailsOutput.stringVal
+        };
+        if (causeToUse.length > 0) {
+            impErrProps.causeErrors = causeToUse;
+        }
+        return new ImperativeError(impErrProps);
+    }
+
+    /**
+     * This function interrogates the supplied propertyVal. If it is a string, it it appended
+     * to outputData.stringVal. If propertyVal is not a string and it is not null-or-undefined,
+     * and outputData.rawVal is currently empty, propertyVal is placed into outputData.rawVal.
+     *
+     * @param {IErrOutputData} outputData [output]
+     *      One (or neither) of outputData.stringVal or outputData.rawVal properties are
+     *      populated by this function. Before the first call to recordPropForOutput,
+     *      stringVal should be an empty string and rawVal should be an empty object.
+     *
+     * @returns True if a property was recorded. False otherwise.
+     * @memberof ImperativeError
+     */
+    private static recordPropForOutput(propertyVal: any, outputData: IErrOutputData): boolean {
+        if (!propertyVal) {
+            return false;
+        }
+
+        if (typeof propertyVal === "string") {
+            if (propertyVal.startsWith(ImperativeError.RAW_ERR_MSG)) {
+                // do not append to our stringVal if propertyVal is already stringified raw data
+                return false;
+            }
+            // append to the string output
+            if (outputData.stringVal.length > 0 && propertyVal.length > 0) {
+                outputData.stringVal += os.EOL;
+            }
+            outputData.stringVal += propertyVal;
+            return true;
+        } else {
+            // only record one raw property
+            if (Object.keys(outputData.rawVal).length === 0) {
+                outputData.rawVal = JSON.stringify(propertyVal);
+                return true;
+            }
+        }
+        return false;
     }
 
     /**

--- a/packages/imperative/src/error/src/ImperativeError.ts
+++ b/packages/imperative/src/error/src/ImperativeError.ts
@@ -194,12 +194,10 @@ export class ImperativeError extends Error {
             }
             outputData.stringVal += propertyVal;
             return true;
-        } else {
+        } else if (Object.keys(outputData.rawVal).length === 0) {
             // only record one raw property
-            if (Object.keys(outputData.rawVal).length === 0) {
-                outputData.rawVal = JSON.stringify(propertyVal);
-                return true;
-            }
+            outputData.rawVal = JSON.stringify(propertyVal);
+            return true;
         }
         return false;
     }

--- a/packages/imperative/src/imperative/__tests__/plugins/cmd/install/install.handler.unit.test.ts
+++ b/packages/imperative/src/imperative/__tests__/plugins/cmd/install/install.handler.unit.test.ts
@@ -385,7 +385,8 @@ describe("Plugin Management Facility install handler", () => {
 
         expect(expectedError).toBeInstanceOf(ImperativeError);
         expect(expectedError.additionalDetails).toContain("Command that failed:");
-        expect(expectedError.additionalDetails).toContain("C:\\pkgs\\nodejs\\npm.CMD config get registry");
+        expect(expectedError.additionalDetails).toContain("npm");
+        expect(expectedError.additionalDetails).toContain("config get registry");
         expect(expectedError.additionalDetails).toContain("Exit code = 1");
         expect(expectedError.additionalDetails).toContain("If you are using an NPM registry, " +
             "confirm that NPM can access the registry with the following command:"

--- a/packages/imperative/src/imperative/__tests__/plugins/cmd/install/install.handler.unit.test.ts
+++ b/packages/imperative/src/imperative/__tests__/plugins/cmd/install/install.handler.unit.test.ts
@@ -334,7 +334,7 @@ describe("Plugin Management Facility install handler", () => {
         // Validate that the read was correct
         wasReadFileSyncCallValid(PMFConstants.instance.PLUGIN_JSON);
 
-        expect(params.response.console.log).toHaveBeenCalledWith("No packages were found in " +
+        expect(params.response.console.log).toHaveBeenCalledWith("\nNo packages were found in " +
             PMFConstants.instance.PLUGIN_JSON + ", so no plugins were installed.");
     });
 
@@ -361,7 +361,7 @@ describe("Plugin Management Facility install handler", () => {
         }
 
         expect(expectedError).toBeInstanceOf(ImperativeError);
-        expect(expectedError.message).toBe("Install Failed");
+        expect(expectedError.message).toBe("Plug-in installation failed.");
     });
 
     it("should handle an error in spawned process", async () => {
@@ -384,8 +384,15 @@ describe("Plugin Management Facility install handler", () => {
         }
 
         expect(expectedError).toBeInstanceOf(ImperativeError);
-        expect(expectedError.additionalDetails).toContain("Command failed");
-        expect(expectedError.additionalDetails).toContain("npm");
+        expect(expectedError.additionalDetails).toContain("Command that failed:");
+        expect(expectedError.additionalDetails).toContain("C:\\pkgs\\nodejs\\npm.CMD config get registry");
+        expect(expectedError.additionalDetails).toContain("Exit code = 1");
+        expect(expectedError.additionalDetails).toContain("If you are using an NPM registry, " +
+            "confirm that NPM can access the registry with the following command:"
+        );
+        expect(expectedError.additionalDetails).toContain("npm view <your_desired_package_name>");
+        expect(expectedError.additionalDetails).toContain("Confirm that NPM can download your package from your registry:");
+        expect(expectedError.additionalDetails).toContain("npm pack <your_desired_package_name>");
     });
     it("should handle installed plugins via package name", async () => {
         const handler = new InstallHandler();
@@ -613,7 +620,7 @@ describe("Plugin Management Facility install handler", () => {
         // Should not attempt any installs for empty file
         expect(mocks.install).not.toHaveBeenCalled();
 
-        expect(params.response.console.log).toHaveBeenCalledWith("No packages were found in " +
+        expect(params.response.console.log).toHaveBeenCalledWith("\nNo packages were found in " +
             PMFConstants.instance.PLUGIN_JSON + ", so no plugins were installed.");
     });
 });

--- a/packages/imperative/src/imperative/__tests__/plugins/cmd/uninstall/uninstall.handler.unit.test.ts
+++ b/packages/imperative/src/imperative/__tests__/plugins/cmd/uninstall/uninstall.handler.unit.test.ts
@@ -100,6 +100,9 @@ describe("Plugin Management Facility uninstall handler", () => {
         // Override the return value for this test only
         mocks.readFileSyncSpy.mockReturnValueOnce(fileJson as any);
 
+        // return a fake plugin configuration with no preUninstall for the plugin
+        jest.spyOn(ConfigurationLoader, "load").mockReturnValue({});
+
         const handler = new UninstallHandler();
 
         const params = getIHandlerParametersObject();
@@ -108,8 +111,7 @@ describe("Plugin Management Facility uninstall handler", () => {
         await handler.process(params as IHandlerParameters);
 
         expect(mocks.uninstallSpy).toHaveBeenCalledWith(fileJson.a.package);
-
-        expect(params.response.console.log).toHaveBeenCalledWith("Removal of the npm package(s) was successful.\n");
+        expect(params.response.console.log).toHaveBeenCalledWith("Removal of the npm package(s) was successful.");
     });
 
     it("should handle an error during the uninstall", async () => {
@@ -254,6 +256,9 @@ describe("callPluginPreUninstall", () => {
         expect(cfgLoaderLoadSpy).toHaveBeenCalledTimes(1);
         expect(thrownErr).not.toBeNull();
         expect(thrownErr.message).toContain(
+            "Unable to perform the 'preUninstall' action of plugin '@zowe/secrets-for-kubernetes-for-zowe-cli'"
+        );
+        expect(thrownErr.causeErrors).toContain(
             `The plugin '${knownCredMgrPlugin}', which overrides the CLI ` +
             `Credential Manager, does not implement the 'pluginLifeCycle' class. ` +
             `The CLI default Credential Manager ` +
@@ -311,6 +316,6 @@ describe("callPluginPreUninstall", () => {
         expect(thrownErr.message).toContain(
             `Unable to perform the 'preUninstall' action of plugin '${knownCredMgrPlugin}'`
         );
-        expect(thrownErr.message).toContain(preUninstallErrText);
+        expect(thrownErr.causeErrors).toContain(preUninstallErrText);
     });
 }); // end callPluginPreUninstall

--- a/packages/imperative/src/imperative/__tests__/plugins/cmd/uninstall/uninstall.handler.unit.test.ts
+++ b/packages/imperative/src/imperative/__tests__/plugins/cmd/uninstall/uninstall.handler.unit.test.ts
@@ -114,6 +114,98 @@ describe("Plugin Management Facility uninstall handler", () => {
         expect(params.response.console.log).toHaveBeenCalledWith("Removal of the npm package(s) was successful.");
     });
 
+    it("should throw an error if the package is not installed", async () => {
+        // plugin definitions mocking file contents
+        const fileJson: IPluginJson = {
+            someOtherPlugin: {
+                package: "SomeOtherPkgName",
+                location: "SomeOtherPkgRegistry",
+                version: "SomeOtherPkgVersion"
+            }
+        };
+
+        // Override the return value for this test only
+        mocks.readFileSyncSpy.mockReturnValueOnce(fileJson as any);
+
+        // return a fake plugin configuration with no preUninstall for the plugin
+        jest.spyOn(ConfigurationLoader, "load").mockReturnValue({});
+
+        const handler = new UninstallHandler();
+
+        const params = getIHandlerParametersObject();
+        params.arguments.plugin = ["pluginThatIsNotInstalled"];
+
+        let expectedError;
+        try {
+            await handler.process(params as IHandlerParameters);
+        } catch (e) {
+            expectedError = e;
+        }
+
+        expect(expectedError).toBeDefined();
+        expect((expectedError as ImperativeError).message).toContain("Plug-in uninstall operation failed");
+        expect((expectedError as ImperativeError).causeErrors).toContain("Plugin name");
+        expect((expectedError as ImperativeError).causeErrors).toContain("pluginThatIsNotInstalled");
+        expect((expectedError as ImperativeError).causeErrors).toContain("is not installed");
+    });
+
+    it("should catch and report a preUninstall error", async () => {
+        // plugin definitions mocking file contents
+        const fileJson: IPluginJson = {
+            testPlugin: {
+                package: packageName,
+                location: "",
+                version: packageVersion
+            },
+            plugin2: {
+                package: packageName2,
+                location: packageRegistry2,
+                version: packageVersion2
+            }
+        };
+
+        // Override the return value for this test only
+        mocks.readFileSyncSpy.mockReturnValueOnce(fileJson as any);
+
+        // record messages that would be logged to the response object
+        let logMsg: string = "";
+        const params = getIHandlerParametersObject();
+        params.arguments.plugin = ["testPlugin"];
+        params.response = {
+            console: {
+                log: jest.fn((logArgs) => {
+                    logMsg += "\n" + logArgs;
+                })
+            }
+        } as any;
+
+        // force callPluginPreUninstall to throw an error
+        const uninstallHndlr = new UninstallHandler();
+        jest.spyOn(uninstallHndlr as any, "callPluginPreUninstall").mockImplementation(() => {
+            throw new ImperativeError({
+                msg: "The plugin's preUninstall error message",
+                causeErrors: "The plugin's preUninstall causeErrors",
+                additionalDetails: "The plugin's preUninstall additionalDetails"
+            });
+        });
+
+        let expectedError;
+        try {
+            await uninstallHndlr.process(params as IHandlerParameters);
+        } catch (e) {
+            expectedError = e;
+        }
+
+        expect(expectedError).not.toBeDefined();
+        expect(logMsg).toContain("The plugin's preUninstall error message");
+        expect(logMsg).toContain("The plugin's preUninstall causeErrors");
+        expect(logMsg).toContain("The plugin's preUninstall additionalDetails");
+        expect(logMsg).toContain(
+            "The uninstall operation of a plug-in will continue even with a 'preUninstall' failure"
+        );
+        expect(logMsg).toContain("Removal of the npm package(s) was successful");
+    });
+
     it("should handle an error during the uninstall", async () => {
         const chalk = TextUtils.chalk;
         const handler = new UninstallHandler();
@@ -130,21 +222,6 @@ describe("Plugin Management Facility uninstall handler", () => {
         }
 
         expect(expectedError.message).toBe(`${chalk.yellow.bold("Package name")} is required.`);
-
-        // const installError = new Error("This is a test");
-        // let expectedError: ImperativeError;
-        //
-        // mocks.install.mockImplementationOnce(() => {
-        //   throw installError;
-        // });
-        //
-        // try {
-        //   await handler.process(params);
-        // } catch (e) {
-        //   expectedError = e;
-        // }
-        //
-        // expect(expectedError.message).toBe("Install Failed");
     });
 }); // end Plugin Management Facility uninstall handler
 

--- a/packages/imperative/src/imperative/__tests__/plugins/cmd/uninstall/uninstall.handler.unit.test.ts
+++ b/packages/imperative/src/imperative/__tests__/plugins/cmd/uninstall/uninstall.handler.unit.test.ts
@@ -144,7 +144,7 @@ describe("Plugin Management Facility uninstall handler", () => {
 
         expect(expectedError).toBeDefined();
         expect((expectedError as ImperativeError).message).toContain("Plug-in uninstall operation failed");
-        expect((expectedError as ImperativeError).causeErrors).toContain("Plugin name");
+        expect((expectedError as ImperativeError).causeErrors).toContain("Plug-in name");
         expect((expectedError as ImperativeError).causeErrors).toContain("pluginThatIsNotInstalled");
         expect((expectedError as ImperativeError).causeErrors).toContain("is not installed");
     });
@@ -183,9 +183,9 @@ describe("Plugin Management Facility uninstall handler", () => {
         const uninstallHndlr = new UninstallHandler();
         jest.spyOn(uninstallHndlr as any, "callPluginPreUninstall").mockImplementation(() => {
             throw new ImperativeError({
-                msg: "The plugin's preUninstall error message",
-                causeErrors: "The plugin's preUninstall causeErrors",
-                additionalDetails: "The plugin's preUninstall additionalDetails"
+                msg: "The plug-in's preUninstall error message",
+                causeErrors: "The plug-in's preUninstall causeErrors",
+                additionalDetails: "The plug-in's preUninstall additionalDetails"
             });
         });
 
@@ -197,11 +197,11 @@ describe("Plugin Management Facility uninstall handler", () => {
         }
 
         expect(expectedError).not.toBeDefined();
-        expect(logMsg).toContain("The plugin's preUninstall error message");
-        expect(logMsg).toContain("The plugin's preUninstall causeErrors");
-        expect(logMsg).toContain("The plugin's preUninstall additionalDetails");
+        expect(logMsg).toContain("The plug-in's preUninstall error message");
+        expect(logMsg).toContain("The plug-in's preUninstall causeErrors");
+        expect(logMsg).toContain("The plug-in's preUninstall additionalDetails");
         expect(logMsg).toContain(
-            "The uninstall operation of a plug-in will continue even with a 'preUninstall' failure"
+            "The uninstall operation of a plug-in continues even with a 'preUninstall' failure"
         );
         expect(logMsg).toContain("Removal of the npm package(s) was successful");
     });

--- a/packages/imperative/src/imperative/__tests__/plugins/utilities/NpmFunctions.unit.test.ts
+++ b/packages/imperative/src/imperative/__tests__/plugins/utilities/NpmFunctions.unit.test.ts
@@ -229,7 +229,7 @@ describe("NpmFunctions", () => {
                 `Unable to parse the JSON output of 'npm pack' for this package: '${pkgSpec}'`
             );
             expect(caughtError.additionalDetails).toContain(
-                "JSON.parse error = Expected property name or '}' in JSON at position 1 (line 1 column 2)"
+                "JSON.parse error = Expected property name or '}' in JSON at position 1"
             );
             expect(caughtError.additionalDetails).toContain("Output of 'npm pack':");
             expect(caughtError.additionalDetails).toContain(badJsonString);

--- a/packages/imperative/src/imperative/__tests__/plugins/utilities/NpmFunctions.unit.test.ts
+++ b/packages/imperative/src/imperative/__tests__/plugins/utilities/NpmFunctions.unit.test.ts
@@ -16,6 +16,7 @@ import * as npmFunctions from "../../../src/plugins/utilities/NpmFunctions";
 import { PMFConstants } from "../../../src/plugins/utilities/PMFConstants";
 import { DaemonRequest, ExecUtils, ImperativeConfig } from "../../../../utilities";
 import { Logger } from "../../../../logger";
+import { ImperativeError } from "../../../../error";
 
 jest.mock("cross-spawn");
 jest.mock("jsonfile");
@@ -190,28 +191,49 @@ describe("NpmFunctions", () => {
             const pkgSpec = "imperative.tgz";
             expect(npmPackageArg(pkgSpec).type).toEqual("file");
 
+            const spawnErrMsg = "Failed to launch the following command: SomeFakeCommand";
+            const spawnDetails = "Error: spawnSync returns some vague message";
             jest.spyOn(ExecUtils, "spawnAndGetOutput").mockImplementation(() => {
-                throw new Error("Fake out an error thrown by cross-spawn.sync");
+                throw new ImperativeError({
+                    msg: spawnErrMsg,
+                    additionalDetails: spawnDetails
+                });
             });
-            expect(() => npmFunctions.getPackageInfo(pkgSpec)).toThrow(
-                `Spawn of 'npm pack' command failed for package: '${pkgSpec}'` +
-                `\nSpawn error = Fake out an error thrown by cross-spawn.sync` +
-                `\nOutput of the spawn action:` +
-                `\nNo npm pack output was retrieved`
-            );
+
+            let caughtError: ImperativeError = {} as ImperativeError;
+            try {
+                npmFunctions.getPackageInfo(pkgSpec);
+            } catch (thrownError) {
+                caughtError = thrownError as ImperativeError;
+            }
+            expect(caughtError).toBeDefined();
+            expect(caughtError.message).toContain(spawnErrMsg);
+            expect(caughtError.additionalDetails).toContain(spawnDetails);
         });
 
         it("should throw error if npm pack output is not parsable JSON", () => {
             const pkgSpec = "imperative.tgz";
             expect(npmPackageArg(pkgSpec).type).toEqual("file");
 
-            jest.spyOn(ExecUtils, "spawnAndGetOutput").mockReturnValueOnce("[]");
-            expect(() => npmFunctions.getPackageInfo(pkgSpec)).toThrow(
-                `Unable to parse the JSON output of 'npm pack' for this package: '${pkgSpec}'` +
-                `\nJSON.parse error = Cannot read properties of undefined (reading 'name')` +
-                `\nOutput of 'npm pack':` +
-                `\n[]`
+            const badJsonString = "{bogus: [}";
+            jest.spyOn(ExecUtils, "spawnAndGetOutput").mockReturnValueOnce(badJsonString);
+
+            let caughtError: ImperativeError = {} as ImperativeError;
+            try {
+                npmFunctions.getPackageInfo(pkgSpec);
+            } catch (thrownError) {
+                caughtError = thrownError as ImperativeError;
+            }
+            expect(caughtError).toBeDefined();
+            expect(caughtError.message).toContain(
+                `Unable to parse the JSON output of 'npm pack' for this package: '${pkgSpec}'`
             );
+            expect(caughtError.additionalDetails).toContain(
+                "JSON.parse error = Expected property name or '}' in JSON at position 1 (line 1 column 2)"
+            );
+            expect(caughtError.additionalDetails).toContain("Output of 'npm pack':");
+            expect(caughtError.additionalDetails).toContain(badJsonString);
+
         });
     });
 
@@ -370,8 +392,6 @@ describe("NpmFunctions", () => {
         it("should handle errors in verbose mode with daemon stream", () => {
             const writeMock = jest.fn();
             const mockDaemonStream = { write: writeMock };
-            const errorMessage = "Install failed";
-
             jest.spyOn(ImperativeConfig, "instance", "get").mockReturnValue({
                 envVariablePrefix: "MOCK_PREFIX",
                 cliHome: "/mock/home",
@@ -380,21 +400,34 @@ describe("NpmFunctions", () => {
                 }
             } as any);
 
+            const spawnErrMsg = "Failed to launch the following command: SomeFakeCommand";
+            const spawnDetails = "Error: spawnSync message during verbose with daemon stream";
             jest.spyOn(ExecUtils, "spawnAndGetOutput").mockImplementation(() => {
-                throw new Error(errorMessage);
+                throw new ImperativeError({
+                    msg: spawnErrMsg,
+                    additionalDetails: spawnDetails
+                });
             });
 
-            const result = npmFunctions.installPackages("samplePlugin", {
-                prefix: "fakePrefix"
-            }, true);
-
-            expect(writeMock).toHaveBeenCalledWith(DaemonRequest.create({ stderr: errorMessage }));
-            expect(result).toBe("");
+            let caughtError: ImperativeError = {} as ImperativeError;
+            const neverSetValue = "result should never be set";
+            let result = neverSetValue;
+            try {
+                result = npmFunctions.installPackages("samplePlugin", {
+                    prefix: "fakePrefix"
+                }, true);
+            } catch (thrownError) {
+                caughtError = thrownError as ImperativeError;
+            }
+            expect(result).toBe(neverSetValue);
+            expect(writeMock).not.toHaveBeenCalledWith();
+            expect(caughtError).toBeDefined();
+            expect(caughtError.message).toContain(spawnErrMsg);
+            expect(caughtError.additionalDetails).toContain(spawnDetails);
         });
 
         it("should handle errors in verbose mode without daemon stream", () => {
             const stderrWriteSpy = jest.spyOn(process.stderr, 'write').mockImplementation();
-            const errorMessage = "Install failed";
 
             jest.spyOn(ImperativeConfig, "instance", "get").mockReturnValue({
                 envVariablePrefix: "MOCK_PREFIX",
@@ -402,16 +435,31 @@ describe("NpmFunctions", () => {
                 daemonContext: null
             } as any);
 
+            const spawnErrMsg = "Failed to launch the following command: SomeFakeCommand";
+            const spawnDetails = "Error: spawnSync message during verbose with no daemon stream";
             jest.spyOn(ExecUtils, "spawnWithInheritedStdio").mockImplementation(() => {
-                throw new Error(errorMessage);
+                throw new ImperativeError({
+                    msg: spawnErrMsg,
+                    additionalDetails: spawnDetails
+                });
             });
 
-            const result = npmFunctions.installPackages("samplePlugin", {
-                prefix: "fakePrefix"
-            }, true);
+            let caughtError: ImperativeError = {} as ImperativeError;
+            const neverSetValue = "result should never be set";
+            let result = neverSetValue;
+            try {
+                result = npmFunctions.installPackages("samplePlugin", {
+                    prefix: "fakePrefix"
+                }, true);
+            } catch (thrownError) {
+                caughtError = thrownError as ImperativeError;
+            }
 
-            expect(stderrWriteSpy).toHaveBeenCalledWith(errorMessage);
-            expect(result).toBe("");
+            expect(result).toBe(neverSetValue);
+            expect(stderrWriteSpy).not.toHaveBeenCalledWith();
+            expect(caughtError).toBeDefined();
+            expect(caughtError.message).toContain(spawnErrMsg);
+            expect(caughtError.additionalDetails).toContain(spawnDetails);
 
             stderrWriteSpy.mockRestore();
         });

--- a/packages/imperative/src/imperative/__tests__/plugins/utilities/npm-interface/install.unit.test.ts
+++ b/packages/imperative/src/imperative/__tests__/plugins/utilities/npm-interface/install.unit.test.ts
@@ -509,6 +509,7 @@ describe("PMF: Install Interface", () => {
     describe("callPluginPostInstall", () => {
         const knownCredMgr = "@zowe/secrets-for-kubernetes-for-zowe-cli";
         const postInstallErrText = "Pretend that the plugin's postInstall function threw an error";
+        const postInstallErrDetails = "plugin postInstall error additional details";
         let callPluginPostInstall : any;
         let fakePluginConfig: IImperativeConfig;
         let installModule;
@@ -548,7 +549,8 @@ describe("PMF: Install Interface", () => {
                 LifeCycleClass = class extends AbstractPluginLifeCycle {
                     postInstall() {
                         throw new ImperativeError({
-                            msg: postInstallErrText
+                            msg: postInstallErrText,
+                            additionalDetails: postInstallErrDetails
                         });
                     }
                     preUninstall() {
@@ -643,9 +645,11 @@ describe("PMF: Install Interface", () => {
             expect(postInstallWorked).toBe(false);
             expect(thrownErr).toBeDefined();
             expect(thrownErr.message).toContain(
-                "Unable to perform the post-install action for plugin 'FakePluginPackageName'."
+                "The plug-in 'FakePluginPackageName' was installed, but the plug-in's post-install action failed"
             );
-            expect(thrownErr.message).toContain(postInstallErrText);
+            expect(thrownErr.causeErrors).toContain(postInstallErrText);
+            expect(thrownErr.additionalDetails).toContain(postInstallErrDetails);
+
         });
     }); // end callPluginPostInstall
 }); // PMF: Install Interface

--- a/packages/imperative/src/imperative/__tests__/plugins/utilities/npm-interface/install.unit.test.ts
+++ b/packages/imperative/src/imperative/__tests__/plugins/utilities/npm-interface/install.unit.test.ts
@@ -508,8 +508,8 @@ describe("PMF: Install Interface", () => {
 
     describe("callPluginPostInstall", () => {
         const knownCredMgr = "@zowe/secrets-for-kubernetes-for-zowe-cli";
-        const postInstallErrText = "Pretend that the plugin's postInstall function threw an error";
-        const postInstallErrDetails = "plugin postInstall error additional details";
+        const postInstallErrText = "Pretend that the plug-in's postInstall function threw an error";
+        const postInstallErrDetails = "plug-in postInstall error additional details";
         let callPluginPostInstall : any;
         let fakePluginConfig: IImperativeConfig;
         let installModule;

--- a/packages/imperative/src/imperative/__tests__/plugins/utilities/npm-interface/uninstall.unit.test.ts
+++ b/packages/imperative/src/imperative/__tests__/plugins/utilities/npm-interface/uninstall.unit.test.ts
@@ -225,18 +225,21 @@ describe("PMF: Uninstall Interface", () => {
             };
 
             mocks.readFileSync.mockReturnValue(pluginJsonFile);
-            jest.spyOn(fs, "existsSync").mockReturnValueOnce(true);
-            let caughtError;
+            jest.spyOn(fs, "existsSync").mockReturnValue(true);
+            let caughtError: ImperativeError = {} as ImperativeError;
 
             try {
                 uninstall("a");
             } catch (error) {
-                caughtError = error;
+                caughtError = error as ImperativeError;
             }
 
             // Validate the install
             wasSpawnSyncCallValid(packageName);
-            expect(caughtError.message).toContain("Failed to uninstall plugin, install folder still exists");
+            expect(caughtError.message).toContain("Failed to uninstall plugin 'a'");
+            expect(caughtError.additionalDetails).toContain("The plugin installation folder still exists:\n" +
+                "    \\sample-cli\\install\\lib\\node_modules\\a"
+            );
         });
     });
 

--- a/packages/imperative/src/imperative/__tests__/plugins/utilities/npm-interface/uninstall.unit.test.ts
+++ b/packages/imperative/src/imperative/__tests__/plugins/utilities/npm-interface/uninstall.unit.test.ts
@@ -14,6 +14,7 @@ jest.mock("cross-spawn");
 jest.mock("jsonfile");
 jest.mock("../../../../src/plugins/utilities/PMFConstants");
 
+import * as path from "path";
 import * as fs from "fs";
 import * as jsonfile from "jsonfile";
 import { Console } from "../../../../../console";
@@ -237,9 +238,8 @@ describe("PMF: Uninstall Interface", () => {
             // Validate the install
             wasSpawnSyncCallValid(packageName);
             expect(caughtError.message).toContain("Failed to uninstall plugin 'a'");
-            expect(caughtError.additionalDetails).toContain("The plugin installation folder still exists:\n" +
-                "    \\sample-cli\\install\\lib\\node_modules\\a"
-            );
+            expect(caughtError.additionalDetails).toContain("The plugin installation folder still exists:");
+            expect(caughtError.additionalDetails).toContain(path.normalize("/sample-cli/install/lib/node_modules/a"));
         });
     });
 

--- a/packages/imperative/src/imperative/__tests__/plugins/utilities/runValidatePlugin.unit.test.ts
+++ b/packages/imperative/src/imperative/__tests__/plugins/utilities/runValidatePlugin.unit.test.ts
@@ -12,6 +12,8 @@
 import { runValidatePlugin } from "../../../src/plugins/utilities/runValidatePlugin";
 import { sync } from "cross-spawn";
 import { Imperative } from "../../..";
+import { ImperativeError } from "../../../../error";
+
 import Mock = jest.Mock;
 
 jest.mock("cross-spawn");
@@ -47,5 +49,34 @@ describe("runValidatePlugin", () => {
         const resultMsg = runValidatePlugin(pluginName);
         expect(resultMsg).toContain(cmdOutputJson.stdout);
         expect(resultMsg).toContain(cmdOutputJson.stderr);
+    });
+
+    it("should catch an error from JSON.parse and throw an ImperativeError", () => {
+        // mock the output of executing the validatePlugin command to produce bad JSON
+        const unparsableJson = "{bogusJson: [}";
+        mocks.spawnSync.mockReturnValue({
+            status: 0,
+            stdout: unparsableJson
+        } as any);
+
+        (Imperative as any).mRootCommandName = "dummy";
+
+        let caughtError;
+        try {
+            runValidatePlugin(pluginName);
+        } catch (e) {
+            caughtError = e;
+        }
+
+        expect(caughtError).toBeDefined();
+        expect(caughtError instanceof ImperativeError).toBe(true);
+        expect((caughtError as ImperativeError).message).toContain(
+            "Unable to parse the JSON output of the 'plugins validate' command"
+        );
+        expect((caughtError as ImperativeError).additionalDetails).toContain(
+            "JSON.parse error = Expected property name or '}' in JSON at position 1"
+        );
+        expect((caughtError as ImperativeError).additionalDetails).toContain("Text that failed to parse:");
+        expect((caughtError as ImperativeError).additionalDetails).toContain("{bogusJson: [}");
     });
 });

--- a/packages/imperative/src/imperative/src/plugins/cmd/install/install.handler.ts
+++ b/packages/imperative/src/imperative/src/plugins/cmd/install/install.handler.ts
@@ -92,7 +92,7 @@ export default class InstallHandler implements ICommandHandler {
                     "Plug-ins within the Imperative CLI Framework can legitimately gain\n" +
                     `control of the ${ImperativeConfig.instance.rootCommandName} CLI application ` +
                     "during the execution of every command.\n" +
-                    "Install 3rd party plug-ins at your own risk."
+                    "Install third party plug-ins at your own risk."
                 );
 
                 // This section determines which npm logic needs to take place

--- a/packages/imperative/src/imperative/src/plugins/cmd/install/install.handler.ts
+++ b/packages/imperative/src/imperative/src/plugins/cmd/install/install.handler.ts
@@ -92,7 +92,7 @@ export default class InstallHandler implements ICommandHandler {
                     "Plug-ins within the Imperative CLI Framework can legitimately gain\n" +
                     `control of the ${ImperativeConfig.instance.rootCommandName} CLI application ` +
                     "during the execution of every command.\n" +
-                    "Install 3rd party plug-ins at your own risk.\n"
+                    "Install 3rd party plug-ins at your own risk."
                 );
 
                 // This section determines which npm logic needs to take place
@@ -107,7 +107,7 @@ export default class InstallHandler implements ICommandHandler {
                     const packageJson: IPluginJson = readFileSync(configFile);
 
                     if (Object.keys(packageJson).length === 0) {
-                        params.response.console.log("No packages were found in " +
+                        params.response.console.log("\nNo packages were found in " +
                             configFile + ", so no plugins were installed.");
                         return;
                     }
@@ -161,7 +161,7 @@ export default class InstallHandler implements ICommandHandler {
                     }
                 }
             } catch (e) {
-                let installResultMsg = "Install Failed";
+                let installResultMsg = "Plug-in installation failed.";
                 /* When we fail to create symbolic links to core and imperative,
                  * give a special message, as per UX request.
                  */
@@ -175,11 +175,7 @@ export default class InstallHandler implements ICommandHandler {
                         installResultMsg = "Installation completed. However, due to the following error, the plugin will not operate correctly.";
                     }
                 }
-                throw new ImperativeError({
-                    msg: installResultMsg,
-                    causeErrors: e,
-                    additionalDetails: e.message
-                });
+                throw ImperativeError.newImpErrorFromExistingError(e, installResultMsg);
             }
         }
     }

--- a/packages/imperative/src/imperative/src/plugins/cmd/uninstall/uninstall.handler.ts
+++ b/packages/imperative/src/imperative/src/plugins/cmd/uninstall/uninstall.handler.ts
@@ -60,9 +60,9 @@ export default class UninstallHandler implements ICommandHandler {
                 for (const packageName of params.arguments.plugin) {
                     // confirm that plugin is installed before calling its preUninstall function
                     const installedPlugins: IPluginJson = readFileSync(PMFConstants.instance.PLUGIN_JSON);
-                    if (!Object.prototype.hasOwnProperty.call(installedPlugins, packageName)) {
+                    if (!Object.hasOwn(installedPlugins, packageName)) {
                         throw new ImperativeError({
-                            msg: `${chalk.yellow.bold("Plugin name")} '${chalk.red.bold(packageName)}' is not installed.`
+                            msg: `${chalk.yellow.bold("Plug-in name")} '${chalk.red.bold(packageName)}' is not installed.`
                         });
                     }
 
@@ -79,7 +79,7 @@ export default class UninstallHandler implements ICommandHandler {
                             params.response.console.log(err.additionalDetails);
                         }
                         params.response.console.log(
-                            "\nThe uninstall operation of a plug-in will continue even with a 'preUninstall' failure.\n"
+                            "\nThe uninstall operation of a plug-in continues even with a 'preUninstall' failure.\n"
                         );
                     }
 

--- a/packages/imperative/src/imperative/src/plugins/cmd/uninstall/uninstall.handler.ts
+++ b/packages/imperative/src/imperative/src/plugins/cmd/uninstall/uninstall.handler.ts
@@ -9,7 +9,9 @@
 *
 */
 
+import { readFileSync } from "jsonfile";
 import { ICommandHandler, IHandlerParameters } from "../../../../../cmd";
+import { IPluginJson } from "../../doc/IPluginJson";
 import { ConfigurationLoader } from "../../../ConfigurationLoader";
 import { CredentialManagerOverride, ICredentialManagerNameMap } from "../../../../../security";
 import { Logger } from "../../../../../logger/";
@@ -56,24 +58,37 @@ export default class UninstallHandler implements ICommandHandler {
         } else {
             try {
                 for (const packageName of params.arguments.plugin) {
+                    // confirm that plugin is installed before calling its preUninstall function
+                    const installedPlugins: IPluginJson = readFileSync(PMFConstants.instance.PLUGIN_JSON);
+                    if (!Object.prototype.hasOwnProperty.call(installedPlugins, packageName)) {
+                        throw new ImperativeError({
+                            msg: `${chalk.yellow.bold("Plugin name")} '${chalk.red.bold(packageName)}' is not installed.`
+                        });
+                    }
+
                     // let the plugin perform any pre-uninstall operations
                     try {
                         await this.callPluginPreUninstall(packageName);
                     } catch(err) {
                         // We do not stop on preUninstall error. We just show a message.
                         params.response.console.log(err.message);
+                        if (typeof err.causeErrors === "string" && err.causeErrors.length > 0) {
+                            params.response.console.log(err.causeErrors);
+                        }
+                        if (typeof err.additionalDetails === "string" && err.additionalDetails.length > 0) {
+                            params.response.console.log(err.additionalDetails);
+                        }
+                        params.response.console.log(
+                            "\nThe uninstall operation of a plug-in will continue even with a 'pre-uninstall' failure.\n"
+                        );
                     }
 
                     uninstall(packageName);
                 }
-                params.response.console.log("Removal of the npm package(s) was successful.\n"
+                params.response.console.log("Removal of the npm package(s) was successful."
                 );
             } catch (e) {
-                throw new ImperativeError({
-                    msg: "Uninstall Failed",
-                    causeErrors: [e],
-                    additionalDetails: e.message
-                });
+                throw ImperativeError.newImpErrorFromExistingError(e, "Plug-in uninstall operation failed.");
             }
         }
     }
@@ -118,10 +133,7 @@ export default class UninstallHandler implements ICommandHandler {
             const lifeCycleInstance = new lifeCycleClass();
             await lifeCycleInstance.preUninstall();
         } catch (err) {
-            throw new ImperativeError({
-                msg: `Unable to perform the 'preUninstall' action of plugin '${pluginPackageNm}'` +
-                    `\nReason: ${err.message}`
-            });
+            throw ImperativeError.newImpErrorFromExistingError(err, `Unable to perform the 'pre-uninstall' action of plugin '${pluginPackageNm}'`);
         }
     }
 }

--- a/packages/imperative/src/imperative/src/plugins/cmd/uninstall/uninstall.handler.ts
+++ b/packages/imperative/src/imperative/src/plugins/cmd/uninstall/uninstall.handler.ts
@@ -79,7 +79,7 @@ export default class UninstallHandler implements ICommandHandler {
                             params.response.console.log(err.additionalDetails);
                         }
                         params.response.console.log(
-                            "\nThe uninstall operation of a plug-in will continue even with a 'pre-uninstall' failure.\n"
+                            "\nThe uninstall operation of a plug-in will continue even with a 'preUninstall' failure.\n"
                         );
                     }
 
@@ -133,7 +133,7 @@ export default class UninstallHandler implements ICommandHandler {
             const lifeCycleInstance = new lifeCycleClass();
             await lifeCycleInstance.preUninstall();
         } catch (err) {
-            throw ImperativeError.newImpErrorFromExistingError(err, `Unable to perform the 'pre-uninstall' action of plugin '${pluginPackageNm}'`);
+            throw ImperativeError.newImpErrorFromExistingError(err, `Unable to perform the 'preUninstall' action of plugin '${pluginPackageNm}'`);
         }
     }
 }

--- a/packages/imperative/src/imperative/src/plugins/utilities/NpmFunctions.ts
+++ b/packages/imperative/src/imperative/src/plugins/utilities/NpmFunctions.ts
@@ -83,10 +83,11 @@ export function installPackages(npmPackage: string, npmArgs: INpmInstallArgs, ve
     }
     catch (error) {
         if (daemonStream != null) {
-            daemonStream.write(DaemonRequest.create({ stderr: error.message }));
+            daemonStream.write(DaemonRequest.create({ stderr: error.message + "\n" }));
         } else {
-            process.stderr.write(error.message);
+            process.stderr.write(error.message + "\n");
         }
+        throw error;
     }
     return execOutput;
 }

--- a/packages/imperative/src/imperative/src/plugins/utilities/NpmFunctions.ts
+++ b/packages/imperative/src/imperative/src/plugins/utilities/NpmFunctions.ts
@@ -65,29 +65,19 @@ export function installPackages(npmPackage: string, npmArgs: INpmInstallArgs, ve
     }
     let execOutput = "";
     const daemonStream = ImperativeConfig.instance.daemonContext?.stream;
-    try {
-        if (verbose && daemonStream == null) {
-            ExecUtils.spawnWithInheritedStdio(npmCmd, args, {
-                cwd: PMFConstants.instance.PMF_ROOT,
-            });
-        } else {
-            execOutput = ExecUtils.spawnAndGetOutput(npmCmd, args, {
-                cwd: PMFConstants.instance.PMF_ROOT,
-                stdio: pipe
-            }).toString();
+    if (verbose && daemonStream == null) {
+        ExecUtils.spawnWithInheritedStdio(npmCmd, args, {
+            cwd: PMFConstants.instance.PMF_ROOT,
+        });
+    } else {
+        execOutput = ExecUtils.spawnAndGetOutput(npmCmd, args, {
+            cwd: PMFConstants.instance.PMF_ROOT,
+            stdio: pipe
+        }).toString();
 
-            if (verbose && daemonStream != null) {
-                daemonStream.write(DaemonRequest.create({ stdout: execOutput }));
-            }
+        if (verbose && daemonStream != null) {
+            daemonStream.write(DaemonRequest.create({ stdout: execOutput }));
         }
-    }
-    catch (error) {
-        if (daemonStream != null) {
-            daemonStream.write(DaemonRequest.create({ stderr: error.message + "\n" }));
-        } else {
-            process.stderr.write(error.message + "\n");
-        }
-        throw error;
     }
     return execOutput;
 }
@@ -105,22 +95,12 @@ export function getPackageInfo(pkgSpec: string): { name: string, version: string
         const maxOutputInx = 200;
         let truncationMsg = "\n<Additional output not displayed>";
         let execOutput:string = "No npm pack output was retrieved";
-        try {
-            // eslint-disable-next-line @typescript-eslint/no-magic-numbers
-            const maxBuffer = 1024 * 1024 * 10; // 10MB
-            execOutput = ExecUtils.spawnAndGetOutput(
-                npmCmd, ["pack", pkgSpec, "--dry-run", "--json"], { maxBuffer }
-            ).toString();
-        } catch (err) {
-            if (execOutput.length < maxOutputInx) {
-                truncationMsg = "";
-            }
-            throw new ImperativeError({
-                msg: `Spawn of 'npm pack' command failed for package: '${pkgSpec}'` +
-                    "\nSpawn error = " + (err as Error).message +
-                    "\nOutput of the spawn action:\n" + execOutput.substring(0, maxOutputInx) + truncationMsg
-            });
-        }
+
+        // eslint-disable-next-line @typescript-eslint/no-magic-numbers
+        const maxBuffer = 1024 * 1024 * 10; // 10MB
+        execOutput = ExecUtils.spawnAndGetOutput(
+            npmCmd, ["pack", pkgSpec, "--dry-run", "--json"], { maxBuffer }
+        ).toString();
 
         // In test pipelines, parallel tests use Git to retrieve source to compile and to
         // run CodeQL analysis. Some conflict causes <YourSourceCodeRootDirectory>/.git/config.lock
@@ -158,8 +138,8 @@ export function getPackageInfo(pkgSpec: string): { name: string, version: string
                 truncationMsg = "";
             }
             throw new ImperativeError({
-                msg: `Unable to parse the JSON output of 'npm pack' for this package: '${pkgSpec}'` +
-                    "\nJSON.parse error = " + (err as Error).message +
+                msg: `Unable to parse the JSON output of 'npm pack' for this package: '${pkgSpec}'`,
+                additionalDetails: "JSON.parse error = " + (err as Error).message +
                     "\nOutput of 'npm pack':\n" + execOutput.substring(0, maxOutputInx) + truncationMsg
             });
         }

--- a/packages/imperative/src/imperative/src/plugins/utilities/npm-interface/install.ts
+++ b/packages/imperative/src/imperative/src/plugins/utilities/npm-interface/install.ts
@@ -228,10 +228,7 @@ export async function install(packageLocation: string, registryInfo: INpmRegistr
         iConsole.info("Plugin '" + packageName + "' successfully installed.");
         return packageName;
     } catch (e) {
-        throw new ImperativeError({
-            msg: e.message,
-            causeErrors: e
-        });
+        throw ImperativeError.newImpErrorFromExistingError(e);
     }
 }
 
@@ -271,10 +268,10 @@ async function callPluginPostInstall(
         const lifeCycleInstance = new lifeCycleClass();
         await lifeCycleInstance.postInstall();
     } catch (err) {
-        throw new ImperativeError({
-            msg: `Unable to perform the post-install action for plugin '${pluginPackageNm}'.` +
-            `\nReason: ${err.message}`
-        });
+        throw ImperativeError.newImpErrorFromExistingError(err,
+            `The plug-in '${pluginPackageNm}' was installed, but ` +
+            `the plug-in's post-install action failed.`
+        );
     }
 }
 

--- a/packages/imperative/src/imperative/src/plugins/utilities/npm-interface/uninstall.ts
+++ b/packages/imperative/src/imperative/src/plugins/utilities/npm-interface/uninstall.ts
@@ -94,7 +94,7 @@ export function uninstall(packageName: string): void {
         }
     } else {
         throw new ImperativeError({
-            msg: `${chalk.yellow.bold("Plugin name")} '${chalk.red.bold(packageName)}' is not installed.`
+            msg: `${chalk.yellow.bold("Plug-in name")} '${chalk.red.bold(packageName)}' is not installed.`
         });
     }
 

--- a/packages/imperative/src/imperative/src/plugins/utilities/npm-interface/uninstall.ts
+++ b/packages/imperative/src/imperative/src/plugins/utilities/npm-interface/uninstall.ts
@@ -130,7 +130,11 @@ export function uninstall(packageName: string): void {
 
         const installFolder = path.join(PMFConstants.instance.PLUGIN_HOME_LOCATION, npmPackage);
         if (fs.existsSync(installFolder)) {
-            throw new Error("Failed to uninstall plugin, install folder still exists:\n  " + installFolder);
+            throw new ImperativeError({
+                msg: `Failed to uninstall plugin '${npmPackage}'`,
+                additionalDetails: `The plugin installation folder still exists:\n    ${installFolder}`
+            });
+
         }
 
         if (PMFConstants.instance.PLUGIN_USING_CONFIG) {
@@ -173,9 +177,6 @@ export function uninstall(packageName: string): void {
         }
 
     } catch (e) {
-        throw new ImperativeError({
-            msg: e.message,
-            causeErrors: [e]
-        });
+        throw ImperativeError.newImpErrorFromExistingError(e);
     }
 }

--- a/packages/imperative/src/imperative/src/plugins/utilities/runValidatePlugin.ts
+++ b/packages/imperative/src/imperative/src/plugins/utilities/runValidatePlugin.ts
@@ -52,15 +52,14 @@ export function runValidatePlugin(pluginName: string): string {
 
     // Debug trace information
     impLogger.trace(`Command Output: ${valOutputJsonTxt}`);
-
     let valResultJsonObj;
     try {
         valResultJsonObj = JSON.parse(valOutputJsonTxt);
     } catch(thrownErr) {
         throw new ImperativeError({
-            msg: "Unable to parse the JSON output of the 'plugins validate' command." +
-            "\nReason = " + thrownErr.message +
-            "\nText that was being parsed:\n" + valOutputJsonTxt
+            msg: "Unable to parse the JSON output of the 'plugins validate' command.",
+            additionalDetails: "JSON.parse error = " + (thrownErr as Error).message +
+                "\nText that failed to parse:\n" + valOutputJsonTxt
         });
     }
     return formValidateMsg(valResultJsonObj);

--- a/packages/imperative/src/io/__tests__/IO.unit.test.ts
+++ b/packages/imperative/src/io/__tests__/IO.unit.test.ts
@@ -436,7 +436,8 @@ describe("IO tests", () => {
             expect(caughtError.message).toContain(
                 "Failed to restrict access to others on file = /this/file/does/not/exist.txt"
             );
-            expect(caughtError.message).toContain("Attempted to restrict access on a non-existent file.");
+            expect(caughtError.causeErrors).toContain("Attempted to restrict access on a non-existent file.");
+            expect(caughtError.additionalDetails).toContain('Raw error data from operation:\n"{}"');
         });
 
         if (sysInfo.platform === "win32") {
@@ -461,8 +462,9 @@ describe("IO tests", () => {
                 }
                 expect(spawnSpy).toHaveBeenCalledTimes(1);
                 expect(caughtError.message).toContain("Failed to restrict access to others on file");
-                expect(caughtError.message).toContain("Who knows what the icacls command might say when it does not like something");
-                expect(caughtError.message).toContain("Successfully processed 0 files; Failed processing 1 files");
+                expect(caughtError.causeErrors).toContain("Who knows what the icacls command might say when it does not like something");
+                expect(caughtError.causeErrors).toContain("Successfully processed 0 files; Failed processing 1 files");
+                expect(caughtError.additionalDetails).toContain('Raw error data from operation:\n"{}"');
             });
         } // end win32
 
@@ -487,7 +489,8 @@ describe("IO tests", () => {
                 }
                 expect(spawnSpy).toHaveBeenCalledTimes(1);
                 expect(caughtError.message).toContain("Failed to restrict access to others on file");
-                expect(caughtError.message).toContain("Pretend that spawn.sync failed to launch the icacls program");
+                expect(caughtError.causeErrors).toContain("Pretend that spawn.sync failed to launch the icacls program");
+                expect(caughtError.additionalDetails).toContain('Raw error data from operation:\n"{}"');
             });
         } // end win32
 

--- a/packages/imperative/src/io/src/IO.ts
+++ b/packages/imperative/src/io/src/IO.ts
@@ -371,9 +371,7 @@ export class IO {
                 fs.chmodSync(fileName, ownerPrivileges);
             }
         } catch(errObj) {
-            throw new ImperativeError({
-                msg: `Failed to restrict access to others on file = ${fileName}\nError Details: ${errObj.message}`
-            });
+            throw ImperativeError.newImpErrorFromExistingError(errObj, `Failed to restrict access to others on file = ${fileName}`);
         }
     }
 

--- a/packages/imperative/src/utilities/__tests__/ExecUtils.unit.test.ts
+++ b/packages/imperative/src/utilities/__tests__/ExecUtils.unit.test.ts
@@ -47,7 +47,8 @@ describe("ExecUtils tests", () => {
                 caughtError = error;
             }
             expect(spawn.sync).toHaveBeenCalledWith("cat", [filename], undefined);
-            expect(caughtError.message).toBe(errMsg);
+            expect(caughtError.message).toBe(`Failed to launch the following command:\n    cat ${filename}`);
+            expect(caughtError.additionalDetails).toBe("Error: " + errMsg);
         });
 
         it("throws error if command fails with non-zero status", () => {
@@ -64,8 +65,13 @@ describe("ExecUtils tests", () => {
                 caughtError = error;
             }
             expect(spawn.sync).toHaveBeenCalledWith("cat", [filename], undefined);
-            expect(caughtError.message).toBe(
-                `Command failed: cat ${filename}\nExit code = 1\nStdErr:\n${stderrBuffer.toString()}`
+            expect(caughtError.message).toBe("Errors occurred in this program: cat");
+            expect(caughtError.additionalDetails).toBe(
+                "Command that failed:\n" +
+                "    cat invalid.txt\n" +
+                "Exit code = 1\n\n" +
+                "Command's standard error stream:\n" +
+                "cat: invalid.txt: No such file or directory\n"
             );
         });
     });
@@ -100,7 +106,8 @@ describe("ExecUtils tests", () => {
                 caughtError = error;
             }
             expect(spawn.sync).toHaveBeenCalledWith("cat", [filename], { stdio: "inherit" });
-            expect(caughtError.message).toBe(errMsg);
+            expect(caughtError.message).toBe(`Failed to launch the following command:\n    cat ${filename}`);
+            expect(caughtError.additionalDetails).toBe("Error: " + errMsg);
         });
 
         it("throws error if command fails with non-zero status", () => {
@@ -117,10 +124,14 @@ describe("ExecUtils tests", () => {
                 caughtError = error;
             }
             expect(spawn.sync).toHaveBeenCalledWith("cat", [filename], { stdio: "inherit" });
-            expect(caughtError.message).toBe(
-                `Command failed: cat ${filename}\nExit code = 1\nStdErr:\n${stderrBuffer.toString()}`
+            expect(caughtError.message).toBe("Errors occurred in this program: cat");
+            expect(caughtError.additionalDetails).toBe(
+                "Command that failed:\n" +
+                "    cat invalid.txt\n" +
+                "Exit code = 1\n\n" +
+                "Command's standard error stream:\n" +
+                "cat: invalid.txt: No such file or directory\n"
             );
-
         });
     });
 });

--- a/packages/imperative/src/utilities/src/ExecUtils.ts
+++ b/packages/imperative/src/utilities/src/ExecUtils.ts
@@ -11,10 +11,7 @@
 
 import { SpawnSyncOptions, SpawnSyncReturns } from "child_process";
 import * as spawn from "cross-spawn";
-import { normalize as pathNormalize } from "path";
-
-import { ImperativeConfig } from "./ImperativeConfig";
-import { Logger } from "../../logger";
+import { ImperativeError } from "../../error/src/ImperativeError";
 
 /**
  * A collection of utilities related to executing a sub-process.
@@ -50,45 +47,36 @@ export class ExecUtils {
         // Implementation based on the child_process module
         // https://github.com/nodejs/node/blob/main/lib/child_process.js
         if (result.error != null) {
-            throw result.error;
+            throw new ImperativeError({
+                msg: `Failed to launch the following command:\n    ${argv.join(" ")}`,
+                additionalDetails: result.error.toString()
+            });
         } else if (result.status !== 0) {
-            // log a detailed message
-            let errMsg = `Command that failed: ${argv.join(" ")}`;
+            // form a detailed message
+            let additionalDetails = `Command that failed:\n    ${argv.join(" ")}`;
             if (result.status) {
-                errMsg += `\nExit code = ${result.status.toString()}`;
+                additionalDetails += `\nExit code = ${result.status.toString()}`;
             }
             if (result.stderr?.length > 0) {
-                errMsg += `\n\nCommand's standard error stream:\n${result.stderr.toString()}`;
+                additionalDetails += `\n\nCommand's standard error stream:\n${result.stderr.toString()}`;
             }
             if (result.stdout?.length > 0) {
-                errMsg += `\nCommand's standard output stream:\n${result.stdout.toString()}`;
+                additionalDetails += `\nCommand's standard output stream:\n${result.stdout.toString()}`;
             }
 
             // give additional tips to debug npm commands
             if (argv[0].toLowerCase().includes("npm")) {
-                errMsg += "\nIf you are using an NPM registry, " +
+                additionalDetails += "\nIf you are using an NPM registry, " +
                     "confirm that NPM can access the registry with the following command:\n" +
                     "    npm view <your_desired_package_name>\n" +
                     "Confirm that NPM can download your package from your registry:\n" +
-                    "    npm pack <your_desired_package_name> -registry <your_npm_registry_name> "
+                    "    npm pack <your_desired_package_name>";
             }
-            Logger.getImperativeLogger().error(errMsg);
 
-            // throw a truncated message to be displayed
-            const truncLen = 100;
-            errMsg = "";
-            if (result.stderr?.length > 0) {
-                errMsg += `${result.stderr.toString()}`;
-            }
-            if (result.stdout?.length > 0) {
-                errMsg += `\n${result.stdout.toString()}`;
-            }
-            if (errMsg.length > truncLen) {
-                errMsg = errMsg.slice(0, truncLen) + " ... <message truncated>";
-            }
-            const impLogFileNm = pathNormalize(ImperativeConfig.instance.cliHome + "/logs/imperative.log");
-            errMsg += `\nFor error details, search for 'Command that failed' in ${impLogFileNm}`;
-            throw new Error(errMsg);
+            throw new ImperativeError({
+                msg: `Errors occurred in this program: ${argv[0]}`,
+                additionalDetails: additionalDetails
+            });
         }
         return result.stdout as T;
     }

--- a/packages/imperative/src/utilities/src/ExecUtils.ts
+++ b/packages/imperative/src/utilities/src/ExecUtils.ts
@@ -11,6 +11,10 @@
 
 import { SpawnSyncOptions, SpawnSyncReturns } from "child_process";
 import * as spawn from "cross-spawn";
+import { normalize as pathNormalize } from "path";
+
+import { ImperativeConfig } from "./ImperativeConfig";
+import { Logger } from "../../logger";
 
 /**
  * A collection of utilities related to executing a sub-process.
@@ -48,15 +52,43 @@ export class ExecUtils {
         if (result.error != null) {
             throw result.error;
         } else if (result.status !== 0) {
-            let msg = `Command failed: ${argv.join(" ")}`;
-            msg += `\nExit code = ${result.status.toString()}`;
+            // log a detailed message
+            let errMsg = `Command that failed: ${argv.join(" ")}`;
+            if (result.status) {
+                errMsg += `\nExit code = ${result.status.toString()}`;
+            }
             if (result.stderr?.length > 0) {
-                msg += `\nStdErr:\n${result.stderr.toString()}`;
+                errMsg += `\n\nCommand's standard error stream:\n${result.stderr.toString()}`;
             }
             if (result.stdout?.length > 0) {
-                msg += `\nStdOut:\n${result.stdout.toString()}`;
+                errMsg += `\nCommand's standard output stream:\n${result.stdout.toString()}`;
             }
-            throw new Error(msg);
+
+            // give additional tips to debug npm commands
+            if (argv[0].toLowerCase().includes("npm")) {
+                errMsg += "\nIf you are using an NPM registry, " +
+                    "confirm that NPM can access the registry with the following command:\n" +
+                    "    npm view <your_desired_package_name>\n" +
+                    "Confirm that NPM can download your package from your registry:\n" +
+                    "    npm pack <your_desired_package_name> -registry <your_npm_registry_name> "
+            }
+            Logger.getImperativeLogger().error(errMsg);
+
+            // throw a truncated message to be displayed
+            const truncLen = 100;
+            errMsg = "";
+            if (result.stderr?.length > 0) {
+                errMsg += `${result.stderr.toString()}`;
+            }
+            if (result.stdout?.length > 0) {
+                errMsg += `\n${result.stdout.toString()}`;
+            }
+            if (errMsg.length > truncLen) {
+                errMsg = errMsg.slice(0, truncLen) + " ... <message truncated>";
+            }
+            const impLogFileNm = pathNormalize(ImperativeConfig.instance.cliHome + "/logs/imperative.log");
+            errMsg += `\nFor error details, search for 'Command that failed' in ${impLogFileNm}`;
+            throw new Error(errMsg);
         }
         return result.stdout as T;
     }


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->
Fixes #2721 

It also restructures error messages produced by 3rd party programs that are spawned by zowe.
- More diagnostic details are displayed.
- Duplication of error message text is eliminated.

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->

Run a plugin installation command that will fail. The easiest such command is to install a plugin name that is invalid.
```
zowe plugins install invalid-plugin
```

You should no longer see an error like the following (which is actually the second error to occur) instead of an error about being unable to run the NPM command.
```
Error: <YourHomeDirectory>\.zowe\plugins\installed\node_modules\bogus-plugin\package.json: ENOENT: no such file or directory, open '<YourHomeDirectory>\.zowe\plugins\installed\node_modules\bogus-plugin\package.json'
```

The error message will now call out a failure in the NPM command like the following:
```
Unable to perform this operation due to the following problem.
Plug-in installation failed.

Response From Service
Errors occurred in this program: <yourNpmInstallationPath>\npm.CMD

Diagnostic Information
Command that failed:
<yourNpmInstallationPath>s\npm.CMD install invalid-plugin -g --legacy-peer-deps --prefix <YourHomeDirectory>\.zowe\plugins\installed --registry https://<YourNpmRegistryURL>
Exit code = 1

Command's standard error stream:
npm error code E404
npm error 404 Not Found - GET https://<YourNpmRegistryURL>/invalid-plugin
npm error 404
npm error 404  The requested resource 'invalid-plugin@*' could not be found or you do not have permission to access it.
npm error 404
npm error 404 Note that you can also install from a
npm error 404 tarball, folder, http url, or git url.
npm error A complete log of this run can be found in: <YourHomeDirectory>\AppData\Local\npm-cache\_logs\2026-05-13T20_53_58_957Z-debug-0.log

If you are using an NPM registry, confirm that NPM can access the registry with the following command:
    npm view <your_desired_package_name>
Confirm that NPM can download your package from your registry:
    npm pack <your_desired_package_name>

```

**Review Checklist**
I certify that I have:
- [x] updated the changelog
- [x] manually tested my changes
- [x] added/updated automated unit/integration tests
- [x] created/ran system tests (provide build number if applicable)
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
