### PR TITLE
refactor: replace any with unknown for rawVal

### DIFF
--- a/packages/imperative/src/error/src/ImperativeError.ts
+++ b/packages/imperative/src/error/src/ImperativeError.ts
@@ -10,6 +10,7 @@
 */
 
 const os = require("node:os");
+
 import { IImperativeError } from "./doc/IImperativeError";
 import { IImperativeErrorParms } from "./doc/IImperativeErrorParms";
 
@@ -19,7 +20,7 @@ import { IImperativeErrorParms } from "./doc/IImperativeErrorParms";
  */
 interface IErrOutputData {
     stringVal: string;
-    rawVal: any;
+    rawVal: unknown;
 }
 
 /**


### PR DESCRIPTION
Fixes #2731

This change replaces `any` with `unknown` for `rawVal` in the IErrOutputData interface.

Using `unknown` improves type safety by forcing consumers to perform proper type checking or casting before accessing the value.

No functional behavior changes.  @zowe-robot 
@crshnburn  please review this PR 