### PR TITLE
refactor: censor equals-form command options in logs

### DIFF
--- a/packages/imperative/CHANGELOG.md
+++ b/packages/imperative/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Imperative package will be documented in this file.
 
+## Recent Changes
+
+- BugFix: Masked sensitive command-line options that are supplied in the equals-separated form (e.g. `--user=example` or `-u=example`) before the command line is written to the log, and also mask secure values that contain embedded whitespace.
+
 ## `8.33.1`
 
 - BugFix: Encoded diff content before embedding it in the inline script of the web diff page to prevent stored cross-site scripting. [#2771](https://github.com/zowe/zowe-cli/pull/2771)

--- a/packages/imperative/CHANGELOG.md
+++ b/packages/imperative/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the Imperative package will be documented in this file.
 
 ## Recent Changes
 
-- BugFix: Masked sensitive command-line options that are supplied in the equals-separated form (e.g. `--user=example` or `-u=example`) before the command line is written to the log, and also mask secure values that contain embedded whitespace.
+- BugFix: Masked sensitive command-line options that are supplied in the equals-separated form (for example, `--user=example` or `-u=example`) before the command line is written to the log, and also mask secure values that contain embedded whitespace.
 
 ## `8.33.1`
 

--- a/packages/imperative/src/censor/__tests__/Censor.unit.test.ts
+++ b/packages/imperative/src/censor/__tests__/Censor.unit.test.ts
@@ -133,6 +133,58 @@ describe("Censor tests", () => {
         }
     });
 
+    describe("censorCommandLine", () => {
+        it("should censor a sensitive option supplied in the space-separated form", () => {
+            const result = Censor.censorCommandLine("zowe cmd --password secret --port 443");
+            expect(result).toContain(`--password ${Censor.CENSOR_RESPONSE}`);
+            expect(result).not.toContain("secret");
+            // non-secure option should be untouched
+            expect(result).toContain("--port 443");
+        });
+
+        it("should censor a sensitive option supplied in the equals-separated form", () => {
+            const result = Censor.censorCommandLine("zowe cmd --password=secret");
+            expect(result).toContain(`--password ${Censor.CENSOR_RESPONSE}`);
+            expect(result).not.toContain("secret");
+        });
+
+        it("should censor a sensitive short option supplied in the equals-separated form when its value is known", () => {
+            const result = Censor.censorCommandLine("zowe cmd -p=secret", { _: [], $0: "", password: "secret" });
+            expect(result).toContain(Censor.CENSOR_RESPONSE);
+            expect(result).not.toContain("secret");
+        });
+
+        it("should censor a sensitive value that contains embedded whitespace when the parsed args are supplied", () => {
+            const result = Censor.censorCommandLine("zowe cmd --password two words", { _: [], $0: "", password: "two words" });
+            expect(result).toContain(`--password ${Censor.CENSOR_RESPONSE}`);
+            expect(result).not.toContain("two words");
+            // the tail of the value must not leak
+            expect(result).not.toMatch(/\bwords\b/);
+        });
+
+        it("should not consume the boundary of a preceding argument", () => {
+            const result = Censor.censorCommandLine("zowe cmd --port 443 --password=secret");
+            expect(result).toContain("--port 443");
+            expect(result).toContain(`--password ${Censor.CENSOR_RESPONSE}`);
+        });
+
+        it("should not censor non-sensitive options", () => {
+            const commandLine = "zowe cmd --host example.com --port 443 --user fakeUser";
+            const result = Censor.censorCommandLine(commandLine);
+            expect(result).toEqual(commandLine);
+            expect(result).not.toContain(Censor.CENSOR_RESPONSE);
+        });
+
+        it("should ignore the reserved yargs keys ($0 and _) when censoring by value", () => {
+            const result = Censor.censorCommandLine("zowe cmd example", { _: ["cmd", "example"], $0: "zowe" });
+            expect(result).toEqual("zowe cmd example");
+        });
+
+        it.each([null, undefined, ""])("should return %p unchanged", (input) => {
+            expect(Censor.censorCommandLine(input as any)).toEqual(input);
+        });
+    });
+
     describe("censorSession", () => {
         const fakeUser = "fakeUser";
         const fakePassword = "fakePassword";

--- a/packages/imperative/src/censor/src/Censor.ts
+++ b/packages/imperative/src/censor/src/Censor.ts
@@ -362,9 +362,9 @@ export class Censor {
         // consuming the leading boundary, and normalizes the separator to a
         // space in the censored output.
         for (const secureArg of censoredOptions) {
-            const escapedArg = secureArg.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+            const escapedArg = secureArg.replace(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`);
             const dashes = secureArg.length > 1 ? "--" : "-";
-            const regex = new RegExp(`(?<=^|\\s)${dashes}${escapedArg}[=\\s]\\S+`, "gi");
+            const regex = new RegExp(String.raw`(?<=^|\s)${dashes}${escapedArg}[=\s]\S+`, "gi");
             censoredLine = censoredLine.replace(regex, `${dashes}${secureArg} ${this.CENSOR_RESPONSE}`);
         }
 

--- a/packages/imperative/src/censor/src/Censor.ts
+++ b/packages/imperative/src/censor/src/Censor.ts
@@ -340,7 +340,6 @@ export class Censor {
         // whitespace that the token-based regex below would otherwise truncate.
         if (args) {
             for (const optName of Object.keys(args)) {
-                if (optName === "_" || optName === "$0") { continue; }
                 if (this.CENSORED_OPTIONS.includes(optName)) {
                     const value = args[optName];
                     if (value != null && typeof value !== "object") {

--- a/packages/imperative/src/censor/src/Censor.ts
+++ b/packages/imperative/src/censor/src/Censor.ts
@@ -336,15 +336,13 @@ export class Censor {
         if (commandLine == null || commandLine.length === 0) { return commandLine; }
         let censoredLine = commandLine;
         // Read the censored options once so both passes below operate on the same list
-        const censoredOptions = this.CENSORED_OPTIONS;
 
         // Value-based censoring first, using the parsed arguments. Because we
         // know the exact value, this reliably masks values containing embedded
         // whitespace that the token-based regex below would otherwise truncate.
         if (args) {
             for (const optName of Object.keys(args)) {
-                if (optName === "_" || optName === "$0") { continue; }
-                if (censoredOptions.includes(optName)) {
+                if (this.CENSORED_OPTIONS.includes(optName)) {
                     const value = args[optName];
                     if (value != null && typeof value !== "object") {
                         const strVal = `${value}`;
@@ -361,7 +359,7 @@ export class Censor {
         // `--opt=value` forms (and the single-dash short form) without
         // consuming the leading boundary, and normalizes the separator to a
         // space in the censored output.
-        for (const secureArg of censoredOptions) {
+        for (const secureArg of this.CENSORED_OPTIONS) {
             const escapedArg = secureArg.replace(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`);
             const dashes = secureArg.length > 1 ? "--" : "-";
             const regex = new RegExp(String.raw`(?<=^|\s)${dashes}${escapedArg}[=\s]\S+`, "gi");

--- a/packages/imperative/src/censor/src/Censor.ts
+++ b/packages/imperative/src/censor/src/Censor.ts
@@ -15,6 +15,7 @@ import { CliUtils } from "../../utilities/src/CliUtils";
 import { ImperativeConfig } from "../../utilities/src/ImperativeConfig";
 import { EnvironmentalVariableSettings } from "../../imperative/src/env/EnvironmentalVariableSettings";
 import type { ICommandProfileProperty } from "../../cmd/src/doc/profiles/definition/ICommandProfileProperty";
+import type { ICommandArguments } from "../../cmd/src/doc/args/ICommandArguments";
 import type { ICensorOptions } from "./doc/ICensorOptions";
 import type { ICommandProfileTypeConfiguration } from "../../cmd/src/doc/profiles/definition/ICommandProfileTypeConfiguration";
 import type { IProfileSchema } from "../../profiles/src/doc/definition/IProfileSchema";
@@ -309,6 +310,65 @@ export class Censor {
             }
         }
         return newArgs;
+    }
+
+    /**
+     * Copy and censor a raw command-line string before logging/printing.
+     *
+     * This is resilient to the different ways a user may supply a sensitive
+     * option on the command line:
+     *  - space separated (`--password secret`)
+     *  - equals separated (`--password=secret`)
+     *  - single-dash short form / aliases (`-p secret` / `-p=secret`)
+     *
+     * When the parsed command arguments are supplied, the literal value of
+     * every secure option is additionally masked wherever it appears in the
+     * string. This catches secure values that contain embedded whitespace
+     * (e.g. a quoted `--password "two words"`, which arrives here as
+     * `--password two words` once the shell has stripped the quotes) that a
+     * token-based regex cannot reliably match.
+     *
+     * @param {string} commandLine - The raw command-line string to censor
+     * @param {ICommandArguments} args - The parsed command arguments, if available
+     * @returns {string} - The censored command-line string
+     */
+    public static censorCommandLine(commandLine: string, args?: ICommandArguments): string {
+        if (commandLine == null || commandLine.length === 0) { return commandLine; }
+        let censoredLine = commandLine;
+        // Read the censored options once so both passes below operate on the same list
+        const censoredOptions = this.CENSORED_OPTIONS;
+
+        // Value-based censoring first, using the parsed arguments. Because we
+        // know the exact value, this reliably masks values containing embedded
+        // whitespace that the token-based regex below would otherwise truncate.
+        if (args) {
+            for (const optName of Object.keys(args)) {
+                if (optName === "_" || optName === "$0") { continue; }
+                if (censoredOptions.includes(optName)) {
+                    const value = args[optName];
+                    if (value != null && typeof value !== "object") {
+                        const strVal = `${value}`;
+                        if (strVal.length > 0 && strVal !== this.CENSOR_RESPONSE) {
+                            // String split/join performs a literal (non-regex) replacement of every occurrence
+                            censoredLine = censoredLine.split(strVal).join(this.CENSOR_RESPONSE);
+                        }
+                    }
+                }
+            }
+        }
+
+        // Option-name based censoring. Matches both the `--opt value` and
+        // `--opt=value` forms (and the single-dash short form) without
+        // consuming the leading boundary, and normalizes the separator to a
+        // space in the censored output.
+        for (const secureArg of censoredOptions) {
+            const escapedArg = secureArg.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+            const dashes = secureArg.length > 1 ? "--" : "-";
+            const regex = new RegExp(`(?<=^|\\s)${dashes}${escapedArg}[=\\s]\\S+`, "gi");
+            censoredLine = censoredLine.replace(regex, `${dashes}${secureArg} ${this.CENSOR_RESPONSE}`);
+        }
+
+        return censoredLine;
     }
 
     /**

--- a/packages/imperative/src/censor/src/Censor.ts
+++ b/packages/imperative/src/censor/src/Censor.ts
@@ -335,13 +335,12 @@ export class Censor {
     public static censorCommandLine(commandLine: string, args?: ICommandArguments): string {
         if (commandLine == null || commandLine.length === 0) { return commandLine; }
         let censoredLine = commandLine;
-        // Read the censored options once so both passes below operate on the same list
-
         // Value-based censoring first, using the parsed arguments. Because we
         // know the exact value, this reliably masks values containing embedded
         // whitespace that the token-based regex below would otherwise truncate.
         if (args) {
             for (const optName of Object.keys(args)) {
+                if (optName === "_" || optName === "$0") { continue; }
                 if (this.CENSORED_OPTIONS.includes(optName)) {
                     const value = args[optName];
                     if (value != null && typeof value !== "object") {

--- a/packages/imperative/src/cmd/__tests__/CommandProcessor.unit.test.ts
+++ b/packages/imperative/src/cmd/__tests__/CommandProcessor.unit.test.ts
@@ -858,6 +858,82 @@ describe("Command Processor", () => {
         expect(logOutput).toContain("-u **** --password **** --token-value **** --cert-file-passphrase **** --cert-key-file /fake/path");
     });
 
+    it("should mask sensitive CLI options supplied in the equals-separated form in log output", async () => {
+        // Allocate the command processor
+        const processor: CommandProcessor = new CommandProcessor({
+            envVariablePrefix: ENV_VAR_PREFIX,
+            fullDefinition: SAMPLE_COMPLEX_COMMAND,
+            definition: SAMPLE_COMMAND_DEFINITION,
+            helpGenerator: FAKE_HELP_GENERATOR,
+            rootCommandName: SAMPLE_ROOT_COMMAND,
+            commandLine: "--user fakeUser --password=fakePass --token-value=fakeToken " +
+                "--cert-file-passphrase=fakePassphrase --cert-key-file /fake/path",
+            promptPhrase: "dummydummy"
+        });
+
+        // Mock log.info call
+        let logOutput: string = "";
+        const mockLogInfo = jest.fn((line) => {
+            logOutput += line + "\n";
+        });
+        Object.defineProperty(processor, "log", {
+            get: () => ({
+                debug: jest.fn(),
+                error: jest.fn(),
+                info: mockLogInfo,
+                trace: jest.fn()
+            })
+        });
+
+        const parms: any = { arguments: { _: [], $0: "", syntaxThrow: true }, responseFormat: "json", silent: true };
+        await processor.invoke(parms);
+
+        expect(mockLogInfo).toHaveBeenCalled();
+        expect(logOutput).toContain("--user fakeUser --password **** --token-value **** --cert-file-passphrase **** --cert-key-file /fake/path");
+        expect(logOutput).not.toContain("fakePass");
+        expect(logOutput).not.toContain("fakeToken");
+        expect(logOutput).not.toContain("fakePassphrase");
+    });
+
+    it("should mask a sensitive value containing embedded whitespace using the parsed arguments", async () => {
+        // Allocate the command processor
+        const processor: CommandProcessor = new CommandProcessor({
+            envVariablePrefix: ENV_VAR_PREFIX,
+            fullDefinition: SAMPLE_COMPLEX_COMMAND,
+            definition: SAMPLE_COMMAND_DEFINITION,
+            helpGenerator: FAKE_HELP_GENERATOR,
+            rootCommandName: SAMPLE_ROOT_COMMAND,
+            commandLine: "--password two words",
+            promptPhrase: "dummydummy"
+        });
+
+        // Mock log.info call
+        let logOutput: string = "";
+        const mockLogInfo = jest.fn((line) => {
+            logOutput += line + "\n";
+        });
+        Object.defineProperty(processor, "log", {
+            get: () => ({
+                debug: jest.fn(),
+                error: jest.fn(),
+                info: mockLogInfo,
+                trace: jest.fn()
+            })
+        });
+
+        const parms: any = {
+            arguments: { _: [], $0: "", password: "two words", syntaxThrow: true },
+            responseFormat: "json",
+            silent: true
+        };
+        await processor.invoke(parms);
+
+        expect(mockLogInfo).toHaveBeenCalled();
+        expect(logOutput).toContain(`--password ${Censor.CENSOR_RESPONSE}`);
+        expect(logOutput).not.toContain("two words");
+        expect(logOutput).not.toMatch(/\bwords\b/);
+    });
+
     it("should handle not being able to instantiate the handler", async () => {
         // Allocate the command processor
         const processor: CommandProcessor = new CommandProcessor({

--- a/packages/imperative/src/cmd/__tests__/CommandProcessor.unit.test.ts
+++ b/packages/imperative/src/cmd/__tests__/CommandProcessor.unit.test.ts
@@ -823,7 +823,7 @@ describe("Command Processor", () => {
 
     it("should mask sensitive CLI options like user and password in log output 2", async () => {
         const realCensoredOptions = Censor.CENSORED_OPTIONS;
-        jest.spyOn(Censor, "CENSORED_OPTIONS", "get").mockReturnValueOnce([...realCensoredOptions, "u"]);
+        jest.spyOn(Censor, "CENSORED_OPTIONS", "get").mockReturnValue([...realCensoredOptions, "u"]);
 
         // Allocate the command processor
         const processor: CommandProcessor = new CommandProcessor({

--- a/packages/imperative/src/cmd/src/CommandProcessor.ts
+++ b/packages/imperative/src/cmd/src/CommandProcessor.ts
@@ -372,23 +372,10 @@ export class CommandProcessor {
             commandArguments: params.arguments
         });
 
-        let commandLine = ImperativeConfig.instance.commandLine || this.commandLine;
-
-        for (const secureArg of Censor.CENSORED_OPTIONS) {
-            let regex: RegExp;
-            if (secureArg.length > 1) {
-                regex = new RegExp(`--${secureArg} ([^\\s]+)`, "gi");
-            } else {
-                regex = new RegExp(`-${secureArg} ([^\\s]+)`, "gi");
-            }
-            if (commandLine.search(regex) >= 0) {
-                if (secureArg.length > 1) {
-                    commandLine = commandLine.replace(regex, `--${secureArg} ${Censor.CENSOR_RESPONSE}`);
-                } else {
-                    commandLine = commandLine.replace(regex, `-${secureArg} ${Censor.CENSOR_RESPONSE}`);
-                }
-            }
-        }
+        const commandLine = Censor.censorCommandLine(
+            ImperativeConfig.instance.commandLine || this.commandLine,
+            params.arguments
+        );
 
         // this.log.info(`post commandLine issued:\n\n${TextUtils.prettyJson(commandLine)}`);
         // Log the invoke


### PR DESCRIPTION
**What It Does**

Refactors censoring of command-line options to cover equals-form (`--pw=example`) as well as options containing embedded whitespace.

**Note:** I've scoped out `censorCLIArgs` from this PR: it has the same `indexOf`-based `=`-blindness, but it operates on already-split arg arrays and is only reachable through deprecated `CliUtils`/`LoggerUtils` wrappers. I left it untouched to keep the fix focused. If we want to harden this logic, please leave it as a suggestion and I can pursue it as part of this work.

**How to Test**

- Set your log level to trace for Zowe CLI
- Execute a Zowe CLI command with a "censored" option passed as equals-form (`zowe files list ds ... --pw=example`)
- Notice that the option's value is now properly censored within the log file

**Review Checklist**
I certify that I have:
- [x] updated the changelog
- [x] manually tested my changes
- [x] added/updated automated unit/integration tests
- [x] created/ran system tests (run 2375)
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)