### PR TITLE
refactor(v2): censor equals-form command options in logs

### DIFF
--- a/packages/imperative/CHANGELOG.md
+++ b/packages/imperative/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Imperative package will be documented in this file.
 
+## Recent Changes
+
+- BugFix: Masked sensitive command-line options that are supplied in the equals-separated form (for example, `--user=example` or `-u=example`) before the command line is written to the log, and also mask secure values that contain embedded whitespace.
+
 ## `5.27.19`
 
 - BugFix: Added the `base64EncodedAuth` session property to the list of session properties redacted from Imperative debug logs. [#2780](https://github.com/zowe/zowe-cli/pull/2780)

--- a/packages/imperative/CHANGELOG.md
+++ b/packages/imperative/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the Imperative package will be documented in this file.
 
 ## Recent Changes
 
-- BugFix: Masked sensitive command-line options that are supplied in the equals-separated form (for example, `--user=example` or `-u=example`) before the command line is written to the log, and also mask secure values that contain embedded whitespace.
+- BugFix: Masked sensitive command-line options that are supplied in the equals-separated form (for example, `--user=example` or `-u=example`) before the command line is written to the log, and also mask secure values that contain embedded whitespace. [#2782](https://github.com/zowe/zowe-cli/pull/2782)
 
 ## `5.27.19`
 

--- a/packages/imperative/src/cmd/__tests__/CommandProcessor.unit.test.ts
+++ b/packages/imperative/src/cmd/__tests__/CommandProcessor.unit.test.ts
@@ -888,6 +888,85 @@ describe("Command Processor", () => {
         expect(logOutput).toContain("--user **** --password **** --token-value **** --cert-file-passphrase **** --cert-key-file ****");
     });
 
+    it("should mask sensitive CLI options supplied in the equals-separated form in log output", async () => {
+        // Allocate the command processor
+        const processor: CommandProcessor = new CommandProcessor({
+            envVariablePrefix: ENV_VAR_PREFIX,
+            fullDefinition: SAMPLE_COMPLEX_COMMAND,
+            definition: SAMPLE_COMMAND_DEFINITION,
+            helpGenerator: FAKE_HELP_GENERATOR,
+            profileManagerFactory: FAKE_PROFILE_MANAGER_FACTORY,
+            rootCommandName: SAMPLE_ROOT_COMMAND,
+            commandLine: "--user fakeUser --password=fakePass --token-value=fakeToken " +
+                "--cert-file-passphrase=fakePassphrase --cert-key-file /fake/path",
+            promptPhrase: "dummydummy"
+        });
+
+        // Mock log.info call
+        let logOutput: string = "";
+        const mockLogInfo = jest.fn((line) => {
+            logOutput += line + "\n";
+        });
+        Object.defineProperty(processor, "log", {
+            get: () => ({
+                debug: jest.fn(),
+                error: jest.fn(),
+                info: mockLogInfo,
+                trace: jest.fn()
+            })
+        });
+
+        const parms: any = { arguments: { _: [], $0: "", syntaxThrow: true }, responseFormat: "json", silent: true };
+        await processor.invoke(parms);
+
+        expect(mockLogInfo).toHaveBeenCalled();
+        expect(logOutput).toContain("--user **** --password **** --token-value **** --cert-file-passphrase **** --cert-key-file ****");
+        expect(logOutput).not.toContain("fakeUser");
+        expect(logOutput).not.toContain("fakePass");
+        expect(logOutput).not.toContain("fakeToken");
+        expect(logOutput).not.toContain("fakePassphrase");
+    });
+
+    it("should mask a sensitive value containing embedded whitespace using the parsed arguments", async () => {
+        // Allocate the command processor
+        const processor: CommandProcessor = new CommandProcessor({
+            envVariablePrefix: ENV_VAR_PREFIX,
+            fullDefinition: SAMPLE_COMPLEX_COMMAND,
+            definition: SAMPLE_COMMAND_DEFINITION,
+            helpGenerator: FAKE_HELP_GENERATOR,
+            profileManagerFactory: FAKE_PROFILE_MANAGER_FACTORY,
+            rootCommandName: SAMPLE_ROOT_COMMAND,
+            commandLine: "--password two words",
+            promptPhrase: "dummydummy"
+        });
+
+        // Mock log.info call
+        let logOutput: string = "";
+        const mockLogInfo = jest.fn((line) => {
+            logOutput += line + "\n";
+        });
+        Object.defineProperty(processor, "log", {
+            get: () => ({
+                debug: jest.fn(),
+                error: jest.fn(),
+                info: mockLogInfo,
+                trace: jest.fn()
+            })
+        });
+
+        const parms: any = {
+            arguments: { _: [], $0: "", password: "two words", syntaxThrow: true },
+            responseFormat: "json",
+            silent: true
+        };
+        await processor.invoke(parms);
+
+        expect(mockLogInfo).toHaveBeenCalled();
+        expect(logOutput).toContain(`--password ${LoggerUtils.CENSOR_RESPONSE}`);
+        expect(logOutput).not.toContain("two words");
+        expect(logOutput).not.toMatch(/\bwords\b/);
+    });
+
     it("should handle an error thrown from the profile loader", async () => {
         // Allocate the command processor
         const processor: CommandProcessor = new CommandProcessor({

--- a/packages/imperative/src/cmd/src/CommandProcessor.ts
+++ b/packages/imperative/src/cmd/src/CommandProcessor.ts
@@ -388,42 +388,14 @@ export class CommandProcessor {
                 `${CommandProcessor.ERROR_TAG} invoke(): Cannot invoke the handler for command "${this.definition.name}". The handler is blank.`);
         }
 
-        let commandLine = ImperativeConfig.instance.commandLine || this.commandLine;
-
-        // determine if the command has the user option and mask the user value
-        let regEx = /--(user|u) ([^\s]+)/gi;
-
-        if (commandLine.search(regEx) >= 0) {
-            commandLine = commandLine.replace(regEx, "--$1 ****");
-        }
-
-        // determine if the command has the password option and mask the password value
-        regEx = /--(password|pass|pw) ([^\s]+)/gi;
-
-        if (commandLine.search(regEx) >= 0) {
-            commandLine = commandLine.replace(regEx, "--$1 ****");
-        }
-
-        // determine if the command has the token value option and mask the token value
-        regEx = /--(token-value|tokenValue|tv) ([^\s]+)/gi;
-
-        if (commandLine.search(regEx) >= 0) {
-            commandLine = commandLine.replace(regEx, "--$1 ****");
-        }
-
-        // determine if the command has the cert key file option and mask the value
-        regEx = /--(cert-key-file|certKeyFile) ([^\s]+)/gi;
-
-        if (commandLine.search(regEx) >= 0) {
-            commandLine = commandLine.replace(regEx, "--$1 ****");
-        }
-
-        // determine if the command has the cert file passphrase option and mask the value
-        regEx = /--(cert-file-passphrase|certFilePassphrase) ([^\s]+)/gi;
-
-        if (commandLine.search(regEx) >= 0) {
-            commandLine = commandLine.replace(regEx, "--$1 ****");
-        }
+        // Censor any sensitive options before the command line is logged. This
+        // masks credentials regardless of the separator used (`--opt value` or
+        // `--opt=value`), the dash form (short aliases), or embedded whitespace
+        // in the value (masked via the parsed arguments).
+        const commandLine = LoggerUtils.censorCommandLine(
+            ImperativeConfig.instance.commandLine || this.commandLine,
+            params.arguments
+        );
 
         // this.log.info(`post commandLine issued:\n\n${TextUtils.prettyJson(commandLine)}`);
         // Log the invoke

--- a/packages/imperative/src/logger/__tests__/LoggerUtils.unit.test.ts
+++ b/packages/imperative/src/logger/__tests__/LoggerUtils.unit.test.ts
@@ -55,6 +55,58 @@ describe("LoggerUtils tests", () => {
         expect(data.notSecret).not.toContain(LoggerUtils.CENSOR_RESPONSE);
     });
 
+    describe("censorCommandLine", () => {
+        it("should censor a sensitive option supplied in the space-separated form", () => {
+            const result = LoggerUtils.censorCommandLine("zowe cmd --password secret --port 443");
+            expect(result).toContain(`--password ${LoggerUtils.CENSOR_RESPONSE}`);
+            expect(result).not.toContain("secret");
+            // non-secure option should be untouched
+            expect(result).toContain("--port 443");
+        });
+
+        it("should censor a sensitive option supplied in the equals-separated form", () => {
+            const result = LoggerUtils.censorCommandLine("zowe cmd --password=secret");
+            expect(result).toContain(`--password ${LoggerUtils.CENSOR_RESPONSE}`);
+            expect(result).not.toContain("secret");
+        });
+
+        it("should censor a sensitive short option supplied in the equals-separated form when its value is known", () => {
+            const result = LoggerUtils.censorCommandLine("zowe cmd -p=secret", { _: [], $0: "", password: "secret" });
+            expect(result).toContain(LoggerUtils.CENSOR_RESPONSE);
+            expect(result).not.toContain("secret");
+        });
+
+        it("should censor a sensitive value that contains embedded whitespace when the parsed args are supplied", () => {
+            const result = LoggerUtils.censorCommandLine("zowe cmd --password two words", { _: [], $0: "", password: "two words" });
+            expect(result).toContain(`--password ${LoggerUtils.CENSOR_RESPONSE}`);
+            expect(result).not.toContain("two words");
+            // the tail of the value must not leak
+            expect(result).not.toMatch(/\bwords\b/);
+        });
+
+        it("should not consume the boundary of a preceding argument", () => {
+            const result = LoggerUtils.censorCommandLine("zowe cmd --port 443 --password=secret");
+            expect(result).toContain("--port 443");
+            expect(result).toContain(`--password ${LoggerUtils.CENSOR_RESPONSE}`);
+        });
+
+        it("should not censor non-sensitive options", () => {
+            const commandLine = "zowe cmd --host example.com --port 443";
+            const result = LoggerUtils.censorCommandLine(commandLine);
+            expect(result).toEqual(commandLine);
+            expect(result).not.toContain(LoggerUtils.CENSOR_RESPONSE);
+        });
+
+        it("should ignore the reserved yargs keys ($0 and _) when censoring by value", () => {
+            const result = LoggerUtils.censorCommandLine("zowe cmd example", { _: ["cmd", "example"], $0: "zowe" });
+            expect(result).toEqual("zowe cmd example");
+        });
+
+        it.each([null, undefined, ""])("should return %p unchanged", (input) => {
+            expect(LoggerUtils.censorCommandLine(input as any)).toEqual(input);
+        });
+    });
+
     describe("censorRawData", () => {
         const secrets = ["secret0", "secret1"];
         let impConfigSpy: jest.SpyInstance = null;

--- a/packages/imperative/src/logger/src/LoggerUtils.ts
+++ b/packages/imperative/src/logger/src/LoggerUtils.ts
@@ -107,7 +107,6 @@ export class LoggerUtils {
     public static censorCommandLine(commandLine: string, args?: Arguments): string {
         if (commandLine == null || commandLine.length === 0) { return commandLine; }
         let censoredLine = commandLine;
-        const censoredOptions = LoggerUtils.COMMAND_LINE_CENSORED_OPTIONS;
 
         // Value-based censoring first, using the parsed arguments. Because we
         // know the exact value, this reliably masks values containing embedded
@@ -115,7 +114,7 @@ export class LoggerUtils {
         if (args) {
             for (const optName of Object.keys(args)) {
                 if (optName === "_" || optName === "$0") { continue; }
-                if (censoredOptions.includes(optName)) {
+                if (LoggerUtils.COMMAND_LINE_CENSORED_OPTIONS.includes(optName)) {
                     const value = args[optName];
                     if (value != null && typeof value !== "object") {
                         const strVal = `${value}`;
@@ -132,7 +131,7 @@ export class LoggerUtils {
         // `--opt=value` forms (and the single-dash short form) without
         // consuming the leading boundary, and normalizes the separator to a
         // space in the censored output.
-        for (const secureArg of censoredOptions) {
+        for (const secureArg of LoggerUtils.COMMAND_LINE_CENSORED_OPTIONS) {
             const escapedArg = secureArg.replace(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`);
             const dashes = secureArg.length > 1 ? "--" : "-";
             const regex = new RegExp(String.raw`(?<=^|\s)${dashes}${escapedArg}[=\s]\S+`, "gi");

--- a/packages/imperative/src/logger/src/LoggerUtils.ts
+++ b/packages/imperative/src/logger/src/LoggerUtils.ts
@@ -34,6 +34,16 @@ export class LoggerUtils {
     public static SECURE_PROMPT_OPTIONS = ["user", "password", "tokenValue", "passphrase"];
 
     /**
+     * The set of secure options whose values must be masked when a raw command
+     * line is written to the log. This mirrors the options historically masked
+     * by CommandProcessor and includes every alias (long, short, camelCase and
+     * kebab-case) so that the value cannot leak regardless of how it is typed.
+     */
+    public static COMMAND_LINE_CENSORED_OPTIONS = ["user", "u",
+        "password", "pass", "pw", "token-value", "tokenValue", "tv",
+        "cert-key-file", "certKeyFile", "cert-file-passphrase", "certFilePassphrase"];
+
+    /**
      * Copy and censor any sensitive CLI arguments before logging/printing
      * @param {string[]} args
      * @returns {string[]}
@@ -72,6 +82,64 @@ export class LoggerUtils {
             }
         }
         return newArgs;
+    }
+
+    /**
+     * Copy and censor a raw command-line string before logging/printing.
+     *
+     * This is resilient to the different ways a user may supply a sensitive
+     * option on the command line:
+     *  - space separated (`--password secret`)
+     *  - equals separated (`--password=secret`)
+     *  - single-dash short form / aliases (`-p secret` / `-p=secret`)
+     *
+     * When the parsed command arguments are supplied, the literal value of
+     * every secure option is additionally masked wherever it appears in the
+     * string. This catches secure values that contain embedded whitespace
+     * (e.g. a quoted `--password "two words"`, which arrives here as
+     * `--password two words` once the shell has stripped the quotes) that a
+     * token-based regex cannot reliably match.
+     *
+     * @param {string} commandLine - The raw command-line string to censor
+     * @param {Arguments} args - The parsed command arguments, if available
+     * @returns {string} - The censored command-line string
+     */
+    public static censorCommandLine(commandLine: string, args?: Arguments): string {
+        if (commandLine == null || commandLine.length === 0) { return commandLine; }
+        let censoredLine = commandLine;
+        const censoredOptions = LoggerUtils.COMMAND_LINE_CENSORED_OPTIONS;
+
+        // Value-based censoring first, using the parsed arguments. Because we
+        // know the exact value, this reliably masks values containing embedded
+        // whitespace that the token-based regex below would otherwise truncate.
+        if (args) {
+            for (const optName of Object.keys(args)) {
+                if (optName === "_" || optName === "$0") { continue; }
+                if (censoredOptions.includes(optName)) {
+                    const value = args[optName];
+                    if (value != null && typeof value !== "object") {
+                        const strVal = `${value}`;
+                        if (strVal.length > 0 && strVal !== LoggerUtils.CENSOR_RESPONSE) {
+                            // String split/join performs a literal (non-regex) replacement of every occurrence
+                            censoredLine = censoredLine.split(strVal).join(LoggerUtils.CENSOR_RESPONSE);
+                        }
+                    }
+                }
+            }
+        }
+
+        // Option-name based censoring. Matches both the `--opt value` and
+        // `--opt=value` forms (and the single-dash short form) without
+        // consuming the leading boundary, and normalizes the separator to a
+        // space in the censored output.
+        for (const secureArg of censoredOptions) {
+            const escapedArg = secureArg.replace(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`);
+            const dashes = secureArg.length > 1 ? "--" : "-";
+            const regex = new RegExp(String.raw`(?<=^|\s)${dashes}${escapedArg}[=\s]\S+`, "gi");
+            censoredLine = censoredLine.replace(regex, `${dashes}${secureArg} ${LoggerUtils.CENSOR_RESPONSE}`);
+        }
+
+        return censoredLine;
     }
 
     /**

--- a/packages/imperative/src/logger/src/LoggerUtils.ts
+++ b/packages/imperative/src/logger/src/LoggerUtils.ts
@@ -39,7 +39,7 @@ export class LoggerUtils {
      * by CommandProcessor and includes every alias (long, short, camelCase and
      * kebab-case) so that the value cannot leak regardless of how it is typed.
      */
-    public static COMMAND_LINE_CENSORED_OPTIONS = ["user", "u",
+    public static readonly COMMAND_LINE_CENSORED_OPTIONS = ["user", "u",
         "password", "pass", "pw", "token-value", "tokenValue", "tv",
         "cert-key-file", "certKeyFile", "cert-file-passphrase", "certFilePassphrase"];
 

--- a/packages/imperative/src/logger/src/LoggerUtils.ts
+++ b/packages/imperative/src/logger/src/LoggerUtils.ts
@@ -113,7 +113,6 @@ export class LoggerUtils {
         // whitespace that the token-based regex below would otherwise truncate.
         if (args) {
             for (const optName of Object.keys(args)) {
-                if (optName === "_" || optName === "$0") { continue; }
                 if (LoggerUtils.COMMAND_LINE_CENSORED_OPTIONS.includes(optName)) {
                     const value = args[optName];
                     if (value != null && typeof value !== "object") {

--- a/packages/imperative/src/logger/src/__mocks__/LoggerUtils.ts
+++ b/packages/imperative/src/logger/src/__mocks__/LoggerUtils.ts
@@ -20,5 +20,6 @@ LoggerUtils.censorRawData.mockImplementation((data: string, category: string = "
 
 LoggerUtils.censorCLIArgs = loggerUtilsRequire.censorCLIArgs;
 LoggerUtils.censorYargsArguments = loggerUtilsRequire.censorYargsArguments;
+LoggerUtils.censorCommandLine = loggerUtilsRequire.censorCommandLine;
 
 exports.LoggerUtils = LoggerUtils;


### PR DESCRIPTION
**What It Does**

Refactors censoring of command-line options to cover equals-form (`-u=example`) as well as options containing embedded whitespace.

**How to Test**

- Set your log level to trace for Zowe CLI
- Execute a Zowe CLI command with a censored option passed as equals-form (`zowe files list ds ... --pw=example`)
- Notice that the option's value is now properly censored within the log file

**Review Checklist**
I certify that I have:
- [x] updated the changelog
- [x] manually tested my changes
- [x] added/updated automated unit/integration tests
- [x] created/ran system tests (job number 2401)
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)