### PR TITLE
Fix: Restrict team config profile properties to schema declared fields

### DIFF
--- a/packages/imperative/CHANGELOG.md
+++ b/packages/imperative/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to the Imperative package will be documented in this file.
 
+## Recent Changes
+- BugFix: Restricted profile properties sourced from team config to only those declared in the profile type's schema, preventing config injection of arbitrary command options.
+
 ## `5.27.20`
 
 - BugFix: Masked sensitive command-line options that are supplied in the equals-separated form (for example, `--user=example` or `-u=example`) before the command line is written to the log, and also mask secure values that contain embedded whitespace. [#2782](https://github.com/zowe/zowe-cli/pull/2782)

--- a/packages/imperative/CHANGELOG.md
+++ b/packages/imperative/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to the Imperative package will be documented in this file.
 
 ## Recent Changes
-- BugFix: Restricted profile properties sourced from team config to only those declared in the profile type's schema, preventing config injection of arbitrary command options.
+- BugFix: Restricted profile properties sourced from team config to only those declared in the profile type's schema, preventing config injection of arbitrary command options. [#2787](https://github.com/zowe/zowe-cli/pull/2787)
 
 ## `5.27.20`
 

--- a/packages/imperative/src/cmd/__tests__/CommandProcessor.unit.test.ts
+++ b/packages/imperative/src/cmd/__tests__/CommandProcessor.unit.test.ts
@@ -110,6 +110,30 @@ const SAMPLE_COMMAND_REAL_HANDLER_WITH_OPT: ICommandDefinition = {
     }
 };
 
+// Command definition that declares both a schema-defined option ("color") and a
+// command-specific option ("editor") to exercise config injection protection.
+const SAMPLE_COMMAND_WITH_EDITOR_OPT: ICommandDefinition = {
+    name: "edit",
+    description: "The edit command",
+    type: "command",
+    handler: __dirname + "/__model__/TestArgHandler",
+    options: [
+        {
+            name: "color",
+            type: "string",
+            description: "The banana color.",
+        },
+        {
+            name: "editor",
+            type: "string",
+            description: "The editor to use.",
+        }
+    ],
+    profile: {
+        optional: ["banana"]
+    }
+};
+
 const SAMPLE_COMMAND_REAL_HANDLER_WITH_POS_OPT: ICommandDefinition = {
     name: "banana",
     description: "The banana command",
@@ -2703,7 +2727,7 @@ describe("Command Processor", () => {
                 envVariablePrefix: ENV_VAR_PREFIX,
                 definition: SAMPLE_COMMAND_REAL_HANDLER_WITH_OPT,
                 helpGenerator: FAKE_HELP_GENERATOR,
-                profileManagerFactory: FAKE_PROFILE_MANAGER_FACTORY,
+                profileManagerFactory: FAKE_PROFILE_MANAGER_FACTORY_WITH_PROPS,
                 rootCommandName: SAMPLE_ROOT_COMMAND,
                 commandLine: "",
                 promptPhrase: "dummydummy",
@@ -2728,6 +2752,96 @@ describe("Command Processor", () => {
         it("should find default profile that matches type", async () => {
             const commandPrepared = await (processor as any).prepare(null, {});
             expect(commandPrepared.args.color).toBe("green");
+        });
+    });
+
+    describe("profile config injection protection", () => {
+        it("should allow schema-declared properties to be sourced from team config", async () => {
+            await setupConfigToLoad({
+                profiles: {
+                    fresh: {
+                        type: "banana",
+                        properties: {
+                            color: "green",
+                            editor: "/path/to/malware"
+                        }
+                    }
+                },
+                defaults: { banana: "fresh" }
+            });
+
+            const processor = new CommandProcessor({
+                envVariablePrefix: ENV_VAR_PREFIX,
+                definition: SAMPLE_COMMAND_WITH_EDITOR_OPT,
+                helpGenerator: FAKE_HELP_GENERATOR,
+                profileManagerFactory: FAKE_PROFILE_MANAGER_FACTORY_WITH_PROPS,
+                rootCommandName: SAMPLE_ROOT_COMMAND,
+                commandLine: "",
+                promptPhrase: "dummydummy",
+                config: ImperativeConfig.instance.config
+            });
+
+            const commandPrepared = await (processor as any).prepare(null, {});
+            expect(commandPrepared.args.color).toBe("green");
+        });
+
+        it("should block non-schema properties injected via team config profile", async () => {
+            await setupConfigToLoad({
+                profiles: {
+                    fresh: {
+                        type: "banana",
+                        properties: {
+                            color: "green",
+                            editor: "/path/to/malware"
+                        }
+                    }
+                },
+                defaults: { banana: "fresh" }
+            });
+
+            const processor = new CommandProcessor({
+                envVariablePrefix: ENV_VAR_PREFIX,
+                definition: SAMPLE_COMMAND_WITH_EDITOR_OPT,
+                helpGenerator: FAKE_HELP_GENERATOR,
+                profileManagerFactory: FAKE_PROFILE_MANAGER_FACTORY_WITH_PROPS,
+                rootCommandName: SAMPLE_ROOT_COMMAND,
+                commandLine: "",
+                promptPhrase: "dummydummy",
+                config: ImperativeConfig.instance.config
+            });
+
+            const commandPrepared = await (processor as any).prepare(null, {});
+            // "editor" is not declared in the banana schema → must be dropped
+            expect(commandPrepared.args.editor).toBeUndefined();
+            // "color" is declared in the schema → must still flow through
+            expect(commandPrepared.args.color).toBe("green");
+        });
+
+        it("should fall back to unfiltered merge when schema is not available", async () => {
+            await setupConfigToLoad({
+                profiles: {
+                    fresh: {
+                        type: "banana",
+                        properties: { color: "green" }
+                    }
+                },
+                defaults: { banana: "fresh" }
+            });
+
+            const processor = new CommandProcessor({
+                envVariablePrefix: ENV_VAR_PREFIX,
+                definition: SAMPLE_COMMAND_WITH_EDITOR_OPT,
+                helpGenerator: FAKE_HELP_GENERATOR,
+                profileManagerFactory: FAKE_PROFILE_MANAGER_FACTORY,
+                rootCommandName: SAMPLE_ROOT_COMMAND,
+                commandLine: "",
+                promptPhrase: "dummydummy",
+                config: ImperativeConfig.instance.config
+            });
+
+            const commandPrepared = await (processor as any).prepare(null, {});
+            // Empty schema → nothing from the profile should be passed through
+            expect(commandPrepared.args.color).toBeUndefined();
         });
     });
 });

--- a/packages/imperative/src/cmd/__tests__/CommandProcessor.unit.test.ts
+++ b/packages/imperative/src/cmd/__tests__/CommandProcessor.unit.test.ts
@@ -2769,6 +2769,10 @@ describe("Command Processor", () => {
                 },
                 defaults: { banana: "fresh" }
             });
+            jest.spyOn(ImperativeConfig.instance, "loadedConfig", "get").mockReturnValue({
+                profiles: [{ type: "banana", schema: { title: "", description: "", type: "object",
+                    properties: { color: { type: "string" } } } }]
+            } as any);
 
             const processor = new CommandProcessor({
                 envVariablePrefix: ENV_VAR_PREFIX,
@@ -2798,6 +2802,10 @@ describe("Command Processor", () => {
                 },
                 defaults: { banana: "fresh" }
             });
+            jest.spyOn(ImperativeConfig.instance, "loadedConfig", "get").mockReturnValue({
+                profiles: [{ type: "banana", schema: { title: "", description: "", type: "object",
+                    properties: { color: { type: "string" } } } }]
+            } as any);
 
             const processor = new CommandProcessor({
                 envVariablePrefix: ENV_VAR_PREFIX,
@@ -2840,8 +2848,8 @@ describe("Command Processor", () => {
             });
 
             const commandPrepared = await (processor as any).prepare(null, {});
-            // Empty schema → nothing from the profile should be passed through
-            expect(commandPrepared.args.color).toBeUndefined();
+
+            expect(commandPrepared.args.color).toBe("green");
         });
     });
 });

--- a/packages/imperative/src/cmd/__tests__/CommandProcessor.unit.test.ts
+++ b/packages/imperative/src/cmd/__tests__/CommandProcessor.unit.test.ts
@@ -2819,9 +2819,8 @@ describe("Command Processor", () => {
             });
 
             const commandPrepared = await (processor as any).prepare(null, {});
-            // "editor" is not declared in the banana schema → must be dropped
             expect(commandPrepared.args.editor).toBeUndefined();
-            // "color" is declared in the schema → must still flow through
+
             expect(commandPrepared.args.color).toBe("green");
         });
 

--- a/packages/imperative/src/cmd/src/CommandProcessor.ts
+++ b/packages/imperative/src/cmd/src/CommandProcessor.ts
@@ -960,7 +960,14 @@ export class CommandProcessor {
                     fulfilled.push(profileType);
                     p = this.mConfig.api.profiles.defaultGet(profileType);
                 }
-                fromCnfg = { ...p, ...fromCnfg };
+                // Restrict profile properties to those declared in the profile type's
+                // schema so that an untrusted zowe.config.json cannot inject arbitrary
+                // command options (e.g. "editor") by placing them inside a profile.
+                const allowedProps = this.schemaPropsForProfileType(profileType);
+                const safeP = allowedProps != null
+                    ? Object.fromEntries(Object.entries(p).filter(([k]) => allowedProps.has(k)))
+                    : p;
+                fromCnfg = { ...safeP, ...fromCnfg };
             }
         }
 
@@ -1277,6 +1284,35 @@ export class CommandProcessor {
             response.console.error(`Contact the creator of handler:`);
             response.console.error(`"${handlerPath}"`);
             response.data.setObj(handlerErr);
+        }
+    }
+
+    /**
+     * Returns the set of property names declared in the given profile type's schema so that
+     * only schema-declared fields can be sourced from team-config profiles into command arguments.
+     * Both camelCase and kebab-case variants of every property name are included to match
+     * whichever key convention appears in the config file.
+     * Returns null when the schema is unavailable; the caller falls back to unfiltered behaviour.
+     * @private
+     */
+    private schemaPropsForProfileType(profileType: string): Set<string> | null {
+        try {
+            const manager = this.mProfileManagerFactory.getManager(profileType);
+            const typeConfig = manager.configurations.find(
+                (c) => c.type === profileType
+            ) as ICommandProfileTypeConfiguration | undefined;
+            const schemaProps = typeConfig?.schema?.properties;
+            if (schemaProps == null) {
+                return null;
+            }
+            const propSet = new Set<string>();
+            for (const propName of Object.keys(schemaProps)) {
+                propSet.add(propName);
+                propSet.add(CliUtils.getOptionFormat(propName).kebabCase);
+            }
+            return propSet;
+        } catch (e) {
+            return null;
         }
     }
 }

--- a/packages/imperative/src/cmd/src/CommandProcessor.ts
+++ b/packages/imperative/src/cmd/src/CommandProcessor.ts
@@ -1297,10 +1297,11 @@ export class CommandProcessor {
      */
     private schemaPropsForProfileType(profileType: string): Set<string> | null {
         try {
-            const manager = this.mProfileManagerFactory.getManager(profileType);
-            const typeConfig = manager.configurations.find(
-                (c) => c.type === profileType
-            ) as ICommandProfileTypeConfiguration | undefined;
+            const profiles = ImperativeConfig.instance.loadedConfig?.profiles;
+            if (profiles == null) {
+                return null;
+            }
+            const typeConfig = profiles.find((c) => c.type === profileType);
             const schemaProps = typeConfig?.schema?.properties;
             if (schemaProps == null) {
                 return null;

--- a/packages/imperative/src/cmd/src/CommandProcessor.ts
+++ b/packages/imperative/src/cmd/src/CommandProcessor.ts
@@ -1312,7 +1312,8 @@ export class CommandProcessor {
                 propSet.add(CliUtils.getOptionFormat(propName).kebabCase);
             }
             return propSet;
-        } catch (e) {
+        } catch (err) {
+            this.log.debug(err);
             return null;
         }
     }


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->
Restricts team config profile properties to schema declared fields

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->

**Review Checklist**
I certify that I have:
- [ ] updated the changelog
- [ ] manually tested my changes
- [ ] added/updated automated unit/integration tests
- [ ] created/ran system tests (provide build number if applicable)
- [ ] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
