### PR TITLE
v2: Port #2743 - Ensure proper permissions on daemon related files

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to the Zowe CLI package will be documented in this file.
 - BugFix: Added extra filesystem checks when downloading data sets and USS files. [#2741](https://github.com/zowe/zowe-cli/pull/2741)
 - BugFix: Added extra filesystem checks when downloading job spool. [#2741](https://github.com/zowe/zowe-cli/pull/2741)
 - **Breaking** BugFix: Updated the `zowe zos-files (ds/uss) edit` command to prompt the user to trust custom editors. [#2742](https://github.com/zowe/zowe-cli/pull/2742)
+- BugFix: Restricted access to daemon-related files and directories to the current user only on all platforms. The daemon directory, `~/.zowe/bin` directory, the extracted native executable, the daemon PID file, and the Unix domain socket are now given owner-only permissions (`0o700`/`0o600` on POSIX, owner-only ACL on Windows) to prevent other local users from accessing them. The daemon directory, the `~/.zowe/bin` directory, and the native executable inside it are also re-restricted when they already exist, so that artifacts created before this fix with looser permissions are corrected on the next `zowe daemon enable` or `zowe daemon restart`. [#2743](https://github.com/zowe/zowe-cli/pull/2743)
+
 
 ## `7.29.25`
 

--- a/packages/cli/__tests__/daemon/__unit__/DaemonDecider.unit.test.ts
+++ b/packages/cli/__tests__/daemon/__unit__/DaemonDecider.unit.test.ts
@@ -18,72 +18,26 @@ jest.mock("@zowe/imperative");
 import * as net from "net";
 import * as os from "os";
 import * as path from "path";
-import Mock = jest.Mock;
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { Imperative, IO } from "@zowe/imperative";  // eslint-disable-line unused-imports/no-unused-imports
 import { DaemonDecider } from "../../../src/daemon/DaemonDecider";
 
 jest.mock("../../../src/daemon/DaemonClient");
 
 describe("DaemonDecider tests", () => {
-    afterEach(() => {
-        delete process.env.ZOWE_DAEMON_DIR;
-        delete process.env.ZOWE_DAEMON_PIPE;
-        jest.resetAllMocks();
-    });
+    let log: jest.Mock;
+    let on: jest.Mock;
+    let listen: jest.Mock;
+    let parse: jest.Mock;
+    let createServerMock: jest.Mock;
 
-    it("should call normal parse method if no daemon keyword", () => {
-
-        const log = jest.fn(() => {
-            // do nothing
-        });
-
-        const on = jest.fn((event, func) => {
-            // do nothing
-        });
-
-        const parse = jest.fn( (data, context) => {
+    beforeEach(() => {
+        log = jest.fn();
+        on = jest.fn();
+        listen = jest.fn();
+        parse = jest.fn((data, context) => {
             expect(data).toBe(undefined);
             expect(context).toBe(undefined);
-        });
-
-        (Imperative as any) = {
-            api: {
-                appLogger: {
-                    trace: log
-                }
-            },
-            parse
-        };
-        const fn = jest.mocked(net.createServer);
-        fn.mockImplementation((unusedclient, ...args: any[]): any => {
-            return {on};
-        });
-
-        const daemonDecider = new DaemonDecider(["--help"]);
-        daemonDecider.init();
-        expect(on).not.toHaveBeenCalled();
-        daemonDecider.runOrUseDaemon();
-        expect(parse).toHaveBeenCalled();
-    });
-
-    it("should start the server when daemon parm is passed", () => {
-
-        const log = jest.fn(() => {
-            // do nothing
-        });
-
-        const on = jest.fn((event, func) => {
-            // do nothing
-        });
-
-        const listen = jest.fn((socket, method) => {
-            // do nothing
-            method();
-        });
-
-        const parse = jest.fn( (data, context) => {
-            expect(data).toMatchSnapshot();
-            expect(context).toMatchSnapshot();
         });
 
         (Imperative as any) = {
@@ -99,10 +53,40 @@ describe("DaemonDecider tests", () => {
             },
             parse
         };
-        const fn = jest.mocked(net.createServer);
-        fn.mockImplementation((method: any, ...args: any[]): any => {
+
+        createServerMock = jest.mocked(net.createServer);
+        createServerMock.mockImplementation(() => {
+            return { on, listen };
+        });
+    });
+
+    afterEach(() => {
+        delete process.env.ZOWE_DAEMON_DIR;
+        delete process.env.ZOWE_DAEMON_PIPE;
+        jest.resetAllMocks();
+    });
+
+    it("should call normal parse method if no daemon keyword", () => {
+        const daemonDecider = new DaemonDecider(["--help"]);
+        daemonDecider.init();
+        expect(on).not.toHaveBeenCalled();
+        daemonDecider.runOrUseDaemon();
+        expect(parse).toHaveBeenCalled();
+    });
+
+    it("should start the server when daemon parm is passed", () => {
+        listen.mockImplementation((socket, method) => {
+            method();
+        });
+
+        parse.mockImplementation((data, context) => {
+            expect(data).toMatchSnapshot();
+            expect(context).toMatchSnapshot();
+        });
+
+        createServerMock.mockImplementation((method: any) => {
             method("fakeClient", "fakeServer");
-            return {on, listen};
+            return { on, listen };
         });
 
         const daemonDecider = new DaemonDecider(["some/file/path", "zowe", "--daemon"]);
@@ -122,24 +106,11 @@ describe("DaemonDecider tests", () => {
     });
 
     it("should set comm channel based on env variable", () => {
-
-        const log = jest.fn(() => {
-            // do nothing
-        });
-
-        (Imperative as any) = {
-            api: {
-                appLogger: {
-                    debug: log
-                }
-            }
-        };
-
         const daemonDecider = new DaemonDecider(["anything"]);
 
         const envWinPipeName = "MyWinPipeName";
         const envDaemonDir = path.normalize("./testOutput/daemonDir");
-        let expectedCommChannel: string = "NotAssignedYet";
+        let expectedCommChannel: string;
 
         if (process.platform === "win32") {
             process.env.ZOWE_DAEMON_PIPE = envWinPipeName;
@@ -155,42 +126,6 @@ describe("DaemonDecider tests", () => {
     });
 
     it("should not start a daemon", () => {
-        const log = jest.fn(() => {
-            // do nothing
-        });
-
-        const on = jest.fn((event, func) => {
-            // do nothing
-        });
-
-        const listen = jest.fn((event, func) => {
-            // do nothing
-        });
-
-        const parse = jest.fn( (data, context) => {
-            expect(data).toBe(undefined);
-            expect(context).toBe(undefined);
-        });
-
-        (Imperative as any) = {
-            api: {
-                appLogger: {
-                    trace: log,
-                    debug: log,
-                    error: log
-                }
-            },
-            console: {
-                info: log
-            },
-            parse
-        };
-
-        const fn = jest.mocked(net.createServer);
-        fn.mockImplementation((unusedclient, ...args: any[]): any => {
-            return {on, listen};
-        });
-
         const daemonDecider = new DaemonDecider(["node", "zowe", "--help"]);
         daemonDecider.init();
 
@@ -199,48 +134,12 @@ describe("DaemonDecider tests", () => {
     });
 
     it("should use the default comm channel location", () => {
-        const log = jest.fn(() => {
-            // do nothing
-        });
-
-        const on = jest.fn((event, func) => {
-            // do nothing
-        });
-
-        const listen = jest.fn((event, func) => {
-            // do nothing
-        });
-
-        const parse = jest.fn( (data, context) => {
-            expect(data).toBe(undefined);
-            expect(context).toBe(undefined);
-        });
-
-        (Imperative as any) = {
-            api: {
-                appLogger: {
-                    trace: log,
-                    debug: log,
-                    error: log
-                }
-            },
-            console: {
-                info: log
-            },
-            parse
-        };
-
-        const fn = jest.mocked(net.createServer);
-        fn.mockImplementation((unusedclient, ...args: any[]): any => {
-            return {on, listen};
-        });
-
         const daemonDecider = new DaemonDecider(["node", "zowe", "--daemon"]);
         daemonDecider.init();
 
-        let expectedCommChannel: string = "NotAssignedYet";
+        let expectedCommChannel: string;
         if (process.platform === "win32") {
-            expectedCommChannel = `\\\\.\\pipe\\${os.userInfo().username}\\ZoweDaemon`;
+            expectedCommChannel = `\\\\.\\pipe\\${os.userInfo().username.toLocaleLowerCase()}\\ZoweDaemon`;
         } else {
             expectedCommChannel = path.join(os.homedir(), ".zowe/daemon/daemon.sock");
         }
@@ -249,42 +148,6 @@ describe("DaemonDecider tests", () => {
     });
 
     it("should try to delete an existing socket on Posix", () => {
-        const log = jest.fn(() => {
-            // do nothing
-        });
-
-        const on = jest.fn((event, func) => {
-            // do nothing
-        });
-
-        const listen = jest.fn((event, func) => {
-            // do nothing
-        });
-
-        const parse = jest.fn( (data, context) => {
-            expect(data).toBe(undefined);
-            expect(context).toBe(undefined);
-        });
-
-        (Imperative as any) = {
-            api: {
-                appLogger: {
-                    trace: log,
-                    debug: log,
-                    error: log
-                }
-            },
-            console: {
-                info: log
-            },
-            parse
-        };
-
-        const fn = jest.mocked(net.createServer);
-        fn.mockImplementation((unusedclient, ...args: any[]): any => {
-            return {on, listen};
-        });
-
         process.env.ZOWE_DAEMON_DIR = path.normalize("./testOutput/daemonDir");
         const daemonDecider = new DaemonDecider(["node", "zowe", "--daemon"]);
 
@@ -321,7 +184,6 @@ describe("DaemonDecider tests", () => {
 
         let existTimes;
         if (process.platform === "win32") {
-            existsSyncSpy.mockImplementationOnce;
             existTimes = 2;
         } else {
             existTimes = 3;
@@ -333,43 +195,44 @@ describe("DaemonDecider tests", () => {
         writeFileSyncSpy.mockClear();
     });
 
+    it("should restrict access to the pid file and socket to the owner on Posix", () => {
+        // invoke the listen callback so the socket-restriction logic runs
+        listen.mockImplementation((_socket, method) => {
+            method();
+        });
+
+        parse.mockImplementation(() => {});
+
+        createServerMock.mockImplementation((method: any) => {
+            method("fakeClient", "fakeServer");
+            return { on, listen };
+        });
+
+        const daemonDir = path.normalize("./testOutput/daemonDir");
+        process.env.ZOWE_DAEMON_DIR = daemonDir;
+
+        // fool our function into thinking we are on a Posix system
+        const realPlatform = process.platform;
+        Object.defineProperty(process, "platform", { value: "linux" });
+
+        const giveAccessSpy = jest.spyOn(IO, "giveAccessOnlyToOwner").mockImplementation(() => {
+            return;
+        });
+        jest.spyOn(IO, "existsSync").mockReturnValue(false);
+
+        const daemonDecider = new DaemonDecider(["node", "zowe", "--daemon"]);
+        daemonDecider.init();
+        daemonDecider.runOrUseDaemon();
+
+        // restore our real platform
+        Object.defineProperty(process, "platform", { value: realPlatform });
+
+        const restrictedPaths = giveAccessSpy.mock.calls.map((call) => call[0]);
+        expect(restrictedPaths).toContain(path.join(daemonDir, "daemon_pid.json"));
+        expect(restrictedPaths).toContain(path.join(daemonDir, "daemon.sock"));
+    });
+
     it("should throw an error when it cannot write the process ID file", () => {
-        const log = jest.fn(() => {
-            // do nothing
-        });
-
-        const on = jest.fn((event, func) => {
-            // do nothing
-        });
-
-        const listen = jest.fn((event, func) => {
-            // do nothing
-        });
-
-        const parse = jest.fn( (data, context) => {
-            expect(data).toBe(undefined);
-            expect(context).toBe(undefined);
-        });
-
-        (Imperative as any) = {
-            api: {
-                appLogger: {
-                    trace: log,
-                    debug: log,
-                    error: log
-                }
-            },
-            console: {
-                info: log
-            },
-            parse
-        };
-
-        const fn = jest.mocked(net.createServer);
-        fn.mockImplementation((unusedclient, ...args: any[]): any => {
-            return {on, listen};
-        });
-
         process.env.ZOWE_DAEMON_DIR = path.normalize("./testOutput/daemonDir");
         const daemonDecider = new DaemonDecider(["node", "zowe", "--daemon"]);
 
@@ -396,42 +259,90 @@ describe("DaemonDecider tests", () => {
         writeFileSyncSpy.mockClear();
     });
 
+    it("should throw an error when it cannot restrict access to the process ID file", () => {
+        process.env.ZOWE_DAEMON_DIR = path.normalize("./testOutput/daemonDir");
+        const daemonDecider = new DaemonDecider(["node", "zowe", "--daemon"]);
+
+        const writeFileSyncSpy = jest.spyOn(fs, "writeFileSync").mockImplementation(() => { return; });
+        writeFileSyncSpy.mockClear();
+
+        const badStuffMsg = "Some bad stuff happened";
+        const giveAccessSpy = jest.spyOn(IO, "giveAccessOnlyToOwner");
+        giveAccessSpy.mockImplementation((filePath: string) => {
+            if (filePath.endsWith("daemon_pid.json")) {
+                throw new Error(badStuffMsg);
+            }
+        });
+
+        let error: Error;
+        try {
+            daemonDecider.init();
+        } catch (e) {
+            error = e;
+        }
+
+        expect(writeFileSyncSpy).toHaveBeenCalledTimes(1);
+        expect(giveAccessSpy).toHaveBeenCalled();
+        expect(error).toBeDefined();
+        expect(error.message).toContain("Failed to write file");
+        expect(error.message).toContain("daemon_pid.json");
+        expect(error.message).toContain(badStuffMsg);
+        writeFileSyncSpy.mockRestore();
+        giveAccessSpy.mockRestore();
+    });
+
+    it("should log an error when it cannot restrict access to the socket on Posix", () => {
+        let errorLogMsg = "";
+        const errorLog = jest.fn((msg) => {
+            errorLogMsg += msg;
+        });
+        (Imperative as any).api.appLogger.error = errorLog;
+
+        // invoke the listen callback so the socket-restriction logic runs
+        listen.mockImplementation((_socket, method) => {
+            method();
+        });
+
+        parse.mockImplementation(() => {});
+
+        createServerMock.mockImplementation((method: any) => {
+            method("fakeClient", "fakeServer");
+            return { on, listen };
+        });
+
+        const daemonDir = path.normalize("./testOutput/daemonDir");
+        process.env.ZOWE_DAEMON_DIR = daemonDir;
+
+        // fool our function into thinking we are on a Posix system
+        const realPlatform = process.platform;
+        Object.defineProperty(process, "platform", { value: "linux" });
+
+        const badStuffMsg = "Some bad stuff happened";
+        const giveAccessSpy = jest.spyOn(IO, "giveAccessOnlyToOwner").mockImplementation((filePath) => {
+            if (filePath.endsWith("daemon.sock")) {
+                throw new Error(badStuffMsg);
+            }
+            return;
+        });
+        jest.spyOn(IO, "existsSync").mockReturnValue(false);
+
+        const daemonDecider = new DaemonDecider(["node", "zowe", "--daemon"]);
+        daemonDecider.init();
+        daemonDecider.runOrUseDaemon();
+
+        // restore our real platform
+        Object.defineProperty(process, "platform", { value: realPlatform });
+
+        expect(errorLog).toHaveBeenCalled();
+        expect(errorLogMsg).toContain("Unable to restrict access to daemon socket");
+        expect(errorLogMsg).toContain(badStuffMsg);
+        giveAccessSpy.mockRestore();
+    });
+
     it("should form the path to a pipe on windows", () => {
-        let recordedLogMsg: string;
-        const log = jest.fn((logMsg) => {
-            recordedLogMsg += logMsg;
-        });
-
-        const on = jest.fn((event, func) => {
-            // do nothing
-        });
-
-        const listen = jest.fn((event, func) => {
-            // do nothing
-        });
-
-        const parse = jest.fn( (data, context) => {
-            expect(data).toBe(undefined);
-            expect(context).toBe(undefined);
-        });
-
-        (Imperative as any) = {
-            api: {
-                appLogger: {
-                    trace: log,
-                    debug: log,
-                    error: log
-                }
-            },
-            console: {
-                info: log
-            },
-            parse
-        };
-
-        const fn = jest.mocked(net.createServer);
-        fn.mockImplementation((unusedclient, ...args: any[]): any => {
-            return {on, listen};
+        let recordedLogMsg = "";
+        log.mockImplementation((logMsg) => {
+            if (logMsg) recordedLogMsg += logMsg;
         });
 
         process.env.ZOWE_DAEMON_DIR = path.normalize("./testOutput/daemonDir");
@@ -448,7 +359,7 @@ describe("DaemonDecider tests", () => {
         daemonDecider.init();
 
         expect(initialParseSpy).toHaveBeenCalledTimes(1);
-        expect(recordedLogMsg).toContain(`daemon server will listen on \\\\.\\pipe\\${os.userInfo().username}\\ZoweDaemon`);
+        expect(recordedLogMsg).toContain(`daemon server will listen on \\\\.\\pipe\\${os.userInfo().username.toLocaleLowerCase()}\\ZoweDaemon`);
 
         // use a custom pipe name
         const envWinPipeName = "MyWinPipeName";

--- a/packages/cli/__tests__/daemon/__unit__/DaemonDecider.unit.test.ts
+++ b/packages/cli/__tests__/daemon/__unit__/DaemonDecider.unit.test.ts
@@ -201,7 +201,9 @@ describe("DaemonDecider tests", () => {
             method();
         });
 
-        parse.mockImplementation(() => {});
+        parse.mockImplementation(() => {
+            // do nothing
+        });
 
         createServerMock.mockImplementation((method: any) => {
             method("fakeClient", "fakeServer");
@@ -303,7 +305,9 @@ describe("DaemonDecider tests", () => {
             method();
         });
 
-        parse.mockImplementation(() => {});
+        parse.mockImplementation(() => {
+            // do nothing
+        });
 
         createServerMock.mockImplementation((method: any) => {
             method("fakeClient", "fakeServer");

--- a/packages/cli/__tests__/daemon/__unit__/DaemonUtil.unit.test.ts
+++ b/packages/cli/__tests__/daemon/__unit__/DaemonUtil.unit.test.ts
@@ -1,0 +1,119 @@
+/*
+* This program and the accompanying materials are made available under the terms of the
+* Eclipse Public License v2.0 which accompanies this distribution, and is available at
+* https://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Copyright Contributors to the Zowe Project.
+*
+*/
+
+import * as os from "os";
+import * as path from "path";
+import { IO } from "@zowe/imperative";
+import { DaemonUtil } from "../../../src/daemon/DaemonUtil";
+
+describe("DaemonUtil tests", () => {
+    let existsSyncSpy: jest.SpyInstance;
+    let createDirSyncSpy: jest.SpyInstance;
+    let giveAccessOnlyToOwnerSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+        existsSyncSpy = jest.spyOn(IO, "existsSync");
+        createDirSyncSpy = jest.spyOn(IO, "createDirSync").mockImplementation(() => {
+            return;
+        });
+        giveAccessOnlyToOwnerSpy = jest.spyOn(IO, "giveAccessOnlyToOwner").mockImplementation(() => {
+            return;
+        });
+    });
+
+    afterEach(() => {
+        delete process.env.ZOWE_DAEMON_DIR;
+        jest.restoreAllMocks();
+    });
+
+    it("should use the ZOWE_DAEMON_DIR environment variable when set", () => {
+        const customDir = path.normalize("./testOutput/customDaemonDir");
+        process.env.ZOWE_DAEMON_DIR = customDir;
+        existsSyncSpy.mockReturnValue(true);
+
+        expect(DaemonUtil.getDaemonDir()).toBe(customDir);
+    });
+
+    it("should default to ~/.zowe/daemon when no environment variable is set", () => {
+        existsSyncSpy.mockReturnValue(true);
+
+        expect(DaemonUtil.getDaemonDir()).toBe(path.join(os.homedir(), ".zowe", "daemon"));
+    });
+
+    it("should create the daemon directory and restrict access to the owner when it does not exist", () => {
+        const customDir = path.normalize("./testOutput/newDaemonDir");
+        process.env.ZOWE_DAEMON_DIR = customDir;
+        existsSyncSpy.mockReturnValue(false);
+
+        const daemonDir = DaemonUtil.getDaemonDir();
+
+        expect(daemonDir).toBe(customDir);
+        expect(createDirSyncSpy).toHaveBeenCalledWith(customDir);
+        expect(giveAccessOnlyToOwnerSpy).toHaveBeenCalledWith(customDir);
+    });
+
+    it("should re-restrict but not re-create the daemon directory when it already exists", () => {
+        const customDir = path.normalize("./testOutput/existingDaemonDir");
+        process.env.ZOWE_DAEMON_DIR = customDir;
+        existsSyncSpy.mockReturnValue(true);
+
+        DaemonUtil.getDaemonDir();
+
+        expect(createDirSyncSpy).not.toHaveBeenCalled();
+        expect(giveAccessOnlyToOwnerSpy).toHaveBeenCalledWith(customDir);
+    });
+
+    it("should throw an error when the daemon directory cannot be created or secured", () => {
+        const customDir = path.normalize("./testOutput/failDaemonDir");
+        process.env.ZOWE_DAEMON_DIR = customDir;
+        existsSyncSpy.mockReturnValue(false);
+
+        const badStuffMsg = "Some awful permission error";
+        giveAccessOnlyToOwnerSpy.mockImplementation(() => {
+            throw new Error(badStuffMsg);
+        });
+
+        let error: Error;
+        try {
+            DaemonUtil.getDaemonDir();
+        } catch (e) {
+            error = e;
+        }
+
+        expect(error).toBeDefined();
+        expect(error.message).toContain("Failed to create directory");
+        expect(error.message).toContain(customDir);
+        expect(error.message).toContain(badStuffMsg);
+    });
+
+    it("should throw an error when the daemon directory cannot be secured when it already exists", () => {
+        const customDir = path.normalize("./testOutput/existingDaemonDir");
+        process.env.ZOWE_DAEMON_DIR = customDir;
+        existsSyncSpy.mockReturnValue(true);
+
+        const badStuffMsg = "Some awful permission error";
+        giveAccessOnlyToOwnerSpy.mockImplementation(() => {
+            throw new Error(badStuffMsg);
+        });
+
+        let error: Error;
+        try {
+            DaemonUtil.getDaemonDir();
+        } catch (e) {
+            error = e;
+        }
+
+        expect(error).toBeDefined();
+        expect(error.message).toContain("Failed to restrict access to directory");
+        expect(error.message).toContain(customDir);
+        expect(error.message).toContain(badStuffMsg);
+    });
+});

--- a/packages/cli/__tests__/daemon/__unit__/enable/Enable.handler.unit.test.ts
+++ b/packages/cli/__tests__/daemon/__unit__/enable/Enable.handler.unit.test.ts
@@ -26,6 +26,7 @@ describe("Handler for daemon enable", () => {
     let preBldDir: string;
     let preBldTgzPath: string;
     let logMessage = "";
+    let createdPreBldDir = false; // Track if we created the directory
 
     beforeAll(() => {
         // instantiate our handler
@@ -59,17 +60,37 @@ describe("Handler for daemon enable", () => {
         preBldTgzPath = nodeJsPath.resolve(preBldDir, tgzFileName);
         if (!IO.existsSync(preBldDir)) {
             IO.createDirSync(preBldDir);
+            createdPreBldDir = true; // Mark that we created it
         }
         if (!IO.existsSync(preBldTgzPath)) {
             fs.copyFileSync(tgzResourcePath, preBldTgzPath);
         }
     });
 
+    let existsSyncSpy: any;
+    let isDirSpy: any;
+    let createDirSyncSpy: any;
+    let giveAccessOnlyToOwnerSpy: any;
+
     beforeEach(() => {
         // remove enableDaemon spy & mock between tests
         enableDaemonSpy?.mockRestore();
         unzipTgzSpy?.mockRestore();
         logMessage = "";
+
+        // Default IO mocks for most tests
+        existsSyncSpy = jest.spyOn(IO, "existsSync").mockReturnValue(true);
+        isDirSpy = jest.spyOn(IO, "isDir").mockReturnValue(true);
+        createDirSyncSpy = jest.spyOn(IO, "createDirSync").mockImplementation(() => { return; });
+
+        // Prevent real chmod/icacls calls against our fake (non-existent) paths.
+        giveAccessOnlyToOwnerSpy = jest.spyOn(IO, "giveAccessOnlyToOwner").mockImplementation(() => {
+            return;
+        });
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
     });
 
     afterAll(() => {
@@ -77,15 +98,18 @@ describe("Handler for daemon enable", () => {
         if (IO.existsSync(preBldTgzPath)) {
             IO.deleteFile(preBldTgzPath);
         }
-        if (IO.existsSync(preBldDir)) {
-            IO.deleteDir(preBldDir);
+        // Only delete the directory if we created it (and it's empty)
+        if (createdPreBldDir && IO.existsSync(preBldDir)) {
+            try {
+                IO.deleteDir(preBldDir);
+            } catch (err) {
+                // Ignore errors if directory is not empty (e.g., contains Rust binaries)
+            }
         }
     });
 
     describe("process method", () => {
         // command parms passed to process() by multiple tests
-        let apiMessage = "";
-        let jsonObj;
         const cmdParms = {
             arguments: {
                 $0: "fake",
@@ -93,11 +117,11 @@ describe("Handler for daemon enable", () => {
             },
             response: {
                 data: {
-                    setMessage: jest.fn((setMsgArgs) => {
-                        apiMessage = setMsgArgs;
+                    setMessage: jest.fn((_setMsgArgs) => {
+                        return;
                     }),
-                    setObj: jest.fn((setObjArgs) => {
-                        jsonObj = setObjArgs;
+                    setObj: jest.fn((_setObjArgs) => {
+                        return;
                     }),
                     setExitCode: jest.fn((exitCode) => {
                         return exitCode;
@@ -199,10 +223,7 @@ describe("Handler for daemon enable", () => {
         });
 
         it("should fail when the tgz file does not exist", async () => {
-            const existsSyncOrig = IO.existsSync;
-            IO.existsSync = jest.fn(() => {
-                return false;
-            });
+            existsSyncSpy.mockReturnValue(false);
 
             let error;
             try {
@@ -212,19 +233,10 @@ describe("Handler for daemon enable", () => {
             }
 
             expect(error.mMessage).toBe(`The archive for your OS executable does not exist: ${preBldTgzPath}`);
-            IO.existsSync = existsSyncOrig;
         });
 
         it("should fail when a bin file exists", async () => {
-            const existsSyncOrig = IO.existsSync;
-            IO.existsSync = jest.fn(() => {
-                return true;
-            });
-
-            const isDirOrig = IO.isDir;
-            IO.isDir = jest.fn(() => {
-                return false;
-            });
+            isDirSpy.mockReturnValue(false);
 
             let error;
             try {
@@ -234,20 +246,16 @@ describe("Handler for daemon enable", () => {
             }
 
             expect(error.mMessage).toContain("The existing file '" + zoweBinDirMock + "' must be a directory.");
-            IO.existsSync = existsSyncOrig;
-            IO.isDir = isDirOrig;
         });
 
         it("should fail if a we cannot create a bin directory", async () => {
             // Mock the IO functions to simulate a failure creating a directory
-            const existsSyncOrig = IO.existsSync;
-            IO.existsSync = jest.fn()
+            existsSyncSpy
                 .mockReturnValueOnce(true)      // for tgz file
                 .mockReturnValueOnce(false);    // for bin dir
 
             const awfulThrownErr = "Some awful directory creation error was thrown";
-            const createDirSyncOrig = IO.createDirSync;
-            IO.createDirSync = jest.fn(() => {
+            createDirSyncSpy.mockImplementation(() => {
                 throw awfulThrownErr;
             });
 
@@ -260,28 +268,12 @@ describe("Handler for daemon enable", () => {
 
             expect(error.mMessage).toContain(`Unable to create directory '${cliHomeDirMock}`);
             expect(error.mMessage).toContain(`Reason: ${awfulThrownErr}`);
-            IO.existsSync = existsSyncOrig;
-            IO.createDirSync = createDirSyncOrig;
         });
 
         it("should return a message that it cannot launch the EXE", async () => {
-            // Mock the IO functions to simulate stuff is working
-            const existsSyncOrig = IO.existsSync;
-            IO.existsSync = jest.fn(() => {
-                return true;
-            });
-
-            const isDirOrig = IO.isDir;
-            IO.isDir = jest.fn(() => {
-                return true;
-            });
-
-            const createDirSyncOrig = IO.createDirSync;
-            IO.createDirSync = jest.fn();
-
             // spy on our handler's private enableDaemon() function
             unzipTgzSpy = jest.spyOn(EnableDaemonHandler.prototype as any, "unzipTgz");
-            unzipTgzSpy.mockImplementation((tgzFile: string, toDir: string, fileToExtract: string) => {return;});
+            unzipTgzSpy.mockImplementation((_tgzFile: string, _toDir: string, _fileToExtract: string) => {return;});
 
             let error;
             let userInfoMsg: string;
@@ -296,34 +288,16 @@ describe("Handler for daemon enable", () => {
 
             // we set a bogus cliHome, so we know it cannot launch the executable
             expect(userInfoMsg).toContain("Zowe CLI native executable version = Failed to get version number");
-
-            IO.existsSync = existsSyncOrig;
-            IO.isDir = isDirOrig;
-            IO.createDirSync = createDirSyncOrig;
         });
 
         it("should return a message with the version number of the EXE", async () => {
-            // Mock the IO functions to simulate stuff is working
-            const existsSyncOrig = IO.existsSync;
-            IO.existsSync = jest.fn(() => {
-                return true;
-            });
-
-            const isDirOrig = IO.isDir;
-            IO.isDir = jest.fn(() => {
-                return true;
-            });
-
-            const createDirSyncOrig = IO.createDirSync;
-            IO.createDirSync = jest.fn();
-
             // This uses child_process from the __mocks__ directory
             const exeVerNumMock = "9.9.9";
             require("child_process").setSpawnSyncOutput(exeVerNumMock);
 
             // spy on our handler's private enableDaemon() function
             unzipTgzSpy = jest.spyOn(EnableDaemonHandler.prototype as any, "unzipTgz");
-            unzipTgzSpy.mockImplementation((tgzFile: string, toDir: string, fileToExtract: string) => {return;});
+            unzipTgzSpy.mockImplementation((_tgzFile: string, _toDir: string, _fileToExtract: string) => {return;});
 
             let error;
             let userInfoMsg: string;
@@ -336,33 +310,15 @@ describe("Handler for daemon enable", () => {
             expect(error).toBeUndefined();
             expect(unzipTgzSpy).toHaveBeenCalledTimes(1);
             expect(userInfoMsg).toContain("Zowe CLI native executable version = " + exeVerNumMock);
-
-            IO.existsSync = existsSyncOrig;
-            IO.isDir = isDirOrig;
-            IO.createDirSync = createDirSyncOrig;
         });
 
         it("should return a message to add our bin to your PATH", async () => {
-            // Mock the IO functions to simulate stuff is working
-            const existsSyncOrig = IO.existsSync;
-            IO.existsSync = jest.fn(() => {
-                return true;
-            });
-
-            const isDirOrig = IO.isDir;
-            IO.isDir = jest.fn(() => {
-                return true;
-            });
-
-            const createDirSyncOrig = IO.createDirSync;
-            IO.createDirSync = jest.fn();
-
             const pathOrig = process.env.PATH;
             process.env.PATH = "ThisPathDoesNotcontainOurBinDir";
 
             // spy on our handler's private enableDaemon() function
             unzipTgzSpy = jest.spyOn(EnableDaemonHandler.prototype as any, "unzipTgz");
-            unzipTgzSpy.mockImplementation((tgzFile: string, toDir: string, fileToExtract: string) => {return;});
+            unzipTgzSpy.mockImplementation((_tgzFile: string, _toDir: string, _fileToExtract: string) => {return;});
 
             let error;
             let userInfoMsg: string;
@@ -377,27 +333,10 @@ describe("Handler for daemon enable", () => {
             expect(userInfoMsg).toContain(`Manually add '${zoweBinDirMock}' to your PATH.`);
             expect(userInfoMsg).toContain("close this terminal and open a new terminal");
 
-            IO.existsSync = existsSyncOrig;
-            IO.isDir = isDirOrig;
-            IO.createDirSync = createDirSyncOrig;
             process.env.PATH = pathOrig;
         });
 
         it("should tell you to open new terminal on Linux even when PATH is set", async () => {
-            // Mock the IO functions to simulate stuff is working
-            const existsSyncOrig = IO.existsSync;
-            IO.existsSync = jest.fn(() => {
-                return true;
-            });
-
-            const isDirOrig = IO.isDir;
-            IO.isDir = jest.fn(() => {
-                return true;
-            });
-
-            const createDirSyncOrig = IO.createDirSync;
-            IO.createDirSync = jest.fn();
-
             const getBasicSystemInfoOrig = ProcessUtils.getBasicSystemInfo;
             ProcessUtils.getBasicSystemInfo = jest.fn(() => {
                 return {
@@ -413,7 +352,7 @@ describe("Handler for daemon enable", () => {
 
             // spy on our handler's private enableDaemon() function
             unzipTgzSpy = jest.spyOn(EnableDaemonHandler.prototype as any, "unzipTgz");
-            unzipTgzSpy.mockImplementation((tgzFile: string, toDir: string, fileToExtract: string) => {return;});
+            unzipTgzSpy.mockImplementation((_tgzFile: string, _toDir: string, _fileToExtract: string) => {return;});
 
             let error;
             let userInfoMsg: string;
@@ -427,28 +366,11 @@ describe("Handler for daemon enable", () => {
             expect(unzipTgzSpy).toHaveBeenCalledTimes(1);
             expect(userInfoMsg).toContain("close this terminal and open a new terminal");
 
-            IO.existsSync = existsSyncOrig;
-            IO.isDir = isDirOrig;
-            IO.createDirSync = createDirSyncOrig;
             ProcessUtils.getBasicSystemInfo = getBasicSystemInfoOrig;
             process.env.PATH = pathOrig;
         });
 
         it("should NOT tell you to open new terminal on Windows when PATH is set", async () => {
-            // Mock the IO functions to simulate stuff is working
-            const existsSyncOrig = IO.existsSync;
-            IO.existsSync = jest.fn(() => {
-                return true;
-            });
-
-            const isDirOrig = IO.isDir;
-            IO.isDir = jest.fn(() => {
-                return true;
-            });
-
-            const createDirSyncOrig = IO.createDirSync;
-            IO.createDirSync = jest.fn();
-
             const getBasicSystemInfoOrig = ProcessUtils.getBasicSystemInfo;
             ProcessUtils.getBasicSystemInfo = jest.fn(() => {
                 return {
@@ -464,7 +386,7 @@ describe("Handler for daemon enable", () => {
 
             // spy on our handler's private enableDaemon() function
             unzipTgzSpy = jest.spyOn(EnableDaemonHandler.prototype as any, "unzipTgz");
-            unzipTgzSpy.mockImplementation((tgzFile: string, toDir: string, fileToExtract: string) => {return;});
+            unzipTgzSpy.mockImplementation((_tgzFile: string, _toDir: string, _fileToExtract: string) => {return;});
 
             let error;
             let userInfoMsg: string;
@@ -478,31 +400,14 @@ describe("Handler for daemon enable", () => {
             expect(unzipTgzSpy).toHaveBeenCalledTimes(1);
             expect(userInfoMsg).not.toContain("close this terminal and open a new terminal");
 
-            IO.existsSync = existsSyncOrig;
-            IO.isDir = isDirOrig;
-            IO.createDirSync = createDirSyncOrig;
             ProcessUtils.getBasicSystemInfo = getBasicSystemInfoOrig;
             process.env.PATH = pathOrig;
         });
 
         it("should not mention ZOWE_USE_DAEMON if is unset", async () => {
-            // Mock the IO functions to simulate stuff is working
-            const existsSyncOrig = IO.existsSync;
-            IO.existsSync = jest.fn(() => {
-                return true;
-            });
-
-            const isDirOrig = IO.isDir;
-            IO.isDir = jest.fn(() => {
-                return true;
-            });
-
-            const createDirSyncOrig = IO.createDirSync;
-            IO.createDirSync = jest.fn();
-
             // spy on our handler's private enableDaemon() function
             unzipTgzSpy = jest.spyOn(EnableDaemonHandler.prototype as any, "unzipTgz");
-            unzipTgzSpy.mockImplementation((tgzFile: string, toDir: string, fileToExtract: string) => {return;});
+            unzipTgzSpy.mockImplementation((_tgzFile: string, _toDir: string, _fileToExtract: string) => {return;});
 
             let error;
             let userInfoMsg: string;
@@ -516,30 +421,12 @@ describe("Handler for daemon enable", () => {
             expect(unzipTgzSpy).toHaveBeenCalledTimes(1);
             expect(userInfoMsg).not.toContain("Your ZOWE_USE_DAEMON environment variable is set");
             expect(userInfoMsg).not.toContain("You must remove it, or set it to 'yes' to use daemon mode.");
-
-            IO.existsSync = existsSyncOrig;
-            IO.isDir = isDirOrig;
-            IO.createDirSync = createDirSyncOrig;
         });
 
         it("should instruct that ZOWE_USE_DAEMON should be removed", async () => {
-            // Mock the IO functions to simulate stuff is working
-            const existsSyncOrig = IO.existsSync;
-            IO.existsSync = jest.fn(() => {
-                return true;
-            });
-
-            const isDirOrig = IO.isDir;
-            IO.isDir = jest.fn(() => {
-                return true;
-            });
-
-            const createDirSyncOrig = IO.createDirSync;
-            IO.createDirSync = jest.fn();
-
             // spy on our handler's private enableDaemon() function
             unzipTgzSpy = jest.spyOn(EnableDaemonHandler.prototype as any, "unzipTgz");
-            unzipTgzSpy.mockImplementation((tgzFile: string, toDir: string, fileToExtract: string) => {return;});
+            unzipTgzSpy.mockImplementation((_tgzFile: string, _toDir: string, _fileToExtract: string) => {return;});
 
             // force the message to reset ZOWE_USE_DAEMON variable
             const noDaemonVal = "no";
@@ -557,10 +444,135 @@ describe("Handler for daemon enable", () => {
             expect(unzipTgzSpy).toHaveBeenCalledTimes(1);
             expect(userInfoMsg).toContain(`Your ZOWE_USE_DAEMON environment variable is set to '${noDaemonVal}'.`);
             expect(userInfoMsg).toContain("You must remove it, or set it to 'yes' to use daemon mode.");
+        });
 
-            IO.existsSync = existsSyncOrig;
-            IO.isDir = isDirOrig;
-            IO.createDirSync = createDirSyncOrig;
+        it("should restrict access to the extracted executable to the owner", async () => {
+            // spy on our handler's private enableDaemon() function
+            unzipTgzSpy = jest.spyOn(EnableDaemonHandler.prototype as any, "unzipTgz");
+            unzipTgzSpy.mockImplementation((_tgzFile: string, _toDir: string, _fileToExtract: string) => {return;});
+
+            let error;
+            try {
+                await enableHandler.enableDaemon(noAskNoAddPath);
+            } catch (e) {
+                error = e;
+            }
+
+            expect(error).toBeUndefined();
+            // the extracted executable should be restricted to the owner
+            const platform = ProcessUtils.getBasicSystemInfo().platform;
+            const exeName = platform === "win32" ? "zowe.exe" : "zowe";
+            const expectedExePath = nodeJsPath.resolve(zoweBinDirMock, exeName);
+            expect(giveAccessOnlyToOwnerSpy).toHaveBeenCalledWith(expectedExePath);
+        });
+
+        it("should restrict access to the bin directory when it is created", async () => {
+            // tgz file exists, bin dir does not exist, exe does not exist afterward
+            existsSyncSpy
+                .mockReturnValueOnce(true)      // for tgz file
+                .mockReturnValueOnce(false)     // for bin dir
+                .mockReturnValue(false);        // for exe existence check
+
+            // spy on our handler's private enableDaemon() function
+            unzipTgzSpy = jest.spyOn(EnableDaemonHandler.prototype as any, "unzipTgz");
+            unzipTgzSpy.mockImplementation((_tgzFile: string, _toDir: string, _fileToExtract: string) => {return;});
+
+            let error;
+            try {
+                await enableHandler.enableDaemon(noAskNoAddPath);
+            } catch (e) {
+                error = e;
+            }
+
+            expect(error).toBeUndefined();
+            expect(createDirSyncSpy).toHaveBeenCalledWith(zoweBinDirMock);
+            // the newly created bin directory should be restricted to the owner
+            expect(giveAccessOnlyToOwnerSpy).toHaveBeenCalledWith(zoweBinDirMock);
+        });
+
+        it("should fail when it cannot restrict access to an existing bin directory", async () => {
+            // tgz file exists, bin dir exists
+            existsSyncSpy.mockReturnValue(true);
+            isDirSpy.mockReturnValue(true);
+
+            const awfulThrownErr = "Some awful permission error was thrown";
+            giveAccessOnlyToOwnerSpy.mockImplementation(() => {
+                throw new Error(awfulThrownErr);
+            });
+
+            let error;
+            try {
+                await enableHandler.enableDaemon(noAskNoAddPath);
+            } catch (e) {
+                error = e;
+            }
+
+            expect(error.mMessage).toContain(`Unable to restrict access to directory '${zoweBinDirMock}`);
+            expect(error.mMessage).toContain(`Reason: Error: ${awfulThrownErr}`);
+        });
+
+        it("should fail when it cannot restrict access to a newly created bin directory", async () => {
+            // tgz file exists, bin dir does not exist
+            existsSyncSpy
+                .mockReturnValueOnce(true)      // for tgz file
+                .mockReturnValueOnce(false);    // for bin dir
+
+            const awfulThrownErr = "Some awful permission error was thrown";
+            giveAccessOnlyToOwnerSpy.mockImplementation(() => {
+                throw new Error(awfulThrownErr);
+            });
+
+            let error;
+            try {
+                await enableHandler.enableDaemon(noAskNoAddPath);
+            } catch (e) {
+                error = e;
+            }
+
+            expect(error.mMessage).toContain(`Unable to create directory '${zoweBinDirMock}`);
+            expect(error.mMessage).toContain(`Reason: Error: ${awfulThrownErr}`);
+        });
+
+        it("should fail when it cannot restrict access to the extracted executable", async () => {
+            // spy on our handler's private enableDaemon() function
+            unzipTgzSpy = jest.spyOn(EnableDaemonHandler.prototype as any, "unzipTgz");
+            unzipTgzSpy.mockImplementation((_tgzFile: string, _toDir: string, _fileToExtract: string) => {return;});
+
+            const awfulThrownErr = "Some awful permission error was thrown";
+            giveAccessOnlyToOwnerSpy.mockImplementation((filePath: string) => {
+                if (filePath.endsWith("zowe") || filePath.endsWith("zowe.exe")) {
+                    throw new Error(awfulThrownErr);
+                }
+                return;
+            });
+
+            let error;
+            try {
+                await enableHandler.enableDaemon(noAskNoAddPath);
+            } catch (e) {
+                error = e;
+            }
+
+            expect(error).toBeDefined();
+            expect(error.message).toContain(awfulThrownErr);
         });
     }); // end enableDaemon method
+
+    describe("unzipTgz method", () => {
+        // Simple test to try and get some coverage for the unzipTgz method
+        it("should reject with an error if the tgz file does not exist", async () => {
+            const nonExistentTgz = nodeJsPath.resolve(__dirname, "does-not-exist.tgz");
+            const tempDir = nodeJsPath.resolve(__dirname, "temp-unzip-test2");
+
+            let error;
+            try {
+                await (enableHandler as any).unzipTgz(nonExistentTgz, tempDir, "zowe");
+            } catch (e) {
+                error = e;
+            }
+
+            expect(error).toBeDefined();
+            expect(error instanceof ImperativeError).toBe(true);
+        });
+    }); // end unzipTgz method
 }); // end Handler

--- a/packages/cli/src/daemon/DaemonDecider.ts
+++ b/packages/cli/src/daemon/DaemonDecider.ts
@@ -114,9 +114,7 @@ export class DaemonDecider {
 
             this.mServer.maxConnections = 1;
             this.mServer.listen(this.mSocket, () => {
-                // On POSIX systems the socket is a file on disk that is created with
-                // umask-derived permissions. Restrict it to the owner so that other
-                // local users cannot connect to our daemon and run commands as us.
+                // On POSIX systems the socket is a file on disk that is created with umask-derived permissions.
                 // On Windows the socket is a named pipe (not a file), so this is skipped.
                 if (process.platform !== "win32") {
                     try {
@@ -153,8 +151,6 @@ export class DaemonDecider {
             // Create the file with owner-only permissions up front to avoid a brief
             // window where it exists with default (umask-derived) permissions.
             fs.writeFileSync(pidFilePath, pidForUserStr, { mode: 0o600 });
-            // Enforce owner-only access cross-platform (icacls on Windows, chmod on POSIX),
-            // and in case the file already existed with looser permissions.
             IO.giveAccessOnlyToOwner(pidFilePath);
         } catch(err) {
             throw new Error("Failed to write file '" + pidFilePath + "'\nDetails = " + err.message);

--- a/packages/cli/src/daemon/DaemonDecider.ts
+++ b/packages/cli/src/daemon/DaemonDecider.ts
@@ -114,6 +114,17 @@ export class DaemonDecider {
 
             this.mServer.maxConnections = 1;
             this.mServer.listen(this.mSocket, () => {
+                // On POSIX systems the socket is a file on disk that is created with
+                // umask-derived permissions. Restrict it to the owner so that other
+                // local users cannot connect to our daemon and run commands as us.
+                // On Windows the socket is a named pipe (not a file), so this is skipped.
+                if (process.platform !== "win32") {
+                    try {
+                        IO.giveAccessOnlyToOwner(this.mSocket);
+                    } catch (err) {
+                        Imperative.api.appLogger.error(`Unable to restrict access to daemon socket ${this.mSocket}: ${err.message}`);
+                    }
+                }
                 Imperative.api.appLogger.debug(`daemon server bound ${this.mSocket}`);
                 new Console(`info`).info(`server bound ${this.mSocket}`);
             });
@@ -139,9 +150,12 @@ export class DaemonDecider {
         const pidForUserStr = JSON.stringify(pidForUser, null, 2);
 
         try {
-            fs.writeFileSync(pidFilePath, pidForUserStr);
-            const ownerReadWrite = 0o600;
-            fs.chmodSync(pidFilePath, ownerReadWrite);
+            // Create the file with owner-only permissions up front to avoid a brief
+            // window where it exists with default (umask-derived) permissions.
+            fs.writeFileSync(pidFilePath, pidForUserStr, { mode: 0o600 });
+            // Enforce owner-only access cross-platform (icacls on Windows, chmod on POSIX),
+            // and in case the file already existed with looser permissions.
+            IO.giveAccessOnlyToOwner(pidFilePath);
         } catch(err) {
             throw new Error("Failed to write file '" + pidFilePath + "'\nDetails = " + err.message);
         }

--- a/packages/cli/src/daemon/DaemonUtil.ts
+++ b/packages/cli/src/daemon/DaemonUtil.ts
@@ -9,7 +9,6 @@
 *
 */
 
-import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
 import { IO } from "@zowe/imperative";
@@ -35,11 +34,20 @@ export class DaemonUtil {
             // our default location.
             daemonDir = path.join(os.homedir(), ".zowe", "daemon");
         }
-        if (!IO.existsSync(daemonDir)) {
+        if (IO.existsSync(daemonDir)) {
+            // The directory already exists. Re-restrict it to the current user in case
+            // it was previously created with permissions that allow group/other access.
             try {
-                IO.mkdirp(daemonDir);
-                const ownerReadWriteTraverse = 0o700;
-                fs.chmodSync(daemonDir, ownerReadWriteTraverse);
+                IO.giveAccessOnlyToOwner(daemonDir);
+            } catch(err) {
+                throw new Error("Failed to restrict access to directory '" + daemonDir + "'\nDetails = " + err.message);
+            }
+        } else {
+            try {
+                IO.createDirSync(daemonDir);
+                // Restrict access to the daemon directory to only the current user.
+                // On Windows this sets an owner-only ACL; on POSIX it sets mode 0o700.
+                IO.giveAccessOnlyToOwner(daemonDir);
             } catch(err) {
                 throw new Error("Failed to create directory '" + daemonDir + "'\nDetails = " + err.message);
             }

--- a/packages/cli/src/daemon/enable/Enable.handler.ts
+++ b/packages/cli/src/daemon/enable/Enable.handler.ts
@@ -116,10 +116,23 @@ export default class EnableDaemonHandler implements ICommandHandler {
                     msg: `The existing file '${pathToZoweBin}' must be a directory.`
                 });
             }
+            // The directory already exists. Re-restrict it to the current user in case
+            // it was previously created with permissions that allow group/other access.
+            try {
+                IO.giveAccessOnlyToOwner(pathToZoweBin);
+            }
+            catch(err) {
+                throw new ImperativeError({
+                    msg: `Unable to restrict access to directory '${pathToZoweBin}'.\nReason: ${err}`
+                });
+            }
         } else {
             // create the directory
             try {
                 IO.createDirSync(pathToZoweBin);
+                // Restrict the bin directory to the current user only.
+                // On Windows this sets an owner-only ACL; on POSIX it sets mode 0o700.
+                IO.giveAccessOnlyToOwner(pathToZoweBin);
             }
             catch(err) {
                 throw new ImperativeError({
@@ -142,6 +155,12 @@ export default class EnableDaemonHandler implements ICommandHandler {
         // display the version of the executable
         let userInfoMsg: string = "Zowe CLI native executable version = ";
         const zoweExePath = nodeJsPath.resolve(pathToZoweBin, exeFileName);
+
+        // Restrict the extracted executable to the current user only. On Windows this sets
+        // an owner-only ACL; on POSIX it enforces 0o700 regardless of the process umask.
+        if (IO.existsSync(zoweExePath)) {
+            IO.giveAccessOnlyToOwner(zoweExePath);
+        }
         const ioOpts: StdioOptions = ["pipe", "pipe", "pipe"];
         try {
             const spawnResult = spawnSync(zoweExePath, ["--version-exe"], {
@@ -194,12 +213,12 @@ export default class EnableDaemonHandler implements ICommandHandler {
      * @returns A void promise to synchronize this operation.
      */
     private async unzipTgz(tgzFile: string, toDir: string, fileToExtract: string): Promise<void> {
-        return new Promise<void>((resolve) => {
+        return new Promise<void>((resolve, reject) => {
             fs.createReadStream(tgzFile)
                 .on('error', function(err: any) {
-                    throw new ImperativeError({
+                    reject(new ImperativeError({
                         msg: err
-                    });
+                    }));
                 })
                 .pipe(new tar.Parser())
                 .on('entry', function(entry: any) {
@@ -207,8 +226,8 @@ export default class EnableDaemonHandler implements ICommandHandler {
                         const sysInfo: ISystemInfo = ProcessUtils.getBasicSystemInfo();
                         let fileCreateOpts: any = {};
                         if (sysInfo.platform == "linux" || sysInfo.platform == "darwin") {
-                            // set file permissions to read, write and execute for user, read and execute for group, in octal
-                            fileCreateOpts = { mode: 0o750 };
+                            // restrict the executable to the owner only (rwx------), in octal
+                            fileCreateOpts = { mode: 0o700 };
                         }
                         // do not include any path structure from the tgz, just the exe name
                         entry.pipe(fs.createWriteStream(nodeJsPath.resolve(toDir, nodeJsPath.basename(entry.path)), fileCreateOpts));

--- a/packages/cli/src/daemon/enable/Enable.handler.ts
+++ b/packages/cli/src/daemon/enable/Enable.handler.ts
@@ -130,8 +130,6 @@ export default class EnableDaemonHandler implements ICommandHandler {
             // create the directory
             try {
                 IO.createDirSync(pathToZoweBin);
-                // Restrict the bin directory to the current user only.
-                // On Windows this sets an owner-only ACL; on POSIX it sets mode 0o700.
                 IO.giveAccessOnlyToOwner(pathToZoweBin);
             }
             catch(err) {

--- a/zowex/src/run.rs
+++ b/zowex/src/run.rs
@@ -104,6 +104,11 @@ pub async fn run_restart_command(njs_zowe_path: &str) -> Result<i32, i32> {
         }
     }
 
+    // Re-restrict the zowe bin directory and executable to the current user, in
+    // case they were previously created with permissions that allow group/other
+    // access. This is best-effort and never prevents the restart.
+    util_restrict_zowe_bin_to_owner();
+
     // Start a new daemon. Note that proc_start_daemon() exits on failure.
     proc_start_daemon(njs_zowe_path);
     eprintln!("A new daemon has started.");

--- a/zowex/src/test.rs
+++ b/zowex/src/test.rs
@@ -146,6 +146,57 @@ fn unit_test_get_zowe_env() {
     env::remove_var("FORCE_COLOR");
 }
 
+#[cfg(target_family = "unix")]
+#[test]
+fn unit_test_util_restrict_path_to_owner() {
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+
+    // create a temp directory with wide-open permissions
+    let mut test_dir = env::temp_dir();
+    test_dir.push(format!("zowe_restrict_test_{}", std::process::id()));
+    let _ = fs::remove_dir_all(&test_dir);
+    fs::create_dir_all(&test_dir).expect("failed to create test dir");
+    fs::set_permissions(&test_dir, fs::Permissions::from_mode(0o777))
+        .expect("failed to loosen test dir perms");
+
+    // create a file inside it with wide-open permissions
+    let mut test_file = test_dir.clone();
+    test_file.push("some_artifact");
+    fs::write(&test_file, b"data").expect("failed to write test file");
+    fs::set_permissions(&test_file, fs::Permissions::from_mode(0o666))
+        .expect("failed to loosen test file perms");
+
+    // restricting the directory should make it owner-only (0o700)
+    assert!(util_restrict_path_to_owner(&test_dir).is_ok());
+    let dir_mode = fs::metadata(&test_dir).unwrap().permissions().mode() & 0o777;
+    assert_eq!(dir_mode, 0o700, "directory should be restricted to 0o700");
+
+    // restricting the file should make it owner-only (0o700)
+    assert!(util_restrict_path_to_owner(&test_file).is_ok());
+    let file_mode = fs::metadata(&test_file).unwrap().permissions().mode() & 0o777;
+    assert_eq!(file_mode, 0o700, "file should be restricted to 0o700");
+
+    // cleanup
+    let _ = fs::remove_dir_all(&test_dir);
+}
+
+#[test]
+fn unit_test_util_restrict_zowe_bin_to_owner() {
+    // The running test executable stands in for the zowe binary that lives in
+    // ~/.zowe/bin. This is best-effort and returns no error, so we simply
+    // confirm that it completes without panicking and that our own executable
+    // (and the directory that contains it) are still accessible afterward.
+    util_restrict_zowe_bin_to_owner();
+
+    let my_exe = env::current_exe().expect("should be able to get current exe path");
+    assert!(my_exe.exists(), "the executable should still exist after restriction");
+    assert!(
+        my_exe.parent().unwrap().exists(),
+        "the bin directory should still exist after restriction"
+    );
+}
+
 #[tokio::test]
 // test daemon restart
 async fn integration_test_restart() {

--- a/zowex/src/util.rs
+++ b/zowex/src/util.rs
@@ -13,7 +13,7 @@
 
 use std::collections::HashMap;
 use std::env;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 extern crate home;
 use home::home_dir;
@@ -115,6 +115,12 @@ pub fn util_get_daemon_dir() -> Result<PathBuf, i32> {
         }
     }
 
+    // Restrict the daemon directory to the current user only, since it can hold
+    // sensitive runtime artifacts (pid file, socket, lock file). We do this for
+    // existing directories too, in case one was previously created with
+    // permissions that allow group/other access.
+    util_restrict_path_to_owner(&daemon_dir)?;
+
     Ok(daemon_dir)
 }
 
@@ -180,4 +186,82 @@ pub fn util_terminal_supports_color() -> i32 {
     }
 
     0
+}
+
+/**
+ * Restrict the ~/.zowe/bin directory and the zowe executable within it so that
+ * only the current user has access. The running executable resides in that bin
+ * directory, so we derive both paths from our own executable path.
+ *
+ * This is best-effort: any failure is reported as a warning and ignored so that
+ * a daemon restart is never prevented by a permission-change error.
+ */
+pub fn util_restrict_zowe_bin_to_owner() {
+    let my_exe_path = match env::current_exe() {
+        Ok(ok_val) => ok_val,
+        Err(err_val) => {
+            eprintln!("Warning: unable to determine the path to the zowe executable.");
+            eprintln!("Reason = {}.", err_val);
+            return;
+        }
+    };
+
+    // restrict the zowe executable itself (owner-only, retains execute on POSIX)
+    let _ = util_restrict_path_to_owner(&my_exe_path);
+
+    // restrict the bin directory that contains the executable
+    if let Some(bin_dir) = my_exe_path.parent() {
+        let _ = util_restrict_path_to_owner(bin_dir);
+    }
+}
+
+/**
+ * Restrict access to a file or directory so that only the current user can
+ * access it. On POSIX systems this sets the mode to 0o700 (rwx for the owner,
+ * which retains execute access required for directories and executables). On
+ * Windows it uses icacls to grant full control to only the current user
+ * (best-effort).
+ *
+ * @param fs_path The path to the file or directory to secure.
+ *
+ * @returns Ok on success, or a failure exit code on a POSIX permission error.
+ */
+#[cfg(target_family = "unix")]
+pub(crate) fn util_restrict_path_to_owner(fs_path: &Path) -> Result<(), i32> {
+    use std::os::unix::fs::PermissionsExt;
+    if let Err(err_val) =
+        std::fs::set_permissions(fs_path, std::fs::Permissions::from_mode(0o700))
+    {
+        eprintln!(
+            "Unable to restrict access to path = {}.",
+            fs_path.display()
+        );
+        eprintln!("Reason = {}.", err_val);
+        return Err(EXIT_CODE_FILE_IO_ERROR);
+    }
+    Ok(())
+}
+
+#[cfg(target_family = "windows")]
+pub(crate) fn util_restrict_path_to_owner(fs_path: &Path) -> Result<(), i32> {
+    use std::process::Command;
+    // Best-effort: remove inherited permissions and grant full control only to the
+    // current user. We only warn on failure so that a missing/locked-down icacls
+    // does not prevent the daemon from functioning.
+    let grant_arg = format!("{}:(OI)(CI)F", util_get_username());
+    if let Err(err_val) = Command::new("icacls")
+        .arg(fs_path)
+        .arg("/inheritancelevel:r")
+        .arg("/grant:r")
+        .arg(grant_arg)
+        .arg("/c")
+        .output()
+    {
+        eprintln!(
+            "Warning: unable to restrict access to path = {}.",
+            fs_path.display()
+        );
+        eprintln!("Reason = {}.", err_val);
+    }
+    Ok(())
 }


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->
- Restricts access to daemon-related files and directories to only the current user on all platforms.

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->
See testing steps in #2743 

**Review Checklist**
I certify that I have:
- [x] updated the changelog
- [x] manually tested my changes
- [x] added/updated automated unit/integration tests
- [x] created/ran system tests (provide build number if applicable) (`#2334`)
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
