### PR TITLE
(v3): Enforce file permissions on daemon related directories and files

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Zowe CLI package will be documented in this file.
 
+## Recent Changes
+
+- BugFix: Restricted access to daemon-related files and directories to the current user only on all platforms. The daemon directory, `~/.zowe/bin` directory, the extracted native executable, the daemon PID file, and the Unix domain socket are now created with owner-only permissions (`0o700`/`0o600` on POSIX, owner-only ACL on Windows) to prevent other local users from accessing them.
+
 ## `8.32.2`
 
 - BugFix: Updated the error handling for plug-in installation to report the first failure that occurs. [#2722](https://github.com/zowe/zowe-cli/pull/2722)

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the Zowe CLI package will be documented in this file.
 
 ## Recent Changes
 
-- BugFix: Restricted access to daemon-related files and directories to the current user only on all platforms. The daemon directory, `~/.zowe/bin` directory, the extracted native executable, the daemon PID file, and the Unix domain socket are now given owner-only permissions (`0o700`/`0o600` on POSIX, owner-only ACL on Windows) to prevent other local users from accessing them. The daemon directory, the `~/.zowe/bin` directory, and the native executable inside it are also re-restricted when they already exist, so that artifacts created before this fix with looser permissions are corrected on the next `zowe daemon enable`, daemon start, or `zowe daemon restart`.
+- BugFix: Restricted access to daemon-related files and directories to the current user only on all platforms. The daemon directory, `~/.zowe/bin` directory, the extracted native executable, the daemon PID file, and the Unix domain socket are now given owner-only permissions (`0o700`/`0o600` on POSIX, owner-only ACL on Windows) to prevent other local users from accessing them. The daemon directory, the `~/.zowe/bin` directory, and the native executable inside it are also re-restricted when they already exist, so that artifacts created before this fix with looser permissions are corrected on the next `zowe daemon enable` or `zowe daemon restart`. [#2743](https://github.com/zowe/zowe-cli/pull/2743)
 
 ## `8.32.2`
 

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the Zowe CLI package will be documented in this file.
 
 ## Recent Changes
 
-- BugFix: Restricted access to daemon-related files and directories to the current user only on all platforms. The daemon directory, `~/.zowe/bin` directory, the extracted native executable, the daemon PID file, and the Unix domain socket are now created with owner-only permissions (`0o700`/`0o600` on POSIX, owner-only ACL on Windows) to prevent other local users from accessing them.
+- BugFix: Restricted access to daemon-related files and directories to the current user only on all platforms. The daemon directory, `~/.zowe/bin` directory, the extracted native executable, the daemon PID file, and the Unix domain socket are now given owner-only permissions (`0o700`/`0o600` on POSIX, owner-only ACL on Windows) to prevent other local users from accessing them. The daemon directory, the `~/.zowe/bin` directory, and the native executable inside it are also re-restricted when they already exist, so that artifacts created before this fix with looser permissions are corrected on the next `zowe daemon enable`, daemon start, or `zowe daemon restart`.
 
 ## `8.32.2`
 

--- a/packages/cli/__tests__/daemon/__unit__/DaemonDecider.unit.test.ts
+++ b/packages/cli/__tests__/daemon/__unit__/DaemonDecider.unit.test.ts
@@ -332,6 +332,66 @@ describe("DaemonDecider tests", () => {
         writeFileSyncSpy.mockClear();
     });
 
+    it("should restrict access to the pid file and socket to the owner on Posix", () => {
+        const log = jest.fn(() => {
+            // do nothing
+        });
+
+        const on = jest.fn((_event, _func) => {
+            // do nothing
+        });
+
+        // invoke the listen callback so the socket-restriction logic runs
+        const listen = jest.fn((_socket, method) => {
+            method();
+        });
+
+        const parse = jest.fn();
+
+        (Imperative as any) = {
+            api: {
+                appLogger: {
+                    trace: log,
+                    debug: log,
+                    error: log
+                }
+            },
+            console: {
+                info: log
+            },
+            parse
+        };
+
+        const fn = jest.mocked(net.createServer);
+        fn.mockImplementation((method: any, ..._args: any[]): any => {
+            method("fakeClient", "fakeServer");
+            return { on, listen };
+        });
+
+        const daemonDir = path.normalize("./testOutput/daemonDir");
+        process.env.ZOWE_DAEMON_DIR = daemonDir;
+
+        // fool our function into thinking we are on a Posix system
+        const realPlatform = process.platform;
+        Object.defineProperty(process, "platform", { value: "linux" });
+
+        const giveAccessSpy = jest.spyOn(IO, "giveAccessOnlyToOwner").mockImplementation(() => {
+            return;
+        });
+        jest.spyOn(IO, "existsSync").mockReturnValue(false);
+
+        const daemonDecider = new DaemonDecider(["node", "zowe", "--daemon"]);
+        daemonDecider.init();
+        daemonDecider.runOrUseDaemon();
+
+        // restore our real platform
+        Object.defineProperty(process, "platform", { value: realPlatform });
+
+        const restrictedPaths = giveAccessSpy.mock.calls.map((call) => call[0]);
+        expect(restrictedPaths).toContain(path.join(daemonDir, "daemon_pid.json"));
+        expect(restrictedPaths).toContain(path.join(daemonDir, "daemon.sock"));
+    });
+
     it("should throw an error when it cannot write the process ID file", () => {
         const log = jest.fn(() => {
             // do nothing

--- a/packages/cli/__tests__/daemon/__unit__/DaemonDecider.unit.test.ts
+++ b/packages/cli/__tests__/daemon/__unit__/DaemonDecider.unit.test.ts
@@ -25,65 +25,19 @@ import { DaemonDecider } from "../../../src/daemon/DaemonDecider";
 jest.mock("../../../src/daemon/DaemonClient");
 
 describe("DaemonDecider tests", () => {
-    afterEach(() => {
-        delete process.env.ZOWE_DAEMON_DIR;
-        delete process.env.ZOWE_DAEMON_PIPE;
-        jest.resetAllMocks();
-    });
+    let log: jest.Mock;
+    let on: jest.Mock;
+    let listen: jest.Mock;
+    let parse: jest.Mock;
+    let createServerMock: jest.Mock;
 
-    it("should call normal parse method if no daemon keyword", () => {
-
-        const log = jest.fn(() => {
-            // do nothing
-        });
-
-        const on = jest.fn((_event, _func) => {
-            // do nothing
-        });
-
-        const parse = jest.fn( (data, context) => {
+    beforeEach(() => {
+        log = jest.fn();
+        on = jest.fn();
+        listen = jest.fn();
+        parse = jest.fn((data, context) => {
             expect(data).toBe(undefined);
             expect(context).toBe(undefined);
-        });
-
-        (Imperative as any) = {
-            api: {
-                appLogger: {
-                    trace: log
-                }
-            },
-            parse
-        };
-        const fn = jest.mocked(net.createServer);
-        fn.mockImplementation((_unusedclient, ..._args: any[]): any => {
-            return {on};
-        });
-
-        const daemonDecider = new DaemonDecider(["--help"]);
-        daemonDecider.init();
-        expect(on).not.toHaveBeenCalled();
-        daemonDecider.runOrUseDaemon();
-        expect(parse).toHaveBeenCalled();
-    });
-
-    it("should start the server when daemon parm is passed", () => {
-
-        const log = jest.fn(() => {
-            // do nothing
-        });
-
-        const on = jest.fn((_event, _func) => {
-            // do nothing
-        });
-
-        const listen = jest.fn((socket, method) => {
-            // do nothing
-            method();
-        });
-
-        const parse = jest.fn( (data, context) => {
-            expect(data).toMatchSnapshot();
-            expect(context).toMatchSnapshot();
         });
 
         (Imperative as any) = {
@@ -99,10 +53,40 @@ describe("DaemonDecider tests", () => {
             },
             parse
         };
-        const fn = jest.mocked(net.createServer);
-        fn.mockImplementation((method: any, ..._args: any[]): any => {
+
+        createServerMock = jest.mocked(net.createServer);
+        createServerMock.mockImplementation(() => {
+            return { on, listen };
+        });
+    });
+
+    afterEach(() => {
+        delete process.env.ZOWE_DAEMON_DIR;
+        delete process.env.ZOWE_DAEMON_PIPE;
+        jest.resetAllMocks();
+    });
+
+    it("should call normal parse method if no daemon keyword", () => {
+        const daemonDecider = new DaemonDecider(["--help"]);
+        daemonDecider.init();
+        expect(on).not.toHaveBeenCalled();
+        daemonDecider.runOrUseDaemon();
+        expect(parse).toHaveBeenCalled();
+    });
+
+    it("should start the server when daemon parm is passed", () => {
+        listen.mockImplementation((socket, method) => {
+            method();
+        });
+
+        parse.mockImplementation((data, context) => {
+            expect(data).toMatchSnapshot();
+            expect(context).toMatchSnapshot();
+        });
+
+        createServerMock.mockImplementation((method: any) => {
             method("fakeClient", "fakeServer");
-            return {on, listen};
+            return { on, listen };
         });
 
         const daemonDecider = new DaemonDecider(["some/file/path", "zowe", "--daemon"]);
@@ -122,19 +106,6 @@ describe("DaemonDecider tests", () => {
     });
 
     it("should set comm channel based on env variable", () => {
-
-        const log = jest.fn(() => {
-            // do nothing
-        });
-
-        (Imperative as any) = {
-            api: {
-                appLogger: {
-                    debug: log
-                }
-            }
-        };
-
         const daemonDecider = new DaemonDecider(["anything"]);
 
         const envWinPipeName = "MyWinPipeName";
@@ -155,42 +126,6 @@ describe("DaemonDecider tests", () => {
     });
 
     it("should not start a daemon", () => {
-        const log = jest.fn(() => {
-            // do nothing
-        });
-
-        const on = jest.fn((_event, _func) => {
-            // do nothing
-        });
-
-        const listen = jest.fn((_event, _func) => {
-            // do nothing
-        });
-
-        const parse = jest.fn( (data, context) => {
-            expect(data).toBe(undefined);
-            expect(context).toBe(undefined);
-        });
-
-        (Imperative as any) = {
-            api: {
-                appLogger: {
-                    trace: log,
-                    debug: log,
-                    error: log
-                }
-            },
-            console: {
-                info: log
-            },
-            parse
-        };
-
-        const fn = jest.mocked(net.createServer);
-        fn.mockImplementation((_unusedclient, ..._args: any[]): any => {
-            return {on, listen};
-        });
-
         const daemonDecider = new DaemonDecider(["node", "zowe", "--help"]);
         daemonDecider.init();
 
@@ -199,42 +134,6 @@ describe("DaemonDecider tests", () => {
     });
 
     it("should use the default comm channel location", () => {
-        const log = jest.fn(() => {
-            // do nothing
-        });
-
-        const on = jest.fn((_event, _func) => {
-            // do nothing
-        });
-
-        const listen = jest.fn((_event, _func) => {
-            // do nothing
-        });
-
-        const parse = jest.fn( (data, context) => {
-            expect(data).toBe(undefined);
-            expect(context).toBe(undefined);
-        });
-
-        (Imperative as any) = {
-            api: {
-                appLogger: {
-                    trace: log,
-                    debug: log,
-                    error: log
-                }
-            },
-            console: {
-                info: log
-            },
-            parse
-        };
-
-        const fn = jest.mocked(net.createServer);
-        fn.mockImplementation((_unusedclient, ..._args: any[]): any => {
-            return {on, listen};
-        });
-
         const daemonDecider = new DaemonDecider(["node", "zowe", "--daemon"]);
         daemonDecider.init();
 
@@ -249,42 +148,6 @@ describe("DaemonDecider tests", () => {
     });
 
     it("should try to delete an existing socket on Posix", () => {
-        const log = jest.fn(() => {
-            // do nothing
-        });
-
-        const on = jest.fn((_event, _func) => {
-            // do nothing
-        });
-
-        const listen = jest.fn((_event, _func) => {
-            // do nothing
-        });
-
-        const parse = jest.fn( (data, context) => {
-            expect(data).toBe(undefined);
-            expect(context).toBe(undefined);
-        });
-
-        (Imperative as any) = {
-            api: {
-                appLogger: {
-                    trace: log,
-                    debug: log,
-                    error: log
-                }
-            },
-            console: {
-                info: log
-            },
-            parse
-        };
-
-        const fn = jest.mocked(net.createServer);
-        fn.mockImplementation((_unusedclient, ..._args: any[]): any => {
-            return {on, listen};
-        });
-
         process.env.ZOWE_DAEMON_DIR = path.normalize("./testOutput/daemonDir");
         const daemonDecider = new DaemonDecider(["node", "zowe", "--daemon"]);
 
@@ -333,37 +196,14 @@ describe("DaemonDecider tests", () => {
     });
 
     it("should restrict access to the pid file and socket to the owner on Posix", () => {
-        const log = jest.fn(() => {
-            // do nothing
-        });
-
-        const on = jest.fn((_event, _func) => {
-            // do nothing
-        });
-
         // invoke the listen callback so the socket-restriction logic runs
-        const listen = jest.fn((_socket, method) => {
+        listen.mockImplementation((_socket, method) => {
             method();
         });
 
-        const parse = jest.fn();
+        parse.mockImplementation(() => {});
 
-        (Imperative as any) = {
-            api: {
-                appLogger: {
-                    trace: log,
-                    debug: log,
-                    error: log
-                }
-            },
-            console: {
-                info: log
-            },
-            parse
-        };
-
-        const fn = jest.mocked(net.createServer);
-        fn.mockImplementation((method: any, ..._args: any[]): any => {
+        createServerMock.mockImplementation((method: any) => {
             method("fakeClient", "fakeServer");
             return { on, listen };
         });
@@ -393,42 +233,6 @@ describe("DaemonDecider tests", () => {
     });
 
     it("should throw an error when it cannot write the process ID file", () => {
-        const log = jest.fn(() => {
-            // do nothing
-        });
-
-        const on = jest.fn((_event, _func) => {
-            // do nothing
-        });
-
-        const listen = jest.fn((_event, _func) => {
-            // do nothing
-        });
-
-        const parse = jest.fn( (data, context) => {
-            expect(data).toBe(undefined);
-            expect(context).toBe(undefined);
-        });
-
-        (Imperative as any) = {
-            api: {
-                appLogger: {
-                    trace: log,
-                    debug: log,
-                    error: log
-                }
-            },
-            console: {
-                info: log
-            },
-            parse
-        };
-
-        const fn = jest.mocked(net.createServer);
-        fn.mockImplementation((_unusedclient, ..._args: any[]): any => {
-            return {on, listen};
-        });
-
         process.env.ZOWE_DAEMON_DIR = path.normalize("./testOutput/daemonDir");
         const daemonDecider = new DaemonDecider(["node", "zowe", "--daemon"]);
 
@@ -455,42 +259,90 @@ describe("DaemonDecider tests", () => {
         writeFileSyncSpy.mockClear();
     });
 
+    it("should throw an error when it cannot restrict access to the process ID file", () => {
+        process.env.ZOWE_DAEMON_DIR = path.normalize("./testOutput/daemonDir");
+        const daemonDecider = new DaemonDecider(["node", "zowe", "--daemon"]);
+
+        const writeFileSyncSpy = jest.spyOn(fs, "writeFileSync").mockImplementation(() => { return; });
+        writeFileSyncSpy.mockClear();
+
+        const badStuffMsg = "Some bad stuff happened";
+        const giveAccessSpy = jest.spyOn(IO, "giveAccessOnlyToOwner");
+        giveAccessSpy.mockImplementation((filePath: string) => {
+            if (filePath.endsWith("daemon_pid.json")) {
+                throw new Error(badStuffMsg);
+            }
+        });
+
+        let error: Error;
+        try {
+            daemonDecider.init();
+        } catch (e) {
+            error = e;
+        }
+
+        expect(writeFileSyncSpy).toHaveBeenCalledTimes(1);
+        expect(giveAccessSpy).toHaveBeenCalled();
+        expect(error).toBeDefined();
+        expect(error.message).toContain("Failed to write file");
+        expect(error.message).toContain("daemon_pid.json");
+        expect(error.message).toContain(badStuffMsg);
+        writeFileSyncSpy.mockRestore();
+        giveAccessSpy.mockRestore();
+    });
+
+    it("should log an error when it cannot restrict access to the socket on Posix", () => {
+        let errorLogMsg = "";
+        const errorLog = jest.fn((msg) => {
+            errorLogMsg += msg;
+        });
+        (Imperative as any).api.appLogger.error = errorLog;
+
+        // invoke the listen callback so the socket-restriction logic runs
+        listen.mockImplementation((_socket, method) => {
+            method();
+        });
+
+        parse.mockImplementation(() => {});
+
+        createServerMock.mockImplementation((method: any) => {
+            method("fakeClient", "fakeServer");
+            return { on, listen };
+        });
+
+        const daemonDir = path.normalize("./testOutput/daemonDir");
+        process.env.ZOWE_DAEMON_DIR = daemonDir;
+
+        // fool our function into thinking we are on a Posix system
+        const realPlatform = process.platform;
+        Object.defineProperty(process, "platform", { value: "linux" });
+
+        const badStuffMsg = "Some bad stuff happened";
+        const giveAccessSpy = jest.spyOn(IO, "giveAccessOnlyToOwner").mockImplementation((filePath) => {
+            if (filePath.endsWith("daemon.sock")) {
+                throw new Error(badStuffMsg);
+            }
+            return;
+        });
+        jest.spyOn(IO, "existsSync").mockReturnValue(false);
+
+        const daemonDecider = new DaemonDecider(["node", "zowe", "--daemon"]);
+        daemonDecider.init();
+        daemonDecider.runOrUseDaemon();
+
+        // restore our real platform
+        Object.defineProperty(process, "platform", { value: realPlatform });
+
+        expect(errorLog).toHaveBeenCalled();
+        expect(errorLogMsg).toContain("Unable to restrict access to daemon socket");
+        expect(errorLogMsg).toContain(badStuffMsg);
+        giveAccessSpy.mockRestore();
+    });
+
     it("should form the path to a pipe on windows", () => {
-        let recordedLogMsg: string;
-        const log = jest.fn((logMsg) => {
-            recordedLogMsg += logMsg;
-        });
-
-        const on = jest.fn((_event, _func) => {
-            // do nothing
-        });
-
-        const listen = jest.fn((_event, _func) => {
-            // do nothing
-        });
-
-        const parse = jest.fn( (data, context) => {
-            expect(data).toBe(undefined);
-            expect(context).toBe(undefined);
-        });
-
-        (Imperative as any) = {
-            api: {
-                appLogger: {
-                    trace: log,
-                    debug: log,
-                    error: log
-                }
-            },
-            console: {
-                info: log
-            },
-            parse
-        };
-
-        const fn = jest.mocked(net.createServer);
-        fn.mockImplementation((_unusedclient, ..._args: any[]): any => {
-            return {on, listen};
+        let recordedLogMsg = "";
+        log.mockImplementation((logMsg) => {
+            if (logMsg) recordedLogMsg += logMsg;
         });
 
         process.env.ZOWE_DAEMON_DIR = path.normalize("./testOutput/daemonDir");

--- a/packages/cli/__tests__/daemon/__unit__/DaemonUtil.unit.test.ts
+++ b/packages/cli/__tests__/daemon/__unit__/DaemonUtil.unit.test.ts
@@ -93,4 +93,27 @@ describe("DaemonUtil tests", () => {
         expect(error.message).toContain(customDir);
         expect(error.message).toContain(badStuffMsg);
     });
+
+    it("should throw an error when the daemon directory cannot be secured when it already exists", () => {
+        const customDir = path.normalize("./testOutput/existingDaemonDir");
+        process.env.ZOWE_DAEMON_DIR = customDir;
+        existsSyncSpy.mockReturnValue(true);
+
+        const badStuffMsg = "Some awful permission error";
+        giveAccessOnlyToOwnerSpy.mockImplementation(() => {
+            throw new Error(badStuffMsg);
+        });
+
+        let error: Error;
+        try {
+            DaemonUtil.getDaemonDir();
+        } catch (e) {
+            error = e;
+        }
+
+        expect(error).toBeDefined();
+        expect(error.message).toContain("Failed to restrict access to directory");
+        expect(error.message).toContain(customDir);
+        expect(error.message).toContain(badStuffMsg);
+    });
 });

--- a/packages/cli/__tests__/daemon/__unit__/DaemonUtil.unit.test.ts
+++ b/packages/cli/__tests__/daemon/__unit__/DaemonUtil.unit.test.ts
@@ -1,0 +1,96 @@
+/*
+* This program and the accompanying materials are made available under the terms of the
+* Eclipse Public License v2.0 which accompanies this distribution, and is available at
+* https://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Copyright Contributors to the Zowe Project.
+*
+*/
+
+import * as os from "os";
+import * as path from "path";
+import { IO } from "@zowe/imperative";
+import { DaemonUtil } from "../../../src/daemon/DaemonUtil";
+
+describe("DaemonUtil tests", () => {
+    let existsSyncSpy: jest.SpyInstance;
+    let createDirSyncSpy: jest.SpyInstance;
+    let giveAccessOnlyToOwnerSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+        existsSyncSpy = jest.spyOn(IO, "existsSync");
+        createDirSyncSpy = jest.spyOn(IO, "createDirSync").mockImplementation(() => {
+            return;
+        });
+        giveAccessOnlyToOwnerSpy = jest.spyOn(IO, "giveAccessOnlyToOwner").mockImplementation(() => {
+            return;
+        });
+    });
+
+    afterEach(() => {
+        delete process.env.ZOWE_DAEMON_DIR;
+        jest.restoreAllMocks();
+    });
+
+    it("should use the ZOWE_DAEMON_DIR environment variable when set", () => {
+        const customDir = path.normalize("./testOutput/customDaemonDir");
+        process.env.ZOWE_DAEMON_DIR = customDir;
+        existsSyncSpy.mockReturnValue(true);
+
+        expect(DaemonUtil.getDaemonDir()).toBe(customDir);
+    });
+
+    it("should default to ~/.zowe/daemon when no environment variable is set", () => {
+        existsSyncSpy.mockReturnValue(true);
+
+        expect(DaemonUtil.getDaemonDir()).toBe(path.join(os.homedir(), ".zowe", "daemon"));
+    });
+
+    it("should create the daemon directory and restrict access to the owner when it does not exist", () => {
+        const customDir = path.normalize("./testOutput/newDaemonDir");
+        process.env.ZOWE_DAEMON_DIR = customDir;
+        existsSyncSpy.mockReturnValue(false);
+
+        const daemonDir = DaemonUtil.getDaemonDir();
+
+        expect(daemonDir).toBe(customDir);
+        expect(createDirSyncSpy).toHaveBeenCalledWith(customDir);
+        expect(giveAccessOnlyToOwnerSpy).toHaveBeenCalledWith(customDir);
+    });
+
+    it("should not re-create or re-restrict the daemon directory when it already exists", () => {
+        const customDir = path.normalize("./testOutput/existingDaemonDir");
+        process.env.ZOWE_DAEMON_DIR = customDir;
+        existsSyncSpy.mockReturnValue(true);
+
+        DaemonUtil.getDaemonDir();
+
+        expect(createDirSyncSpy).not.toHaveBeenCalled();
+        expect(giveAccessOnlyToOwnerSpy).not.toHaveBeenCalled();
+    });
+
+    it("should throw an error when the daemon directory cannot be created or secured", () => {
+        const customDir = path.normalize("./testOutput/failDaemonDir");
+        process.env.ZOWE_DAEMON_DIR = customDir;
+        existsSyncSpy.mockReturnValue(false);
+
+        const badStuffMsg = "Some awful permission error";
+        giveAccessOnlyToOwnerSpy.mockImplementation(() => {
+            throw new Error(badStuffMsg);
+        });
+
+        let error: Error;
+        try {
+            DaemonUtil.getDaemonDir();
+        } catch (e) {
+            error = e;
+        }
+
+        expect(error).toBeDefined();
+        expect(error.message).toContain("Failed to create directory");
+        expect(error.message).toContain(customDir);
+        expect(error.message).toContain(badStuffMsg);
+    });
+});

--- a/packages/cli/__tests__/daemon/__unit__/DaemonUtil.unit.test.ts
+++ b/packages/cli/__tests__/daemon/__unit__/DaemonUtil.unit.test.ts
@@ -60,7 +60,7 @@ describe("DaemonUtil tests", () => {
         expect(giveAccessOnlyToOwnerSpy).toHaveBeenCalledWith(customDir);
     });
 
-    it("should not re-create or re-restrict the daemon directory when it already exists", () => {
+    it("should re-restrict but not re-create the daemon directory when it already exists", () => {
         const customDir = path.normalize("./testOutput/existingDaemonDir");
         process.env.ZOWE_DAEMON_DIR = customDir;
         existsSyncSpy.mockReturnValue(true);
@@ -68,7 +68,7 @@ describe("DaemonUtil tests", () => {
         DaemonUtil.getDaemonDir();
 
         expect(createDirSyncSpy).not.toHaveBeenCalled();
-        expect(giveAccessOnlyToOwnerSpy).not.toHaveBeenCalled();
+        expect(giveAccessOnlyToOwnerSpy).toHaveBeenCalledWith(customDir);
     });
 
     it("should throw an error when the daemon directory cannot be created or secured", () => {

--- a/packages/cli/__tests__/daemon/__unit__/enable/Enable.handler.unit.test.ts
+++ b/packages/cli/__tests__/daemon/__unit__/enable/Enable.handler.unit.test.ts
@@ -67,11 +67,22 @@ describe("Handler for daemon enable", () => {
         }
     });
 
+    let giveAccessOnlyToOwnerSpy: any;
+
     beforeEach(() => {
         // remove enableDaemon spy & mock between tests
         enableDaemonSpy?.mockRestore();
         unzipTgzSpy?.mockRestore();
         logMessage = "";
+
+        // Prevent real chmod/icacls calls against our fake (non-existent) paths.
+        giveAccessOnlyToOwnerSpy = jest.spyOn(IO, "giveAccessOnlyToOwner").mockImplementation(() => {
+            return;
+        });
+    });
+
+    afterEach(() => {
+        giveAccessOnlyToOwnerSpy?.mockRestore();
     });
 
     afterAll(() => {
@@ -565,6 +576,74 @@ describe("Handler for daemon enable", () => {
 
             IO.existsSync = existsSyncOrig;
             IO.isDir = isDirOrig;
+            IO.createDirSync = createDirSyncOrig;
+        });
+
+        it("should restrict access to the extracted executable to the owner", async () => {
+            // Mock the IO functions to simulate stuff is working
+            const existsSyncOrig = IO.existsSync;
+            IO.existsSync = jest.fn(() => {
+                return true;
+            });
+
+            const isDirOrig = IO.isDir;
+            IO.isDir = jest.fn(() => {
+                return true;
+            });
+
+            const createDirSyncOrig = IO.createDirSync;
+            IO.createDirSync = jest.fn();
+
+            // spy on our handler's private enableDaemon() function
+            unzipTgzSpy = jest.spyOn(EnableDaemonHandler.prototype as any, "unzipTgz");
+            unzipTgzSpy.mockImplementation((_tgzFile: string, _toDir: string, _fileToExtract: string) => {return;});
+
+            let error;
+            try {
+                await enableHandler.enableDaemon(noAskNoAddPath);
+            } catch (e) {
+                error = e;
+            }
+
+            expect(error).toBeUndefined();
+            // the extracted executable should be restricted to the owner
+            expect(giveAccessOnlyToOwnerSpy).toHaveBeenCalled();
+            const restrictedPaths = giveAccessOnlyToOwnerSpy.mock.calls.map((call: any[]) => call[0]);
+            expect(restrictedPaths.some((p: string) => p.includes(nodeJsPath.normalize("/bin/")))).toBe(true);
+
+            IO.existsSync = existsSyncOrig;
+            IO.isDir = isDirOrig;
+            IO.createDirSync = createDirSyncOrig;
+        });
+
+        it("should restrict access to the bin directory when it is created", async () => {
+            const existsSyncOrig = IO.existsSync;
+            // tgz file exists, bin dir does not exist, exe does not exist afterward
+            IO.existsSync = jest.fn()
+                .mockReturnValueOnce(true)      // for tgz file
+                .mockReturnValueOnce(false)     // for bin dir
+                .mockReturnValue(false);        // for exe existence check
+
+            const createDirSyncOrig = IO.createDirSync;
+            IO.createDirSync = jest.fn();
+
+            // spy on our handler's private enableDaemon() function
+            unzipTgzSpy = jest.spyOn(EnableDaemonHandler.prototype as any, "unzipTgz");
+            unzipTgzSpy.mockImplementation((_tgzFile: string, _toDir: string, _fileToExtract: string) => {return;});
+
+            let error;
+            try {
+                await enableHandler.enableDaemon(noAskNoAddPath);
+            } catch (e) {
+                error = e;
+            }
+
+            expect(error).toBeUndefined();
+            expect(IO.createDirSync).toHaveBeenCalledWith(zoweBinDirMock);
+            // the newly created bin directory should be restricted to the owner
+            expect(giveAccessOnlyToOwnerSpy).toHaveBeenCalledWith(zoweBinDirMock);
+
+            IO.existsSync = existsSyncOrig;
             IO.createDirSync = createDirSyncOrig;
         });
     }); // end enableDaemon method

--- a/packages/cli/__tests__/daemon/__unit__/enable/Enable.handler.unit.test.ts
+++ b/packages/cli/__tests__/daemon/__unit__/enable/Enable.handler.unit.test.ts
@@ -11,7 +11,7 @@
 
 jest.mock("child_process"); // using child_process from the __mocks__ directory
 
-import { ImperativeConfig, ImperativeError, IO, ProcessUtils, ISystemInfo, CliUtils } from "@zowe/imperative";
+import { ImperativeConfig, ImperativeError, IO, ProcessUtils, ISystemInfo } from "@zowe/imperative";
 
 import { IDaemonEnableQuestions } from "../../../../src/daemon/doc/IDaemonEnableQuestions";
 import EnableDaemonHandler from "../../../../src/daemon/enable/Enable.handler";

--- a/packages/cli/__tests__/daemon/__unit__/enable/Enable.handler.unit.test.ts
+++ b/packages/cli/__tests__/daemon/__unit__/enable/Enable.handler.unit.test.ts
@@ -460,7 +460,9 @@ describe("Handler for daemon enable", () => {
 
             expect(error).toBeUndefined();
             // the extracted executable should be restricted to the owner
-            const expectedExePath = nodeJsPath.resolve(zoweBinDirMock, "zowe");
+            const platform = ProcessUtils.getBasicSystemInfo().platform;
+            const exeName = platform === "win32" ? "zowe.exe" : "zowe";
+            const expectedExePath = nodeJsPath.resolve(zoweBinDirMock, exeName);
             expect(giveAccessOnlyToOwnerSpy).toHaveBeenCalledWith(expectedExePath);
         });
 

--- a/packages/cli/__tests__/daemon/__unit__/enable/Enable.handler.unit.test.ts
+++ b/packages/cli/__tests__/daemon/__unit__/enable/Enable.handler.unit.test.ts
@@ -11,7 +11,7 @@
 
 jest.mock("child_process"); // using child_process from the __mocks__ directory
 
-import { ImperativeConfig, ImperativeError, IO, ProcessUtils, ISystemInfo } from "@zowe/imperative";
+import { ImperativeConfig, ImperativeError, IO, ProcessUtils, ISystemInfo, CliUtils } from "@zowe/imperative";
 
 import { IDaemonEnableQuestions } from "../../../../src/daemon/doc/IDaemonEnableQuestions";
 import EnableDaemonHandler from "../../../../src/daemon/enable/Enable.handler";
@@ -67,6 +67,9 @@ describe("Handler for daemon enable", () => {
         }
     });
 
+    let existsSyncSpy: any;
+    let isDirSpy: any;
+    let createDirSyncSpy: any;
     let giveAccessOnlyToOwnerSpy: any;
 
     beforeEach(() => {
@@ -75,6 +78,11 @@ describe("Handler for daemon enable", () => {
         unzipTgzSpy?.mockRestore();
         logMessage = "";
 
+        // Default IO mocks for most tests
+        existsSyncSpy = jest.spyOn(IO, "existsSync").mockReturnValue(true);
+        isDirSpy = jest.spyOn(IO, "isDir").mockReturnValue(true);
+        createDirSyncSpy = jest.spyOn(IO, "createDirSync").mockImplementation(() => { return; });
+
         // Prevent real chmod/icacls calls against our fake (non-existent) paths.
         giveAccessOnlyToOwnerSpy = jest.spyOn(IO, "giveAccessOnlyToOwner").mockImplementation(() => {
             return;
@@ -82,7 +90,7 @@ describe("Handler for daemon enable", () => {
     });
 
     afterEach(() => {
-        giveAccessOnlyToOwnerSpy?.mockRestore();
+        jest.restoreAllMocks();
     });
 
     afterAll(() => {
@@ -215,10 +223,7 @@ describe("Handler for daemon enable", () => {
         });
 
         it("should fail when the tgz file does not exist", async () => {
-            const existsSyncOrig = IO.existsSync;
-            IO.existsSync = jest.fn(() => {
-                return false;
-            });
+            existsSyncSpy.mockReturnValue(false);
 
             let error;
             try {
@@ -228,19 +233,10 @@ describe("Handler for daemon enable", () => {
             }
 
             expect(error.mMessage).toBe(`The archive for your OS executable does not exist: ${preBldTgzPath}`);
-            IO.existsSync = existsSyncOrig;
         });
 
         it("should fail when a bin file exists", async () => {
-            const existsSyncOrig = IO.existsSync;
-            IO.existsSync = jest.fn(() => {
-                return true;
-            });
-
-            const isDirOrig = IO.isDir;
-            IO.isDir = jest.fn(() => {
-                return false;
-            });
+            isDirSpy.mockReturnValue(false);
 
             let error;
             try {
@@ -250,20 +246,16 @@ describe("Handler for daemon enable", () => {
             }
 
             expect(error.mMessage).toContain("The existing file '" + zoweBinDirMock + "' must be a directory.");
-            IO.existsSync = existsSyncOrig;
-            IO.isDir = isDirOrig;
         });
 
         it("should fail if a we cannot create a bin directory", async () => {
             // Mock the IO functions to simulate a failure creating a directory
-            const existsSyncOrig = IO.existsSync;
-            IO.existsSync = jest.fn()
+            existsSyncSpy
                 .mockReturnValueOnce(true)      // for tgz file
                 .mockReturnValueOnce(false);    // for bin dir
 
             const awfulThrownErr = "Some awful directory creation error was thrown";
-            const createDirSyncOrig = IO.createDirSync;
-            IO.createDirSync = jest.fn(() => {
+            createDirSyncSpy.mockImplementation(() => {
                 throw awfulThrownErr;
             });
 
@@ -276,25 +268,9 @@ describe("Handler for daemon enable", () => {
 
             expect(error.mMessage).toContain(`Unable to create directory '${cliHomeDirMock}`);
             expect(error.mMessage).toContain(`Reason: ${awfulThrownErr}`);
-            IO.existsSync = existsSyncOrig;
-            IO.createDirSync = createDirSyncOrig;
         });
 
         it("should return a message that it cannot launch the EXE", async () => {
-            // Mock the IO functions to simulate stuff is working
-            const existsSyncOrig = IO.existsSync;
-            IO.existsSync = jest.fn(() => {
-                return true;
-            });
-
-            const isDirOrig = IO.isDir;
-            IO.isDir = jest.fn(() => {
-                return true;
-            });
-
-            const createDirSyncOrig = IO.createDirSync;
-            IO.createDirSync = jest.fn();
-
             // spy on our handler's private enableDaemon() function
             unzipTgzSpy = jest.spyOn(EnableDaemonHandler.prototype as any, "unzipTgz");
             unzipTgzSpy.mockImplementation((_tgzFile: string, _toDir: string, _fileToExtract: string) => {return;});
@@ -312,27 +288,9 @@ describe("Handler for daemon enable", () => {
 
             // we set a bogus cliHome, so we know it cannot launch the executable
             expect(userInfoMsg).toContain("Zowe CLI native executable version = Failed to get version number");
-
-            IO.existsSync = existsSyncOrig;
-            IO.isDir = isDirOrig;
-            IO.createDirSync = createDirSyncOrig;
         });
 
         it("should return a message with the version number of the EXE", async () => {
-            // Mock the IO functions to simulate stuff is working
-            const existsSyncOrig = IO.existsSync;
-            IO.existsSync = jest.fn(() => {
-                return true;
-            });
-
-            const isDirOrig = IO.isDir;
-            IO.isDir = jest.fn(() => {
-                return true;
-            });
-
-            const createDirSyncOrig = IO.createDirSync;
-            IO.createDirSync = jest.fn();
-
             // This uses child_process from the __mocks__ directory
             const exeVerNumMock = "9.9.9";
             require("child_process").setSpawnSyncOutput(exeVerNumMock);
@@ -352,27 +310,9 @@ describe("Handler for daemon enable", () => {
             expect(error).toBeUndefined();
             expect(unzipTgzSpy).toHaveBeenCalledTimes(1);
             expect(userInfoMsg).toContain("Zowe CLI native executable version = " + exeVerNumMock);
-
-            IO.existsSync = existsSyncOrig;
-            IO.isDir = isDirOrig;
-            IO.createDirSync = createDirSyncOrig;
         });
 
         it("should return a message to add our bin to your PATH", async () => {
-            // Mock the IO functions to simulate stuff is working
-            const existsSyncOrig = IO.existsSync;
-            IO.existsSync = jest.fn(() => {
-                return true;
-            });
-
-            const isDirOrig = IO.isDir;
-            IO.isDir = jest.fn(() => {
-                return true;
-            });
-
-            const createDirSyncOrig = IO.createDirSync;
-            IO.createDirSync = jest.fn();
-
             const pathOrig = process.env.PATH;
             process.env.PATH = "ThisPathDoesNotcontainOurBinDir";
 
@@ -393,27 +333,10 @@ describe("Handler for daemon enable", () => {
             expect(userInfoMsg).toContain(`Manually add '${zoweBinDirMock}' to your PATH.`);
             expect(userInfoMsg).toContain("close this terminal and open a new terminal");
 
-            IO.existsSync = existsSyncOrig;
-            IO.isDir = isDirOrig;
-            IO.createDirSync = createDirSyncOrig;
             process.env.PATH = pathOrig;
         });
 
         it("should tell you to open new terminal on Linux even when PATH is set", async () => {
-            // Mock the IO functions to simulate stuff is working
-            const existsSyncOrig = IO.existsSync;
-            IO.existsSync = jest.fn(() => {
-                return true;
-            });
-
-            const isDirOrig = IO.isDir;
-            IO.isDir = jest.fn(() => {
-                return true;
-            });
-
-            const createDirSyncOrig = IO.createDirSync;
-            IO.createDirSync = jest.fn();
-
             const getBasicSystemInfoOrig = ProcessUtils.getBasicSystemInfo;
             ProcessUtils.getBasicSystemInfo = jest.fn(() => {
                 return {
@@ -443,28 +366,11 @@ describe("Handler for daemon enable", () => {
             expect(unzipTgzSpy).toHaveBeenCalledTimes(1);
             expect(userInfoMsg).toContain("close this terminal and open a new terminal");
 
-            IO.existsSync = existsSyncOrig;
-            IO.isDir = isDirOrig;
-            IO.createDirSync = createDirSyncOrig;
             ProcessUtils.getBasicSystemInfo = getBasicSystemInfoOrig;
             process.env.PATH = pathOrig;
         });
 
         it("should NOT tell you to open new terminal on Windows when PATH is set", async () => {
-            // Mock the IO functions to simulate stuff is working
-            const existsSyncOrig = IO.existsSync;
-            IO.existsSync = jest.fn(() => {
-                return true;
-            });
-
-            const isDirOrig = IO.isDir;
-            IO.isDir = jest.fn(() => {
-                return true;
-            });
-
-            const createDirSyncOrig = IO.createDirSync;
-            IO.createDirSync = jest.fn();
-
             const getBasicSystemInfoOrig = ProcessUtils.getBasicSystemInfo;
             ProcessUtils.getBasicSystemInfo = jest.fn(() => {
                 return {
@@ -494,28 +400,11 @@ describe("Handler for daemon enable", () => {
             expect(unzipTgzSpy).toHaveBeenCalledTimes(1);
             expect(userInfoMsg).not.toContain("close this terminal and open a new terminal");
 
-            IO.existsSync = existsSyncOrig;
-            IO.isDir = isDirOrig;
-            IO.createDirSync = createDirSyncOrig;
             ProcessUtils.getBasicSystemInfo = getBasicSystemInfoOrig;
             process.env.PATH = pathOrig;
         });
 
         it("should not mention ZOWE_USE_DAEMON if is unset", async () => {
-            // Mock the IO functions to simulate stuff is working
-            const existsSyncOrig = IO.existsSync;
-            IO.existsSync = jest.fn(() => {
-                return true;
-            });
-
-            const isDirOrig = IO.isDir;
-            IO.isDir = jest.fn(() => {
-                return true;
-            });
-
-            const createDirSyncOrig = IO.createDirSync;
-            IO.createDirSync = jest.fn();
-
             // spy on our handler's private enableDaemon() function
             unzipTgzSpy = jest.spyOn(EnableDaemonHandler.prototype as any, "unzipTgz");
             unzipTgzSpy.mockImplementation((_tgzFile: string, _toDir: string, _fileToExtract: string) => {return;});
@@ -532,27 +421,9 @@ describe("Handler for daemon enable", () => {
             expect(unzipTgzSpy).toHaveBeenCalledTimes(1);
             expect(userInfoMsg).not.toContain("Your ZOWE_USE_DAEMON environment variable is set");
             expect(userInfoMsg).not.toContain("You must remove it, or set it to 'yes' to use daemon mode.");
-
-            IO.existsSync = existsSyncOrig;
-            IO.isDir = isDirOrig;
-            IO.createDirSync = createDirSyncOrig;
         });
 
         it("should instruct that ZOWE_USE_DAEMON should be removed", async () => {
-            // Mock the IO functions to simulate stuff is working
-            const existsSyncOrig = IO.existsSync;
-            IO.existsSync = jest.fn(() => {
-                return true;
-            });
-
-            const isDirOrig = IO.isDir;
-            IO.isDir = jest.fn(() => {
-                return true;
-            });
-
-            const createDirSyncOrig = IO.createDirSync;
-            IO.createDirSync = jest.fn();
-
             // spy on our handler's private enableDaemon() function
             unzipTgzSpy = jest.spyOn(EnableDaemonHandler.prototype as any, "unzipTgz");
             unzipTgzSpy.mockImplementation((_tgzFile: string, _toDir: string, _fileToExtract: string) => {return;});
@@ -573,27 +444,9 @@ describe("Handler for daemon enable", () => {
             expect(unzipTgzSpy).toHaveBeenCalledTimes(1);
             expect(userInfoMsg).toContain(`Your ZOWE_USE_DAEMON environment variable is set to '${noDaemonVal}'.`);
             expect(userInfoMsg).toContain("You must remove it, or set it to 'yes' to use daemon mode.");
-
-            IO.existsSync = existsSyncOrig;
-            IO.isDir = isDirOrig;
-            IO.createDirSync = createDirSyncOrig;
         });
 
         it("should restrict access to the extracted executable to the owner", async () => {
-            // Mock the IO functions to simulate stuff is working
-            const existsSyncOrig = IO.existsSync;
-            IO.existsSync = jest.fn(() => {
-                return true;
-            });
-
-            const isDirOrig = IO.isDir;
-            IO.isDir = jest.fn(() => {
-                return true;
-            });
-
-            const createDirSyncOrig = IO.createDirSync;
-            IO.createDirSync = jest.fn();
-
             // spy on our handler's private enableDaemon() function
             unzipTgzSpy = jest.spyOn(EnableDaemonHandler.prototype as any, "unzipTgz");
             unzipTgzSpy.mockImplementation((_tgzFile: string, _toDir: string, _fileToExtract: string) => {return;});
@@ -607,25 +460,16 @@ describe("Handler for daemon enable", () => {
 
             expect(error).toBeUndefined();
             // the extracted executable should be restricted to the owner
-            expect(giveAccessOnlyToOwnerSpy).toHaveBeenCalled();
-            const restrictedPaths = giveAccessOnlyToOwnerSpy.mock.calls.map((call: any[]) => call[0]);
-            expect(restrictedPaths.some((p: string) => p.includes(nodeJsPath.normalize("/bin/")))).toBe(true);
-
-            IO.existsSync = existsSyncOrig;
-            IO.isDir = isDirOrig;
-            IO.createDirSync = createDirSyncOrig;
+            const expectedExePath = nodeJsPath.resolve(zoweBinDirMock, "zowe");
+            expect(giveAccessOnlyToOwnerSpy).toHaveBeenCalledWith(expectedExePath);
         });
 
         it("should restrict access to the bin directory when it is created", async () => {
-            const existsSyncOrig = IO.existsSync;
             // tgz file exists, bin dir does not exist, exe does not exist afterward
-            IO.existsSync = jest.fn()
+            existsSyncSpy
                 .mockReturnValueOnce(true)      // for tgz file
                 .mockReturnValueOnce(false)     // for bin dir
                 .mockReturnValue(false);        // for exe existence check
-
-            const createDirSyncOrig = IO.createDirSync;
-            IO.createDirSync = jest.fn();
 
             // spy on our handler's private enableDaemon() function
             unzipTgzSpy = jest.spyOn(EnableDaemonHandler.prototype as any, "unzipTgz");
@@ -639,12 +483,94 @@ describe("Handler for daemon enable", () => {
             }
 
             expect(error).toBeUndefined();
-            expect(IO.createDirSync).toHaveBeenCalledWith(zoweBinDirMock);
+            expect(createDirSyncSpy).toHaveBeenCalledWith(zoweBinDirMock);
             // the newly created bin directory should be restricted to the owner
             expect(giveAccessOnlyToOwnerSpy).toHaveBeenCalledWith(zoweBinDirMock);
+        });
 
-            IO.existsSync = existsSyncOrig;
-            IO.createDirSync = createDirSyncOrig;
+        it("should fail when it cannot restrict access to an existing bin directory", async () => {
+            // tgz file exists, bin dir exists
+            existsSyncSpy.mockReturnValue(true);
+            isDirSpy.mockReturnValue(true);
+
+            const awfulThrownErr = "Some awful permission error was thrown";
+            giveAccessOnlyToOwnerSpy.mockImplementation(() => {
+                throw new Error(awfulThrownErr);
+            });
+
+            let error;
+            try {
+                await enableHandler.enableDaemon(noAskNoAddPath);
+            } catch (e) {
+                error = e;
+            }
+
+            expect(error.mMessage).toContain(`Unable to restrict access to directory '${zoweBinDirMock}`);
+            expect(error.mMessage).toContain(`Reason: Error: ${awfulThrownErr}`);
+        });
+
+        it("should fail when it cannot restrict access to a newly created bin directory", async () => {
+            // tgz file exists, bin dir does not exist
+            existsSyncSpy
+                .mockReturnValueOnce(true)      // for tgz file
+                .mockReturnValueOnce(false);    // for bin dir
+
+            const awfulThrownErr = "Some awful permission error was thrown";
+            giveAccessOnlyToOwnerSpy.mockImplementation(() => {
+                throw new Error(awfulThrownErr);
+            });
+
+            let error;
+            try {
+                await enableHandler.enableDaemon(noAskNoAddPath);
+            } catch (e) {
+                error = e;
+            }
+
+            expect(error.mMessage).toContain(`Unable to create directory '${zoweBinDirMock}`);
+            expect(error.mMessage).toContain(`Reason: Error: ${awfulThrownErr}`);
+        });
+
+        it("should fail when it cannot restrict access to the extracted executable", async () => {
+            // spy on our handler's private enableDaemon() function
+            unzipTgzSpy = jest.spyOn(EnableDaemonHandler.prototype as any, "unzipTgz");
+            unzipTgzSpy.mockImplementation((_tgzFile: string, _toDir: string, _fileToExtract: string) => {return;});
+
+            const awfulThrownErr = "Some awful permission error was thrown";
+            giveAccessOnlyToOwnerSpy.mockImplementation((filePath: string) => {
+                if (filePath.endsWith("zowe") || filePath.endsWith("zowe.exe")) {
+                    throw new Error(awfulThrownErr);
+                }
+                return;
+            });
+
+            let error;
+            try {
+                await enableHandler.enableDaemon(noAskNoAddPath);
+            } catch (e) {
+                error = e;
+            }
+
+            expect(error).toBeDefined();
+            expect(error.message).toContain(awfulThrownErr);
         });
     }); // end enableDaemon method
+
+    describe("unzipTgz method", () => {
+        // Simple test to try and get some coverage for the unzipTgz method
+        it("should reject with an error if the tgz file does not exist", async () => {
+            const nonExistentTgz = nodeJsPath.resolve(__dirname, "does-not-exist.tgz");
+            const tempDir = nodeJsPath.resolve(__dirname, "temp-unzip-test2");
+
+            let error;
+            try {
+                await (enableHandler as any).unzipTgz(nonExistentTgz, tempDir, "zowe");
+            } catch (e) {
+                error = e;
+            }
+
+            expect(error).toBeDefined();
+            expect(error instanceof ImperativeError).toBe(true);
+        });
+    }); // end unzipTgz method
 }); // end Handler

--- a/packages/cli/src/daemon/DaemonDecider.ts
+++ b/packages/cli/src/daemon/DaemonDecider.ts
@@ -114,21 +114,7 @@ export class DaemonDecider {
 
             this.mServer.maxConnections = 1;
 
-            // On macOS and some BSDs, `chmod` has no effect on Unix domain sockets
-            // after they are created. The only way to secure the socket file is to
-            // set a restrictive umask before the `listen` (bind) call creates it.
-            let oldUmask: number | undefined;
-            if (process.platform !== "win32") {
-                oldUmask = process.umask(0o077);
-            }
-            // Slight concern that the umask will apply to other files being created
-            // by this process at the exact same milliseconds, but I this is acceptable.
             this.mServer.listen(this.mSocket, () => {
-                // Restore the original umask immediately after the socket is bound
-                if (oldUmask !== undefined) {
-                    process.umask(oldUmask);
-                }
-
                 // On POSIX systems the socket is a file on disk that is created with
                 // umask-derived permissions. Restrict it to the owner so that other
                 // local users cannot connect to our daemon and run commands as us.

--- a/packages/cli/src/daemon/DaemonDecider.ts
+++ b/packages/cli/src/daemon/DaemonDecider.ts
@@ -114,6 +114,17 @@ export class DaemonDecider {
 
             this.mServer.maxConnections = 1;
             this.mServer.listen(this.mSocket, () => {
+                // On POSIX systems the socket is a file on disk that is created with
+                // umask-derived permissions. Restrict it to the owner so that other
+                // local users cannot connect to our daemon and run commands as us.
+                // On Windows the socket is a named pipe (not a file), so this is skipped.
+                if (process.platform !== "win32") {
+                    try {
+                        IO.giveAccessOnlyToOwner(this.mSocket);
+                    } catch (err) {
+                        Imperative.api.appLogger.error(`Unable to restrict access to daemon socket ${this.mSocket}: ${err.message}`);
+                    }
+                }
                 Imperative.api.appLogger.debug(`daemon server bound ${this.mSocket}`);
                 new Console(`info`).info(`server bound ${this.mSocket}`);
             });
@@ -139,9 +150,12 @@ export class DaemonDecider {
         const pidForUserStr = JSON.stringify(pidForUser, null, 2);
 
         try {
-            fs.writeFileSync(pidFilePath, pidForUserStr);
-            const ownerReadWrite = 0o600;
-            fs.chmodSync(pidFilePath, ownerReadWrite);
+            // Create the file with owner-only permissions up front to avoid a brief
+            // window where it exists with default (umask-derived) permissions.
+            fs.writeFileSync(pidFilePath, pidForUserStr, { mode: 0o600 });
+            // Enforce owner-only access cross-platform (icacls on Windows, chmod on POSIX),
+            // and in case the file already existed with looser permissions.
+            IO.giveAccessOnlyToOwner(pidFilePath);
         } catch(err) {
             throw new Error("Failed to write file '" + pidFilePath + "'\nDetails = " + err.message);
         }

--- a/packages/cli/src/daemon/DaemonDecider.ts
+++ b/packages/cli/src/daemon/DaemonDecider.ts
@@ -113,7 +113,21 @@ export class DaemonDecider {
             });
 
             this.mServer.maxConnections = 1;
+
+            // On macOS and some BSDs, `chmod` has no effect on Unix domain sockets
+            // after they are created. The only way to secure the socket file is to
+            // set a restrictive umask before the `listen` (bind) call creates it.
+            let oldUmask: number | undefined;
+            if (process.platform !== "win32") {
+                oldUmask = process.umask(0o077);
+            }
+
             this.mServer.listen(this.mSocket, () => {
+                // Restore the original umask immediately after the socket is bound
+                if (oldUmask !== undefined) {
+                    process.umask(oldUmask);
+                }
+
                 // On POSIX systems the socket is a file on disk that is created with
                 // umask-derived permissions. Restrict it to the owner so that other
                 // local users cannot connect to our daemon and run commands as us.

--- a/packages/cli/src/daemon/DaemonDecider.ts
+++ b/packages/cli/src/daemon/DaemonDecider.ts
@@ -121,7 +121,8 @@ export class DaemonDecider {
             if (process.platform !== "win32") {
                 oldUmask = process.umask(0o077);
             }
-
+            // Slight concern that the umask will apply to other files being created
+            // by this process at the exact same milliseconds, but I this is acceptable.
             this.mServer.listen(this.mSocket, () => {
                 // Restore the original umask immediately after the socket is bound
                 if (oldUmask !== undefined) {

--- a/packages/cli/src/daemon/DaemonUtil.ts
+++ b/packages/cli/src/daemon/DaemonUtil.ts
@@ -34,7 +34,15 @@ export class DaemonUtil {
             // our default location.
             daemonDir = path.join(os.homedir(), ".zowe", "daemon");
         }
-        if (!IO.existsSync(daemonDir)) {
+        if (IO.existsSync(daemonDir)) {
+            // The directory already exists. Re-restrict it to the current user in case
+            // it was previously created with permissions that allow group/other access.
+            try {
+                IO.giveAccessOnlyToOwner(daemonDir);
+            } catch(err) {
+                throw new Error("Failed to restrict access to directory '" + daemonDir + "'\nDetails = " + err.message);
+            }
+        } else {
             try {
                 IO.createDirSync(daemonDir);
                 // Restrict access to the daemon directory to only the current user.
@@ -42,14 +50,6 @@ export class DaemonUtil {
                 IO.giveAccessOnlyToOwner(daemonDir);
             } catch(err) {
                 throw new Error("Failed to create directory '" + daemonDir + "'\nDetails = " + err.message);
-            }
-        } else {
-            // The directory already exists. Re-restrict it to the current user in case
-            // it was previously created with permissions that allow group/other access.
-            try {
-                IO.giveAccessOnlyToOwner(daemonDir);
-            } catch(err) {
-                throw new Error("Failed to restrict access to directory '" + daemonDir + "'\nDetails = " + err.message);
             }
         }
         return daemonDir;

--- a/packages/cli/src/daemon/DaemonUtil.ts
+++ b/packages/cli/src/daemon/DaemonUtil.ts
@@ -9,7 +9,6 @@
 *
 */
 
-import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
 import { IO } from "@zowe/imperative";
@@ -38,8 +37,9 @@ export class DaemonUtil {
         if (!IO.existsSync(daemonDir)) {
             try {
                 IO.createDirSync(daemonDir);
-                const ownerReadWriteTraverse = 0o700;
-                fs.chmodSync(daemonDir, ownerReadWriteTraverse);
+                // Restrict access to the daemon directory to only the current user.
+                // On Windows this sets an owner-only ACL; on POSIX it sets mode 0o700.
+                IO.giveAccessOnlyToOwner(daemonDir);
             } catch(err) {
                 throw new Error("Failed to create directory '" + daemonDir + "'\nDetails = " + err.message);
             }

--- a/packages/cli/src/daemon/DaemonUtil.ts
+++ b/packages/cli/src/daemon/DaemonUtil.ts
@@ -43,6 +43,14 @@ export class DaemonUtil {
             } catch(err) {
                 throw new Error("Failed to create directory '" + daemonDir + "'\nDetails = " + err.message);
             }
+        } else {
+            // The directory already exists. Re-restrict it to the current user in case
+            // it was previously created with permissions that allow group/other access.
+            try {
+                IO.giveAccessOnlyToOwner(daemonDir);
+            } catch(err) {
+                throw new Error("Failed to restrict access to directory '" + daemonDir + "'\nDetails = " + err.message);
+            }
         }
         return daemonDir;
     }

--- a/packages/cli/src/daemon/enable/Enable.handler.ts
+++ b/packages/cli/src/daemon/enable/Enable.handler.ts
@@ -243,7 +243,7 @@ export default class EnableDaemonHandler implements ICommandHandler {
     /**
      * Add our .zowe/bin directory to the user's PATH.
      *
-     * @param pathToZoweBin The absolute path to our .zowe/bin drectory.
+     * @param pathToZoweBin The absolute path to our .zowe/bin directory.
      *
      * @param {IDaemonEnableQuestions} userQuestions Questions for user (if permitted)
      *

--- a/packages/cli/src/daemon/enable/Enable.handler.ts
+++ b/packages/cli/src/daemon/enable/Enable.handler.ts
@@ -120,6 +120,9 @@ export default class EnableDaemonHandler implements ICommandHandler {
             // create the directory
             try {
                 IO.createDirSync(pathToZoweBin);
+                // Restrict the bin directory to the current user only.
+                // On Windows this sets an owner-only ACL; on POSIX it sets mode 0o700.
+                IO.giveAccessOnlyToOwner(pathToZoweBin);
             }
             catch(err) {
                 throw new ImperativeError({
@@ -142,6 +145,13 @@ export default class EnableDaemonHandler implements ICommandHandler {
         // display the version of the executable
         let userInfoMsg: string = "Zowe CLI native executable version = ";
         const zoweExePath = nodeJsPath.resolve(pathToZoweBin, exeFileName);
+
+        // Restrict the extracted executable to the current user only. On Windows this sets
+        // an owner-only ACL; on POSIX it enforces 0o700 regardless of the process umask.
+        if (IO.existsSync(zoweExePath)) {
+            IO.giveAccessOnlyToOwner(zoweExePath);
+        }
+
         const ioOpts: StdioOptions = ["pipe", "pipe", "pipe"];
         try {
             const spawnResult = spawnSync(zoweExePath, ["--version-exe"], {
@@ -207,8 +217,8 @@ export default class EnableDaemonHandler implements ICommandHandler {
                         const sysInfo: ISystemInfo = ProcessUtils.getBasicSystemInfo();
                         let fileCreateOpts: any = {};
                         if (sysInfo.platform == "linux" || sysInfo.platform == "darwin") {
-                            // set file permissions to read, write and execute for user, read and execute for group, in octal
-                            fileCreateOpts = { mode: 0o750 };
+                            // restrict the executable to the owner only (rwx------), in octal
+                            fileCreateOpts = { mode: 0o700 };
                         }
                         // do not include any path structure from the tgz, just the exe name
                         entry.pipe(fs.createWriteStream(nodeJsPath.resolve(toDir, nodeJsPath.basename(entry.path)), fileCreateOpts));

--- a/packages/cli/src/daemon/enable/Enable.handler.ts
+++ b/packages/cli/src/daemon/enable/Enable.handler.ts
@@ -116,6 +116,16 @@ export default class EnableDaemonHandler implements ICommandHandler {
                     msg: `The existing file '${pathToZoweBin}' must be a directory.`
                 });
             }
+            // The directory already exists. Re-restrict it to the current user in case
+            // it was previously created with permissions that allow group/other access.
+            try {
+                IO.giveAccessOnlyToOwner(pathToZoweBin);
+            }
+            catch(err) {
+                throw new ImperativeError({
+                    msg: `Unable to restrict access to directory '${pathToZoweBin}'.\nReason: ${err}`
+                });
+            }
         } else {
             // create the directory
             try {

--- a/packages/cli/src/daemon/enable/Enable.handler.ts
+++ b/packages/cli/src/daemon/enable/Enable.handler.ts
@@ -214,12 +214,12 @@ export default class EnableDaemonHandler implements ICommandHandler {
      * @returns A void promise to synchronize this operation.
      */
     private async unzipTgz(tgzFile: string, toDir: string, fileToExtract: string): Promise<void> {
-        return new Promise<void>((resolve) => {
+        return new Promise<void>((resolve, reject) => {
             fs.createReadStream(tgzFile)
                 .on('error', function(err: any) {
-                    throw new ImperativeError({
+                    reject(new ImperativeError({
                         msg: err
-                    });
+                    }));
                 })
                 .pipe(new tar.Parser())
                 .on('entry', function(entry: any) {

--- a/zowex/src/run.rs
+++ b/zowex/src/run.rs
@@ -104,6 +104,11 @@ pub async fn run_restart_command(njs_zowe_path: &str) -> Result<i32, i32> {
         }
     }
 
+    // Re-restrict the zowe bin directory and executable to the current user, in
+    // case they were previously created with permissions that allow group/other
+    // access. This is best-effort and never prevents the restart.
+    util_restrict_zowe_bin_to_owner();
+
     // Start a new daemon. Note that proc_start_daemon() exits on failure.
     proc_start_daemon(njs_zowe_path);
     eprintln!("A new daemon has started.");

--- a/zowex/src/test.rs
+++ b/zowex/src/test.rs
@@ -146,6 +146,57 @@ fn unit_test_get_zowe_env() {
     env::remove_var("FORCE_COLOR");
 }
 
+#[cfg(target_family = "unix")]
+#[test]
+fn unit_test_util_restrict_path_to_owner() {
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+
+    // create a temp directory with wide-open permissions
+    let mut test_dir = env::temp_dir();
+    test_dir.push(format!("zowe_restrict_test_{}", std::process::id()));
+    let _ = fs::remove_dir_all(&test_dir);
+    fs::create_dir_all(&test_dir).expect("failed to create test dir");
+    fs::set_permissions(&test_dir, fs::Permissions::from_mode(0o777))
+        .expect("failed to loosen test dir perms");
+
+    // create a file inside it with wide-open permissions
+    let mut test_file = test_dir.clone();
+    test_file.push("some_artifact");
+    fs::write(&test_file, b"data").expect("failed to write test file");
+    fs::set_permissions(&test_file, fs::Permissions::from_mode(0o666))
+        .expect("failed to loosen test file perms");
+
+    // restricting the directory should make it owner-only (0o700)
+    assert!(util_restrict_path_to_owner(&test_dir).is_ok());
+    let dir_mode = fs::metadata(&test_dir).unwrap().permissions().mode() & 0o777;
+    assert_eq!(dir_mode, 0o700, "directory should be restricted to 0o700");
+
+    // restricting the file should make it owner-only (0o700)
+    assert!(util_restrict_path_to_owner(&test_file).is_ok());
+    let file_mode = fs::metadata(&test_file).unwrap().permissions().mode() & 0o777;
+    assert_eq!(file_mode, 0o700, "file should be restricted to 0o700");
+
+    // cleanup
+    let _ = fs::remove_dir_all(&test_dir);
+}
+
+#[test]
+fn unit_test_util_restrict_zowe_bin_to_owner() {
+    // The running test executable stands in for the zowe binary that lives in
+    // ~/.zowe/bin. This is best-effort and returns no error, so we simply
+    // confirm that it completes without panicking and that our own executable
+    // (and the directory that contains it) are still accessible afterward.
+    util_restrict_zowe_bin_to_owner();
+
+    let my_exe = env::current_exe().expect("should be able to get current exe path");
+    assert!(my_exe.exists(), "the executable should still exist after restriction");
+    assert!(
+        my_exe.parent().unwrap().exists(),
+        "the bin directory should still exist after restriction"
+    );
+}
+
 #[tokio::test]
 // test daemon restart
 async fn integration_test_restart() {

--- a/zowex/src/util.rs
+++ b/zowex/src/util.rs
@@ -13,7 +13,7 @@
 
 use std::collections::HashMap;
 use std::env;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 extern crate home;
 use home::home_dir;
@@ -113,9 +113,62 @@ pub fn util_get_daemon_dir() -> Result<PathBuf, i32> {
             eprintln!("Reason = {}.", err_val);
             return Err(EXIT_CODE_FILE_IO_ERROR);
         }
+
+        // Restrict the daemon directory to the current user only, since it can
+        // hold sensitive runtime artifacts (pid file, socket, lock file).
+        util_restrict_dir_to_owner(&daemon_dir)?;
     }
 
     Ok(daemon_dir)
+}
+
+/**
+ * Restrict access to a directory so that only the current user can access it.
+ * On POSIX systems this sets the directory mode to 0o700. On Windows it uses
+ * icacls to grant full control to only the current user (best-effort).
+ *
+ * @param dir_path The path to the directory to secure.
+ *
+ * @returns Ok on success, or a failure exit code on a POSIX permission error.
+ */
+#[cfg(target_family = "unix")]
+fn util_restrict_dir_to_owner(dir_path: &Path) -> Result<(), i32> {
+    use std::os::unix::fs::PermissionsExt;
+    if let Err(err_val) =
+        std::fs::set_permissions(dir_path, std::fs::Permissions::from_mode(0o700))
+    {
+        eprintln!(
+            "Unable to restrict access to zowe daemon directory = {}.",
+            dir_path.display()
+        );
+        eprintln!("Reason = {}.", err_val);
+        return Err(EXIT_CODE_FILE_IO_ERROR);
+    }
+    Ok(())
+}
+
+#[cfg(target_family = "windows")]
+fn util_restrict_dir_to_owner(dir_path: &Path) -> Result<(), i32> {
+    use std::process::Command;
+    // Best-effort: remove inherited permissions and grant full control only to the
+    // current user. We only warn on failure so that a missing/locked-down icacls
+    // does not prevent the daemon from functioning.
+    let grant_arg = format!("{}:(OI)(CI)F", util_get_username());
+    if let Err(err_val) = Command::new("icacls")
+        .arg(dir_path)
+        .arg("/inheritancelevel:r")
+        .arg("/grant:r")
+        .arg(grant_arg)
+        .arg("/c")
+        .output()
+    {
+        eprintln!(
+            "Warning: unable to restrict access to zowe daemon directory = {}.",
+            dir_path.display()
+        );
+        eprintln!("Reason = {}.", err_val);
+    }
+    Ok(())
 }
 
 #[cfg(target_family = "unix")]

--- a/zowex/src/util.rs
+++ b/zowex/src/util.rs
@@ -113,33 +113,64 @@ pub fn util_get_daemon_dir() -> Result<PathBuf, i32> {
             eprintln!("Reason = {}.", err_val);
             return Err(EXIT_CODE_FILE_IO_ERROR);
         }
-
-        // Restrict the daemon directory to the current user only, since it can
-        // hold sensitive runtime artifacts (pid file, socket, lock file).
-        util_restrict_dir_to_owner(&daemon_dir)?;
     }
+
+    // Restrict the daemon directory to the current user only, since it can hold
+    // sensitive runtime artifacts (pid file, socket, lock file). We do this for
+    // existing directories too, in case one was previously created with
+    // permissions that allow group/other access.
+    util_restrict_path_to_owner(&daemon_dir)?;
 
     Ok(daemon_dir)
 }
 
 /**
- * Restrict access to a directory so that only the current user can access it.
- * On POSIX systems this sets the directory mode to 0o700. On Windows it uses
- * icacls to grant full control to only the current user (best-effort).
+ * Restrict the ~/.zowe/bin directory and the zowe executable within it so that
+ * only the current user has access. The running executable resides in that bin
+ * directory, so we derive both paths from our own executable path.
  *
- * @param dir_path The path to the directory to secure.
+ * This is best-effort: any failure is reported as a warning and ignored so that
+ * a daemon restart is never prevented by a permission-change error.
+ */
+pub fn util_restrict_zowe_bin_to_owner() {
+    let my_exe_path = match env::current_exe() {
+        Ok(ok_val) => ok_val,
+        Err(err_val) => {
+            eprintln!("Warning: unable to determine the path to the zowe executable.");
+            eprintln!("Reason = {}.", err_val);
+            return;
+        }
+    };
+
+    // restrict the zowe executable itself (owner-only, retains execute on POSIX)
+    let _ = util_restrict_path_to_owner(&my_exe_path);
+
+    // restrict the bin directory that contains the executable
+    if let Some(bin_dir) = my_exe_path.parent() {
+        let _ = util_restrict_path_to_owner(bin_dir);
+    }
+}
+
+/**
+ * Restrict access to a file or directory so that only the current user can
+ * access it. On POSIX systems this sets the mode to 0o700 (rwx for the owner,
+ * which retains execute access required for directories and executables). On
+ * Windows it uses icacls to grant full control to only the current user
+ * (best-effort).
+ *
+ * @param fs_path The path to the file or directory to secure.
  *
  * @returns Ok on success, or a failure exit code on a POSIX permission error.
  */
 #[cfg(target_family = "unix")]
-fn util_restrict_dir_to_owner(dir_path: &Path) -> Result<(), i32> {
+pub(crate) fn util_restrict_path_to_owner(fs_path: &Path) -> Result<(), i32> {
     use std::os::unix::fs::PermissionsExt;
     if let Err(err_val) =
-        std::fs::set_permissions(dir_path, std::fs::Permissions::from_mode(0o700))
+        std::fs::set_permissions(fs_path, std::fs::Permissions::from_mode(0o700))
     {
         eprintln!(
-            "Unable to restrict access to zowe daemon directory = {}.",
-            dir_path.display()
+            "Unable to restrict access to path = {}.",
+            fs_path.display()
         );
         eprintln!("Reason = {}.", err_val);
         return Err(EXIT_CODE_FILE_IO_ERROR);
@@ -148,14 +179,14 @@ fn util_restrict_dir_to_owner(dir_path: &Path) -> Result<(), i32> {
 }
 
 #[cfg(target_family = "windows")]
-fn util_restrict_dir_to_owner(dir_path: &Path) -> Result<(), i32> {
+pub(crate) fn util_restrict_path_to_owner(fs_path: &Path) -> Result<(), i32> {
     use std::process::Command;
     // Best-effort: remove inherited permissions and grant full control only to the
     // current user. We only warn on failure so that a missing/locked-down icacls
     // does not prevent the daemon from functioning.
     let grant_arg = format!("{}:(OI)(CI)F", util_get_username());
     if let Err(err_val) = Command::new("icacls")
-        .arg(dir_path)
+        .arg(fs_path)
         .arg("/inheritancelevel:r")
         .arg("/grant:r")
         .arg(grant_arg)
@@ -163,8 +194,8 @@ fn util_restrict_dir_to_owner(dir_path: &Path) -> Result<(), i32> {
         .output()
     {
         eprintln!(
-            "Warning: unable to restrict access to zowe daemon directory = {}.",
-            dir_path.display()
+            "Warning: unable to restrict access to path = {}.",
+            fs_path.display()
         );
         eprintln!("Reason = {}.", err_val);
     }


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->

- Restricts access to daemon-related files and directories to only the current user on all platforms. 
- The following items were given owner-only permissions (`0o700`/`0o600` on POSIX, owner-only ACL on Windows) to prevent other local users from accessing them.
  - The daemon directory: `~/.zowe/daemon/`
  - The zowe-bin directory: `~/.zowe/bin`
  - The extracted native executable: `~/.zowe/bin/zowe`
  - The daemon PID file: `~/.zowe/daemon/daemon_pid.json`
  - The Unix domain socket: `~/.zowe/daemon/daemon.sock`
- The following items were re-restricted when they already exist, so that artifacts created before this fix with looser permissions are corrected on the next `zowe daemon enable` or `zowe daemon restart`.
  - The daemon directory: `~/.zowe/daemon/`
  - The zowe-bin directory: `~/.zowe/bin`
  - The native executable: `~/.zowe/bin/zowe`

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->

1. Prepare the binary:
    - `cd` to the root of the project
    - `cd zowex`
    - `cargo build -r`
    - `cd target/release`
    - `gtar -cvzf zowe-macos.tgz zowe` (`zowe-linux.tgz` or `zowe-windows.tgz`)
    - `mv zowe-macos.tgz ../../../packages/cli/prebuilds/`
2. Build the project:
    - `cd` to the root of the project
    - `npm run build` (or just `npm run watch` 😋 )
3. Enable the daemon using the built version of the CLI:
    - `cd` to the root of the project
    - `node packages/cli/lib/main.js daemon enable`
4. Run a command using the binary
    - `~/.zowe/bin/zowe --version`
5. Verify file permissions
    - `ls -al ~/.zowe/bin`
    - `ls -al ~/.zowe.daemon`

**Review Checklist**
I certify that I have:
- [x] updated the changelog
- [x] manually tested my changes
- [x] added/updated automated unit/integration tests
- [x] created/ran system tests (provide build number if applicable) `Build: #2291`
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)

**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->

TODO:
- [x] Look into why the socket keeps going back to `0o755` on `os.platform==darwin`
- [x] Add coverage for potential errors coming from `IO.giveAccessOnlyToOwner`
- [x] Review system tests
  - Expected APIML test files/suites to fail if not using APIML
    - `packages/cli/__tests__/config/auto-init/__system__/cli.config.auto-init.system.test.ts`
    - `packages/cli/__tests__/auth/__system__/cli.auth.login.apiml.system.test.ts`
    - `packages/core/__tests__/auth/__system__/Logout.system.test.ts`
    - `packages/core/__tests__/apiml/__system__/Services.system.test.ts`
    - `packages/core/__tests__/auth/__system__/Login.system.test.ts`
  - These also fail on the `master` branch (with and without the daemon)
    - `packages/cli/__tests__/zosmf/__system__/list/systems/zosmf.list.systems.system.test.ts`
    - `packages/cli/__tests__/zosmf/__system__/check/status/zosmf.check.status.system.test.ts`
    - `__tests__/__system__/cli/logging/LoggingCredentials.system.test.ts`
    - `packages/cli/__tests__/zosfiles/__system__/edit/uss/Edit.uss.system.test.ts`
    - `packages/cli/__tests__/zosfiles/__system__/edit/ds/Edit.ds.system.test.ts`
    - `packages/zosfiles/__tests__/__system__/methods/copy/Copy.system.test.ts`
  