### PR TITLE
refactor(v2): redact `base64EncodedAuth` in session props

### DIFF
--- a/packages/imperative/CHANGELOG.md
+++ b/packages/imperative/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Imperative package will be documented in this file.
 
+## Recent Changes
+
+- BugFix: Added the `base64EncodedAuth` session property to the list of session properties redacted from Imperative debug logs. [#2780](https://github.com/zowe/zowe-cli/pull/2780)
+
 ## `5.27.18`
 
 - BugFix: Removed environment variables from the log messages produced when an exception is caught during Imperative.init. [#2765](https://github.com/zowe/zowe-cli/pull/2765)

--- a/packages/imperative/src/rest/__tests__/session/ConnectionPropsForSessCfg.unit.test.ts
+++ b/packages/imperative/src/rest/__tests__/session/ConnectionPropsForSessCfg.unit.test.ts
@@ -1285,7 +1285,8 @@ describe("ConnectionPropsForSessCfg tests", () => {
             user: "FakeUser",
             password: "FakePassword",
             tokenType: SessConstants.TOKEN_TYPE_JWT,
-            tokenValue: "FakeToken"
+            tokenValue: "FakeToken",
+            base64EncodedAuth: Buffer.from("FakeUser:FakePassword").toString("base64")
         });
         getImperativeLoggerSpy.mockRestore();
         expect(mockLoggerDebug).toHaveBeenCalledTimes(1);
@@ -1294,6 +1295,46 @@ describe("ConnectionPropsForSessCfg tests", () => {
         expect(logOutput).not.toContain("FakeUser");
         expect(logOutput).not.toContain("FakePassword");
         expect(logOutput).not.toContain("FakeToken");
+    });
+
+    it("should not log base64EncodedAuth in the session config", async () => {
+        const mockLoggerDebug = jest.fn();
+        const getImperativeLoggerSpy = jest.spyOn(Logger, "getImperativeLogger")
+            .mockReturnValueOnce({ debug: mockLoggerDebug } as any);
+        // base64EncodedAuth is the trivially-reversible base64 of user:password
+        const base64EncodedAuth = Buffer.from("FakeUser:FakePassword").toString("base64");
+        (ConnectionPropsForSessCfg as any).logSessCfg({
+            host: "SomeHost",
+            port: 11,
+            base64EncodedAuth
+        });
+        getImperativeLoggerSpy.mockRestore();
+        expect(mockLoggerDebug).toHaveBeenCalledTimes(1);
+        const logOutput = mockLoggerDebug.mock.calls[0][0];
+        // the non-secret host should still be logged
+        expect(logOutput).toContain("SomeHost");
+        // the base64 credential must be masked, not leaked
+        expect(logOutput).not.toContain(base64EncodedAuth);
+        expect(logOutput).toContain("base64EncodedAuth_is_hidden");
+    });
+
+    it("should still log the non-secret cert/certKey file paths in the session config", async () => {
+        const mockLoggerDebug = jest.fn();
+        const getImperativeLoggerSpy = jest.spyOn(Logger, "getImperativeLogger")
+            .mockReturnValueOnce({ debug: mockLoggerDebug } as any);
+        // cert and certKey hold file paths (not inline key material), so they are not masked
+        (ConnectionPropsForSessCfg as any).logSessCfg({
+            host: "SomeHost",
+            port: 11,
+            cert: "/path/to/cert.pem",
+            certKey: "/path/to/certKey.pem"
+        });
+        getImperativeLoggerSpy.mockRestore();
+        expect(mockLoggerDebug).toHaveBeenCalledTimes(1);
+        const logOutput = mockLoggerDebug.mock.calls[0][0];
+        expect(logOutput).toContain("SomeHost");
+        expect(logOutput).toContain("/path/to/cert.pem");
+        expect(logOutput).toContain("/path/to/certKey.pem");
     });
 
     it("SSO CallBack with getValuesBack", async() => {

--- a/packages/imperative/src/rest/src/session/ConnectionPropsForSessCfg.ts
+++ b/packages/imperative/src/rest/src/session/ConnectionPropsForSessCfg.ts
@@ -354,7 +354,7 @@ export class ConnectionPropsForSessCfg {
      * NOTE(Kelosky): redundant from LoggerUtils.SECURE_PROMPT_OPTIONS - leaving
      * for future date to consolidate
      */
-    private static secureSessCfgProps: Set<string> = new Set(["user", "password", "tokenValue", "passphrase"]);
+    private static secureSessCfgProps: Set<string> = new Set(["user", "password", "tokenValue", "passphrase", "base64EncodedAuth"]);
 
     /**
      * List of prompt messages that is used when the CLI prompts for session


### PR DESCRIPTION
**What It Does**

Adds `base64EncodedAuth` to the list of secure session config properties.

**Review Checklist**
I certify that I have:
- [x] updated the changelog
- [x] manually tested my changes
- [x] added/updated automated unit/integration tests
- [x] created/ran system tests (job 2395)
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**

These changes are specific to the V2 branch. V3 already properly censors the `base64EncodedAuth` session property.