### PR TITLE
[v2] trust customer editors

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the Zowe CLI package will be documented in this file.
 
 ## Recent Changes
 
-- **Breaking** BugFix: Updated the `zowe zos-files (ds/uss) edit` command to prompt the user to trust custom editors. [#2740](https://github.com/zowe/zowe-cli/pull/2740)
+- **Breaking** BugFix: Updated the `zowe zos-files (ds/uss) edit` command to prompt the user to trust custom editors. [#2742](https://github.com/zowe/zowe-cli/pull/2742)
 
 ## `7.29.25`
 

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Zowe CLI package will be documented in this file.
 
+## Recent Changes
+
+- **Breaking** BugFix: Updated the `zowe zos-files (ds/uss) edit` command to prompt the user to trust custom editors. [#2740](https://github.com/zowe/zowe-cli/pull/2740)
+
 ## `7.29.25`
 
 - BugFix: Updated the `lodash`, `brace-expansion`, and `diff` dependencies to resolve technical currency. [#2711](https://github.com/zowe/zowe-cli/pull/2711)

--- a/packages/cli/__tests__/zosfiles/__unit__/edit/Edit.handler.unit.test.ts
+++ b/packages/cli/__tests__/zosfiles/__unit__/edit/Edit.handler.unit.test.ts
@@ -11,7 +11,7 @@
 
 import { GuiResult, IHandlerParameters, ImperativeError, ProcessUtils, RestConstants, TextUtils } from "@zowe/imperative";
 import {ILocalFile,
-    EditUtilities} from "../../../../src/zosfiles/edit/Edit.utils";
+    EditUtilities, Prompt } from "../../../../src/zosfiles/edit/Edit.utils";
 import { mockHandlerParameters } from "@zowe/cli-test-utils";
 import { EditDefinition } from "../../../../src/zosfiles/edit/Edit.definition";
 import EditHandler from "../../../../src/zosfiles/edit/Edit.handler";
@@ -133,6 +133,89 @@ describe("Files Edit Group Handler", () => {
                 caughtError = e;
             }
             expect(caughtError).toBeInstanceOf(ImperativeError);
+
+            // Restore original implementation
+            localDownloadSpy.mockImplementation(async () => {
+                return localFile;
+            });
+        });
+
+        it("should throw an error if the editor argument is provided and the user does not trust the editor", async () => {
+            localDownloadSpy.mockImplementation(async () => {
+                return localFile;
+            });
+            const localParams = {
+                ...params,
+                arguments: {
+                    ...params.arguments,
+                    editor: "my-editor"
+                },
+                response: {
+                    ...params.response,
+                    console: {
+                        ...params.response.console,
+                        log: jest.fn()
+                    }
+                }
+            };
+            promptUserSpy.mockImplementation(async (prompt, conflict, promptTexts) => {
+                if (prompt === Prompt.trustEditor) {
+                    return false;
+                }
+                return true;
+            });
+
+            let caughtError;
+            try {
+                await handler.process(localParams);
+            } catch (e) {
+                caughtError = e;
+            }
+            expect(caughtError).toBeInstanceOf(ImperativeError);
+            expect(caughtError.message).toContain("User did not trust the editor. Command terminated.");
+            expect(promptUserSpy).toHaveBeenCalledWith(Prompt.trustEditor, false, ["my-editor"]);
+
+            // Restore original implementation
+            promptUserSpy.mockImplementation(async () => {
+                return true;
+            });
+        });
+
+        it("should proceed if the editor argument is provided and the user trusts the editor", async () => {
+            localDownloadSpy.mockImplementation(async () => {
+                return localFile;
+            });
+            const localParams = {
+                ...params,
+                arguments: {
+                    ...params.arguments,
+                    editor: "my-editor"
+                },
+                response: {
+                    ...params.response,
+                    console: {
+                        ...params.response.console,
+                        log: jest.fn()
+                    }
+                }
+            };
+            promptUserSpy.mockImplementation(async (prompt, conflict, promptTexts) => {
+                if (prompt === Prompt.trustEditor) {
+                    return true;
+                }
+                return true;
+            });
+            jest.spyOn(EditUtilities, "makeEdits").mockResolvedValueOnce(true);
+            jest.spyOn(EditUtilities, "uploadEdits").mockResolvedValueOnce([true, false]);
+
+            await handler.process(localParams);
+            expect(promptUserSpy).toHaveBeenCalledWith(Prompt.trustEditor, false, ["my-editor"]);
+            expect(EditUtilities.makeEdits).toHaveBeenCalledWith(expect.anything(), "my-editor");
+
+            // Restore original implementation
+            promptUserSpy.mockImplementation(async () => {
+                return true;
+            });
         });
     });
 });

--- a/packages/cli/__tests__/zosfiles/__unit__/edit/Edit.utils.unit.test.ts
+++ b/packages/cli/__tests__/zosfiles/__unit__/edit/Edit.utils.unit.test.ts
@@ -152,6 +152,10 @@ describe("Files Edit Utilities", () => {
                 const response = await EditUtilities.promptUser(Prompt.overwriteRemote);
                 expect(response).toBe(true);
             });
+            it("should understand that user wants to trust the editor - case Prompt.trustEditor", async() => {
+                const response = await EditUtilities.promptUser(Prompt.trustEditor, false, ["my-editor"]);
+                expect(response).toBe(true);
+            });
         });
         describe("falsy prompt responses", () => {
             beforeEach(async () => {
@@ -173,6 +177,10 @@ describe("Files Edit Utilities", () => {
             });
             it("should understand that user does NOT want to overwrite remote - case Prompt.overwriteRemote", async() => {
                 const response = await EditUtilities.promptUser(Prompt.overwriteRemote);
+                expect(response).toBe(false);
+            });
+            it("should understand that user does NOT want to trust the editor - case Prompt.trustEditor", async() => {
+                const response = await EditUtilities.promptUser(Prompt.trustEditor, false, ["my-editor"]);
                 expect(response).toBe(false);
             });
         });
@@ -201,6 +209,14 @@ describe("Files Edit Utilities", () => {
             it("should timeout of the entire command because no user input - case Prompt.viewUpdatedRemote", async() => {
                 try {
                     await EditUtilities.promptUser(Prompt.viewUpdatedRemote);
+                } catch(e) {
+                    caughtError = e;
+                }
+                expect(caughtError).toBeInstanceOf(ImperativeError);
+            });
+            it("should timeout of the entire command because no user input - case Prompt.trustEditor", async() => {
+                try {
+                    await EditUtilities.promptUser(Prompt.trustEditor, false, ["my-editor"]);
                 } catch(e) {
                     caughtError = e;
                 }

--- a/packages/cli/__tests__/zosfiles/__unit__/edit/__snapshots__/Edit.handler.unit.test.ts.snap
+++ b/packages/cli/__tests__/zosfiles/__unit__/edit/__snapshots__/Edit.handler.unit.test.ts.snap
@@ -22,6 +22,13 @@ Object {
 }
 `;
 
+exports[`Files Edit Group Handler process method should proceed if the editor argument is provided and the user trusts the editor 1`] = `
+Object {
+  "commandResponse": "[32mSuccessfully uploaded edits to mainframe.[39m",
+  "success": true,
+}
+`;
+
 exports[`Files Edit Group Handler process method should upload edits unsuccessfully 1`] = `"Temp file location: /tmp/dataset.txt"`;
 
 exports[`Files Edit Group Handler process method should upload edits unsuccessfully 2`] = `"Exiting now. Temp file persists for editing."`;

--- a/packages/cli/src/zosfiles/edit/Edit.handler.ts
+++ b/packages/cli/src/zosfiles/edit/Edit.handler.ts
@@ -21,6 +21,16 @@ import { EditUtilities as Utils, Prompt, ILocalFile } from "../edit/Edit.utils";
  */
 export default class EditHandler extends ZosFilesBaseHandler {
     public async processWithSession(commandParameters: IHandlerParameters, session: AbstractSession): Promise<IZosFilesResponse> {
+        if(commandParameters.arguments.editor){
+            const trustEditor = await Utils.promptUser(Prompt.trustEditor, false, [commandParameters.arguments.editor]);
+            if (!trustEditor){
+                throw new ImperativeError({
+                    msg: TextUtils.chalk.red(`User did not trust the editor. Command terminated.`),
+                    causeErrors: new Error(`User did not trust the editor.`)
+                });
+            }
+        }
+
         // Setup - build temp and check for stash
         let lfFile: ILocalFile = {
             tempPath: null,

--- a/packages/cli/src/zosfiles/edit/Edit.utils.ts
+++ b/packages/cli/src/zosfiles/edit/Edit.utils.ts
@@ -30,7 +30,8 @@ export enum Prompt {
     viewDiff,
     overwriteRemote,
     viewUpdatedRemote,
-    continueToUpload
+    continueToUpload,
+    trustEditor
 }
 
 /**
@@ -111,7 +112,7 @@ export class EditUtilities {
      * @returns {Promise<boolean>} - promise whose resolution depends on user input
      * @memberof EditUtilities
      */
-    public static async promptUser(prompt: Prompt, conflict?: boolean): Promise<boolean>{
+    public static async promptUser(prompt: Prompt, conflict?: boolean, promptTexts?: string[]): Promise<boolean>{
         let input;
         let promptText;
         const promptPrefix = (conflict ? 'CONFLICT: ' : '');
@@ -131,6 +132,11 @@ export class EditUtilities {
             case Prompt.continueToUpload:
                 promptText = promptPrefix + 'Ignore conflicts and overwrite remote? y/n';
                 break;
+            case Prompt.trustEditor: {
+                const editorName = promptTexts?.length > 0 ? promptTexts[0] : "the custom editor";
+                promptText = `You are about to edit using '${editorName}'. Would you like to trust this editor? y/n`;
+                break;
+            }
         }
         do {
             input = await CliUtils.readPrompt(TextUtils.chalk.green(promptText));


### PR DESCRIPTION
**What It Does**

 Updated `zowe zos-files (ds/uss) edit` to prompt the user to trust custom editors.

**How to Test**

Run `zowe zos-files edit uss <file> --editor <pathToEditor>`
**OR**
Run `zowe zos-files edit uss <file>` with the `editor` property set on the profile

This may also be ran against `zowe zos-file edit ds`

Expected result:

<img width="988" height="77" alt="image" src="https://github.com/user-attachments/assets/6ad3aca9-d4da-44a0-b8f7-89917cc82ce2" />



**Review Checklist**
I certify that I have:
- [x] updated the changelog
- [x] manually tested my changes
- [x] added/updated automated unit/integration tests
- [ ] created/ran system tests (provide build number if applicable)
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
