### PR TITLE
fix: sanitization for schema path

### DIFF
--- a/packages/imperative/CHANGELOG.md
+++ b/packages/imperative/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Imperative package will be documented in this file.
 
+## Recent Changes
+
+- BugFix: Added path sanitization checks to prevent writing the configuration schema to an invalid file path. [#2763](https://github.com/zowe/zowe-cli/pull/2763)
+
 ## `8.32.3`
 
 - BugFix: Updated `js-yaml` and `markdown-it` dependencies for technical currency. [#2752](https://github.com/zowe/zowe-cli/pull/2752)

--- a/packages/imperative/__tests__/__integration__/imperative/__tests__/__integration__/cli/config/update-schemas/cli.imperative-test-cli.config.update-schemas.integration.test.ts
+++ b/packages/imperative/__tests__/__integration__/imperative/__tests__/__integration__/cli/config/update-schemas/cli.imperative-test-cli.config.update-schemas.integration.test.ts
@@ -133,4 +133,23 @@ describe("imperative-test-cli config update-schemas", () => {
         expect(response.stdout.toString()).toContain(globalPath);
         expect(response.stdout.toString()).toContain(`skipped: ${httpSchema}`);
     });
+
+    it("should not write a schema outside the config directory when $schema escapes the layer", () => {
+        runCliScript(__dirname + "/../init/__scripts__/init_config.sh", TEST_ENVIRONMENT.workingDir, ["--prompt false"]);
+
+        const projectPath = path.join(TEST_ENVIRONMENT.workingDir, "test", "imperative-test-cli.config.json");
+        const maliciousSchema = "../imperative-test-cli.evil.schema.json";
+        const maliciousTarget = path.join(TEST_ENVIRONMENT.workingDir, "imperative-test-cli.evil.schema.json");
+        fs.writeFileSync(projectPath,
+            JSON.stringify({ ...JSON.parse(fs.readFileSync(projectPath).toString()), ...{ $schema: maliciousSchema } }));
+
+        const response = runCliScript(__dirname + "/__scripts__/update-schemas.sh", TEST_ENVIRONMENT.workingDir, [""]);
+
+        expect(response.error).toBeFalsy();
+        expect(response.stderr.toString()).toEqual("");
+        expect(response.stdout.toString()).toContain("Configuration files found: 1");
+        expect(response.stdout.toString()).toContain(`skipped: ${maliciousSchema}`);
+        // The fix must prevent the schema from being written outside the config directory
+        expect(fs.existsSync(maliciousTarget)).toBe(false);
+    });
 });

--- a/packages/imperative/src/config/__tests__/Config.unit.test.ts
+++ b/packages/imperative/src/config/__tests__/Config.unit.test.ts
@@ -552,6 +552,26 @@ describe("Config tests", () => {
             expect(jsonText.match(/^{\s*"\$schema":/)).not.toBeNull();
         });
 
+        it("should not save schema to disk if $schema escapes the config directory via traversal", async () => {
+            const writeFileSpy = jest.spyOn(fs, "writeFileSync").mockImplementation(() => undefined);
+            const config = await Config.load(MY_APP);
+            const layer = (config as any).layerActive();
+            layer.properties.$schema = "./../../../../../../../../evil.schema.json";
+            config.setSchema({ title: "malicious" });
+            expect(writeFileSpy).not.toHaveBeenCalled();
+            writeFileSpy.mockRestore();
+        });
+
+        it("should not save schema to disk if $schema is an absolute path outside the config directory", async () => {
+            const writeFileSpy = jest.spyOn(fs, "writeFileSync").mockImplementation(() => undefined);
+            const config = await Config.load(MY_APP);
+            const layer = (config as any).layerActive();
+            layer.properties.$schema = path.resolve(path.sep, "evil.schema.json");
+            config.setSchema({ title: "malicious" });
+            expect(writeFileSpy).not.toHaveBeenCalled();
+            writeFileSpy.mockRestore();
+        });
+
         it("should add a new layer when one is specified in the set", async () => {
             const config = await Config.load(MY_APP);
             config.set("profiles.fruit.profiles.mango.properties.color", "orange");

--- a/packages/imperative/src/config/__tests__/ConfigSchema.unit.test.ts
+++ b/packages/imperative/src/config/__tests__/ConfigSchema.unit.test.ts
@@ -432,7 +432,8 @@ describe("Config Schema", () => {
             it("should update the schema for the project config when no user config is found", () => {
                 spyConfigLayersExists.mockReturnValueOnce(true).mockReturnValue(false);
                 spyConfigLayerActive.mockReturnValue(fakeLayer);
-                spyConfigGetSchemaInfo.mockReturnValue({ original: fakeSchema, local: true });
+                spyConfigGetSchemaInfo.mockReturnValue(
+                    { original: fakeSchema, local: true, resolved: path.join(path.dirname(fakeProjPath), "fake.schema.json") });
 
                 const expectedUpdatedPaths = {
                     [fakeLayer.path]: { schema: fakeSchema, updated: true },
@@ -447,13 +448,27 @@ describe("Config Schema", () => {
 
             });
 
+            it("should report the schema as skipped when its resolved path escapes the layer directory", () => {
+                spyConfigLayersExists.mockReturnValueOnce(true).mockReturnValue(false);
+                spyConfigLayerActive.mockReturnValue(fakeLayer);
+                // A local $schema whose resolved path is outside the directory of the config file
+                spyConfigGetSchemaInfo.mockReturnValue(
+                    { original: "../fake.schema.json", local: true, resolved: path.resolve(path.dirname(fakeProjPath), "../fake.schema.json") });
+
+                const expectedUpdatedPaths = {
+                    [fakeLayer.path]: { schema: "../fake.schema.json", updated: false },
+                };
+                expect(anyConfigSchema._updateSchemaActive(helperOptions)).toEqual(expectedUpdatedPaths);
+            });
+
             it("should update the schema for both, project and user config", () => {
                 spyConfigLayersExists.mockReturnValue(true);
                 spyConfigLayerActive
                     .mockReturnValueOnce({ ...fakeLayer, ...{ path: fakeUserPath } })
                     .mockReturnValueOnce({ ...fakeLayer, ...{ path: fakeProjPath } });
                 spyConfigGetSchemaInfo
-                    .mockReturnValueOnce({ original: fakeSchema, local: true })
+                    .mockReturnValueOnce(
+                        { original: fakeSchema, local: true, resolved: path.join(path.dirname(fakeUserPath), "fake.schema.json") })
                     .mockReturnValueOnce({ original: fakeSchema, local: false });
 
                 const expectedUpdatedPaths = {

--- a/packages/imperative/src/config/__tests__/ProfileInfo.TeamConfig.unit.test.ts
+++ b/packages/imperative/src/config/__tests__/ProfileInfo.TeamConfig.unit.test.ts
@@ -1716,6 +1716,27 @@ describe("TeamConfig ProfileInfo tests", () => {
                 (profInfo as any).updateSchemaAtLayer("dummy", {}, testCfgLayer);
                 expect(writeFileSyncMock).toHaveBeenCalled();
             });
+
+            // case 3: $schema escapes the config layer directory; refuse to write
+            it("does not write schema outside the config layer directory", async () => {
+                const blockMocks = getBlockMocks();
+                const profInfo = createNewProfInfo(teamProjDir);
+                await profInfo.readProfilesFromDisk({ homeDir: teamHomeProjDir });
+                blockMocks.buildSchema.mockReturnValueOnce({} as any);
+                const loggerSpy = jest.spyOn(Logger.prototype, "trace");
+                const existsSyncSpy = jest.spyOn(fs, "existsSync");
+                writeFileSyncMock.mockClear();
+                const maliciousLayer = {
+                    ...testCfgLayer,
+                    properties: { ...testCfgLayer.properties, $schema: "../../../../../../../../evil.schema.json" },
+                };
+                expect((profInfo as any).updateSchemaAtLayer("dummy", {}, maliciousLayer)).toBe(false);
+                expect(loggerSpy).toHaveBeenCalledWith(
+                    "ProfileInfo.updateSchemaAtLayer returned false: the schema path escapes the config layer directory."
+                );
+                expect(existsSyncSpy).not.toHaveBeenCalled();
+                expect(writeFileSyncMock).not.toHaveBeenCalled();
+            });
         });
 
         describe("addProfileToConfig", () => {

--- a/packages/imperative/src/config/src/Config.ts
+++ b/packages/imperative/src/config/src/Config.ts
@@ -30,6 +30,7 @@ import { ConfigLayers, ConfigPlugins, ConfigProfiles, ConfigSecure } from "./api
 import { ConfigUtils } from "./ConfigUtils";
 import { IConfigSchemaInfo } from "./doc/IConfigSchema";
 import { JsUtils } from "../../utilities/src/JsUtils";
+import { IO } from "../../io";
 import { IConfigMergeOpts } from "./doc/IConfigMergeOpts";
 import { ConfigEnvironmentVariables } from "./ConfigEnvironmentVariables";
 import { IConfigEnvVarManaged } from "./doc/IConfigEnvVarManaged";
@@ -566,7 +567,10 @@ export class Config {
         }
 
         const schemaInfo = this.getSchemaInfo();
-        if (schemaObj != null && (schemaInfo.local || schemaInfo.original.startsWith("./"))) {
+        // Only write the schema to disk if the resolved path is contained within the directory of the
+        // config file that declared it.
+        if (schemaObj != null && (schemaInfo.local || schemaInfo.original.startsWith("./")) &&
+            IO.isSubPath(path.dirname(layer.path), schemaInfo.resolved)) {
             fs.writeFileSync(schemaInfo.resolved, JSONC.stringify(schemaObj, null, ConfigConstants.INDENT));
         }
     }

--- a/packages/imperative/src/config/src/ConfigSchema.ts
+++ b/packages/imperative/src/config/src/ConfigSchema.ts
@@ -17,6 +17,7 @@ import { IProfileProperty, IProfileSchema, IProfileTypeConfiguration } from "../
 import { IConfigSchema, IConfigUpdateSchemaHelperOptions, IConfigUpdateSchemaOptions, IConfigUpdateSchemaPaths } from "./doc/IConfigSchema";
 import { ImperativeConfig } from "../../utilities/src/ImperativeConfig";
 import { Logger } from "../../logger/src/Logger";
+import { IO } from "../../io";
 import { Config } from "./Config";
 import { ImperativeError } from "../../error/src/ImperativeError";
 import { IConfig } from "./doc/IConfig";
@@ -161,7 +162,9 @@ export class ConfigSchema {
             // Get the schema information to gather a list of updated paths
             const schemaInfo = opts.config.getSchemaInfo();
 
-            updatedPaths = { [layer.path]: { schema: schemaInfo.original, updated: schemaInfo.local } };
+            // Only report as updated when the schema was actually written within the layer directory
+            const schemaUpdated = schemaInfo.local && IO.isSubPath(path.dirname(layer.path), schemaInfo.resolved);
+            updatedPaths = { [layer.path]: { schema: schemaInfo.original, updated: schemaUpdated } };
         }
         if (opts.config.layerExists(path.dirname(layer.path), !layer.user) && checkContrastingLayer) {
             opts.config.api.layers.activate(!layer.user, layer.global, path.dirname(layer.path));

--- a/packages/imperative/src/config/src/ProfileInfo.ts
+++ b/packages/imperative/src/config/src/ProfileInfo.ts
@@ -10,6 +10,7 @@
 */
 
 import * as fs from "fs";
+import * as path from "path";
 import * as url from "url";
 import * as jsonfile from "jsonfile";
 import * as lodash from "lodash";
@@ -52,6 +53,7 @@ import { IAddProfTypeResult, IExtenderTypeInfo, IExtendersJsonOpts } from "./doc
 import { IConfigLayer } from "..";
 import { Constants } from "../../constants";
 import { Censor } from "../../censor";
+import { IO } from "../../io";
 
 /**
  * This class provides functions to retrieve profile-related information.
@@ -1166,6 +1168,15 @@ export class ProfileInfo {
         this.mProfileSchemaCache.set(cacheKey, schema);
         const schemaUri = new url.URL(layer.properties.$schema, url.pathToFileURL(layer.path));
         const schemaPath = url.fileURLToPath(schemaUri);
+
+        // Refuse to write if the resolved schema path escapes the directory of the config file that
+        // declared it.
+        if (!IO.isSubPath(path.dirname(layer.path), schemaPath)) {
+            this.mImpLogger.trace(
+                "ProfileInfo.updateSchemaAtLayer returned false: the schema path escapes the config layer directory."
+            );
+            return false;
+        }
 
         if (!fs.existsSync(schemaPath)) {
             this.mImpLogger.trace(


### PR DESCRIPTION
**What It Does**

Adds sanitization to the configuration schema path before writing contents of the schema to disk.

**How to Test**

- `zowe config update-schemas` works as it did on `main` (no impact)
- Installing a plug-in should update the schema to include its contributed profile types
- Uninstalling a plug-in should update the schema to remove its contributed profile types
- All tests (unit, integration, system) should pass

**Review Checklist**
I certify that I have:
- [x] updated the changelog
- [x] manually tested my changes
- [x] added/updated automated unit/integration tests
- [x] created/ran system tests (build number 2358)
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)