### PR TITLE
fix(daemon): Add ownership check for Windows named pipes

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to the Zowe CLI package will be documented in this file.
 ## Recent Changes
 
 - BugFix: Censored sensitive connection properties from the diagnostic details serialized into workflow and job submission command errors. [#2784](https://github.com/zowe/zowe-cli/pull/2784)
+- BugFix: Prevented the daemon client from connecting to a Windows named pipe that belongs to a different user. [#2790](https://github.com/zowe/zowe-cli/pull/2790)
 
 ## `8.33.1`
 

--- a/zowex/Cargo.toml
+++ b/zowex/Cargo.toml
@@ -28,7 +28,7 @@ fslock = "0.2.1"
 windows-sys = { version = "0.52.0", features = [
     "Win32_Foundation",
     "Win32_Security",
-    "Win32_Security_Authorization",
+    "Win32_System_Pipes",
     "Win32_System_Threading",
 ] }
 

--- a/zowex/Cargo.toml
+++ b/zowex/Cargo.toml
@@ -25,7 +25,12 @@ yansi = "0.5.1"
 
 [target.'cfg(windows)'.dependencies]
 fslock = "0.2.1"
-windows-sys = "0.52.0"
+windows-sys = { version = "0.52.0", features = [
+    "Win32_Foundation",
+    "Win32_Security",
+    "Win32_Security_Authorization",
+    "Win32_System_Threading",
+] }
 
 [dev-dependencies]
 tokio-test = "0.4.4"

--- a/zowex/src/comm.rs
+++ b/zowex/src/comm.rs
@@ -25,16 +25,15 @@ use std::os::windows::io::AsRawHandle;
 #[cfg(target_family = "windows")]
 use tokio::net::windows::named_pipe::{ClientOptions, NamedPipeClient};
 #[cfg(target_family = "windows")]
-use windows_sys::Win32::Foundation::{CloseHandle, LocalFree, ERROR_PIPE_BUSY, HANDLE, PSID};
+use windows_sys::Win32::Foundation::{CloseHandle, ERROR_PIPE_BUSY, HANDLE};
 #[cfg(target_family = "windows")]
-use windows_sys::Win32::Security::Authorization::{GetSecurityInfo, SE_KERNEL_OBJECT};
+use windows_sys::Win32::Security::{EqualSid, GetTokenInformation, TokenUser, TOKEN_QUERY, TOKEN_USER};
 #[cfg(target_family = "windows")]
-use windows_sys::Win32::Security::{
-    EqualSid, GetTokenInformation, TokenOwner, OWNER_SECURITY_INFORMATION, TOKEN_OWNER,
-    TOKEN_QUERY,
+use windows_sys::Win32::System::Pipes::GetNamedPipeServerProcessId;
+#[cfg(target_family = "windows")]
+use windows_sys::Win32::System::Threading::{
+    GetCurrentProcess, OpenProcess, OpenProcessToken, PROCESS_QUERY_LIMITED_INFORMATION,
 };
-#[cfg(target_family = "windows")]
-use windows_sys::Win32::System::Threading::{GetCurrentProcess, OpenProcessToken};
 
 extern crate base64;
 use base64::prelude::*;
@@ -179,90 +178,112 @@ pub async fn comm_establish_connection(
 }
 
 /**
- * Confirm that the named pipe we just connected to was created by the
- * current Windows user.
+ * Confirm that the named pipe we just connected to is being served by a
+ * process running as the current Windows user.
  *
  * The pipe name is derived from the user name (see util_get_socket_string),
  * so it is guessable by any other local account on a shared host. That
  * account could squat on the pipe name before our real daemon starts,
  * causing us to hand it the command line, environment, stdin, and secure
- * prompt replies that we intend for our own daemon. We compare the pipe's
- * owning SID to the owner SID of our own token (not our user SID, since
- * Windows assigns BUILTIN\Administrators as the default owner of objects
- * created by an account in the local Administrators group), and treat any
- * failure to positively confirm a match as untrusted.
+ * prompt replies that we intend for our own daemon. We identify the process
+ * on the other end of the pipe and compare its user SID to our own user SID
+ * (not the pipe's kernel-object owner, which Windows can default to
+ * BUILTIN\Administrators rather than the actual creating account), and treat
+ * any failure to positively confirm a match as untrusted.
  *
  * @param stream
  *      The already-connected pipe client.
  *
  * @returns
- *      true only if the pipe's owning security principal is the current user.
+ *      true only if the process serving the pipe runs as the current user.
  */
 #[cfg(target_family = "windows")]
 fn windows_pipe_owned_by_current_user(stream: &NamedPipeClient) -> bool {
     unsafe {
         let pipe_handle = stream.as_raw_handle() as HANDLE;
 
-        let mut pipe_owner_sid: PSID = std::ptr::null_mut();
-        let mut unused_group_sid: PSID = std::ptr::null_mut();
-        let mut security_descriptor: *mut core::ffi::c_void = std::ptr::null_mut();
-
-        let sec_info_result = GetSecurityInfo(
-            pipe_handle,
-            SE_KERNEL_OBJECT,
-            OWNER_SECURITY_INFORMATION,
-            &mut pipe_owner_sid,
-            &mut unused_group_sid,
-            std::ptr::null_mut(),
-            std::ptr::null_mut(),
-            &mut security_descriptor,
-        );
-        if sec_info_result != 0 || pipe_owner_sid.is_null() {
-            eprintln!("Warning: Unable to verify the owner of the Zowe daemon pipe.");
+        let mut server_pid: u32 = 0;
+        if GetNamedPipeServerProcessId(pipe_handle, &mut server_pid) == 0 {
+            eprintln!("Warning: Unable to determine the process serving the Zowe daemon pipe.");
             return false;
         }
 
-        let mut current_user_token: HANDLE = 0;
-        if OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &mut current_user_token) == 0 {
-            eprintln!("Warning: Unable to determine the identity of the current user.");
-            LocalFree(security_descriptor as _);
+        let server_process = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, server_pid);
+        if server_process == 0 {
+            eprintln!("Warning: Unable to open the process serving the Zowe daemon pipe.");
             return false;
         }
+        let server_user_sid = windows_process_user_sid(server_process);
+        CloseHandle(server_process);
 
-        let mut token_owner_len: u32 = 0;
-        GetTokenInformation(
-            current_user_token,
-            TokenOwner,
-            std::ptr::null_mut(),
-            0,
-            &mut token_owner_len,
-        );
-        let mut token_owner_buf: Vec<u8> = vec![0; token_owner_len as usize];
-        let got_token_owner = GetTokenInformation(
-            current_user_token,
-            TokenOwner,
-            token_owner_buf.as_mut_ptr() as *mut core::ffi::c_void,
-            token_owner_len,
-            &mut token_owner_len,
-        );
-        CloseHandle(current_user_token);
+        let current_user_sid = windows_process_user_sid(GetCurrentProcess());
 
-        if got_token_owner == 0 || (token_owner_len as usize) < std::mem::size_of::<TOKEN_OWNER>()
-        {
-            eprintln!("Warning: Unable to determine the identity of the current user.");
-            LocalFree(security_descriptor as _);
-            return false;
+        match (server_user_sid, current_user_sid) {
+            (Some(server_user_sid_buf), Some(current_user_sid_buf)) => {
+                // Both TOKEN_USER.User.Sid pointers point into their own
+                // buffer, so both buffers must outlive this EqualSid call.
+                let server_sid =
+                    std::ptr::read_unaligned(server_user_sid_buf.as_ptr() as *const TOKEN_USER)
+                        .User
+                        .Sid;
+                let current_sid =
+                    std::ptr::read_unaligned(current_user_sid_buf.as_ptr() as *const TOKEN_USER)
+                        .User
+                        .Sid;
+                EqualSid(server_sid, current_sid) != 0
+            }
+            _ => {
+                eprintln!("Warning: Unable to verify the owner of the Zowe daemon pipe.");
+                false
+            }
         }
-
-        let token_owner: TOKEN_OWNER =
-            std::ptr::read_unaligned(token_owner_buf.as_ptr() as *const TOKEN_OWNER);
-        let current_user_owner_sid = token_owner.Owner;
-        let owned_by_current_user = EqualSid(pipe_owner_sid, current_user_owner_sid) != 0;
-
-        LocalFree(security_descriptor as _);
-
-        owned_by_current_user
     }
+}
+
+/**
+ * Fetch the raw TOKEN_USER bytes (SID and attributes) for the user running
+ * the given process.
+ *
+ * The returned buffer owns the memory that the contained SID pointer points
+ * into, so it must be kept alive for as long as that SID is used.
+ *
+ * @param process_handle
+ *      A handle to the process whose user identity we want. This may be a
+ *      pseudo-handle, such as the one returned by GetCurrentProcess.
+ *
+ * @returns
+ *      The raw TOKEN_USER buffer on success, or None on any failure.
+ */
+#[cfg(target_family = "windows")]
+unsafe fn windows_process_user_sid(process_handle: HANDLE) -> Option<Vec<u8>> {
+    let mut token_handle: HANDLE = 0;
+    if OpenProcessToken(process_handle, TOKEN_QUERY, &mut token_handle) == 0 {
+        return None;
+    }
+
+    let mut token_user_len: u32 = 0;
+    GetTokenInformation(
+        token_handle,
+        TokenUser,
+        std::ptr::null_mut(),
+        0,
+        &mut token_user_len,
+    );
+    let mut token_user_buf: Vec<u8> = vec![0; token_user_len as usize];
+    let got_token_user = GetTokenInformation(
+        token_handle,
+        TokenUser,
+        token_user_buf.as_mut_ptr() as *mut core::ffi::c_void,
+        token_user_len,
+        &mut token_user_len,
+    );
+    CloseHandle(token_handle);
+
+    if got_token_user == 0 || (token_user_len as usize) < std::mem::size_of::<TOKEN_USER>() {
+        return None;
+    }
+
+    Some(token_user_buf)
 }
 
 /**

--- a/zowex/src/comm.rs
+++ b/zowex/src/comm.rs
@@ -30,7 +30,8 @@ use windows_sys::Win32::Foundation::{CloseHandle, LocalFree, ERROR_PIPE_BUSY, HA
 use windows_sys::Win32::Security::Authorization::{GetSecurityInfo, SE_KERNEL_OBJECT};
 #[cfg(target_family = "windows")]
 use windows_sys::Win32::Security::{
-    EqualSid, GetTokenInformation, TokenUser, OWNER_SECURITY_INFORMATION, TOKEN_QUERY, TOKEN_USER,
+    EqualSid, GetTokenInformation, TokenOwner, OWNER_SECURITY_INFORMATION, TOKEN_OWNER,
+    TOKEN_QUERY,
 };
 #[cfg(target_family = "windows")]
 use windows_sys::Win32::System::Threading::{GetCurrentProcess, OpenProcessToken};
@@ -186,8 +187,10 @@ pub async fn comm_establish_connection(
  * account could squat on the pipe name before our real daemon starts,
  * causing us to hand it the command line, environment, stdin, and secure
  * prompt replies that we intend for our own daemon. We compare the pipe's
- * owning SID to our own, and treat any failure to positively confirm a
- * match as untrusted.
+ * owning SID to the owner SID of our own token (not our user SID, since
+ * Windows assigns BUILTIN\Administrators as the default owner of objects
+ * created by an account in the local Administrators group), and treat any
+ * failure to positively confirm a match as untrusted.
  *
  * @param stream
  *      The already-connected pipe client.
@@ -226,32 +229,35 @@ fn windows_pipe_owned_by_current_user(stream: &NamedPipeClient) -> bool {
             return false;
         }
 
-        let mut token_user_len: u32 = 0;
+        let mut token_owner_len: u32 = 0;
         GetTokenInformation(
             current_user_token,
-            TokenUser,
+            TokenOwner,
             std::ptr::null_mut(),
             0,
-            &mut token_user_len,
+            &mut token_owner_len,
         );
-        let mut token_user_buf: Vec<u8> = vec![0; token_user_len as usize];
-        let got_token_user = GetTokenInformation(
+        let mut token_owner_buf: Vec<u8> = vec![0; token_owner_len as usize];
+        let got_token_owner = GetTokenInformation(
             current_user_token,
-            TokenUser,
-            token_user_buf.as_mut_ptr() as *mut core::ffi::c_void,
-            token_user_len,
-            &mut token_user_len,
+            TokenOwner,
+            token_owner_buf.as_mut_ptr() as *mut core::ffi::c_void,
+            token_owner_len,
+            &mut token_owner_len,
         );
         CloseHandle(current_user_token);
 
-        if got_token_user == 0 {
-            eprintln!("Warning: Unable to read the identity of the current user.");
+        if got_token_owner == 0 || (token_owner_len as usize) < std::mem::size_of::<TOKEN_OWNER>()
+        {
+            eprintln!("Warning: Unable to determine the identity of the current user.");
             LocalFree(security_descriptor as _);
             return false;
         }
 
-        let current_user_sid = (*(token_user_buf.as_ptr() as *const TOKEN_USER)).User.Sid;
-        let owned_by_current_user = EqualSid(pipe_owner_sid, current_user_sid) != 0;
+        let token_owner: TOKEN_OWNER =
+            std::ptr::read_unaligned(token_owner_buf.as_ptr() as *const TOKEN_OWNER);
+        let current_user_owner_sid = token_owner.Owner;
+        let owned_by_current_user = EqualSid(pipe_owner_sid, current_user_owner_sid) != 0;
 
         LocalFree(security_descriptor as _);
 

--- a/zowex/src/comm.rs
+++ b/zowex/src/comm.rs
@@ -91,16 +91,20 @@ pub async fn comm_establish_connection(
                 if windows_pipe_owned_by_current_user(&stream) {
                     break stream;
                 }
-                // A pipe with our daemon's name exists, but it was not created by
-                // the current user. Since the pipe name is predictable, another
-                // local account could have squatted on it before our real daemon
-                // started, in order to capture what we would otherwise send to
-                // it. Drop this connection and keep retrying/starting our own
-                // daemon instead of trusting it.
-                eprintln!(
-                    "Warning: The Zowe daemon pipe at {} is not owned by the current user. Ignoring it.",
-                    daemon_socket
-                );
+                // A pipe with our daemon's name exists, but it is not served by a
+                // process running as the current user. Since the pipe name is
+                // predictable, another local account could have squatted on it
+                // before our real daemon started, in order to capture what we
+                // would otherwise send to it. Drop this connection and keep
+                // retrying/starting our own daemon instead of trusting it. Only
+                // warn once, since this branch is reached on every retry.
+                static WARNED_UNTRUSTED_PIPE: std::sync::Once = std::sync::Once::new();
+                WARNED_UNTRUSTED_PIPE.call_once(|| {
+                    eprintln!(
+                        "Warning: The Zowe daemon pipe at {} does not belong to the current user. Ignoring it.",
+                        daemon_socket
+                    );
+                });
                 drop(stream);
             }
             // Two possible errors when calling ClientOptions::open:
@@ -181,15 +185,15 @@ pub async fn comm_establish_connection(
  * Confirm that the named pipe we just connected to is being served by a
  * process running as the current Windows user.
  *
- * The pipe name is derived from the user name (see util_get_socket_string),
- * so it is guessable by any other local account on a shared host. That
- * account could squat on the pipe name before our real daemon starts,
- * causing us to hand it the command line, environment, stdin, and secure
- * prompt replies that we intend for our own daemon. We identify the process
- * on the other end of the pipe and compare its user SID to our own user SID
- * (not the pipe's kernel-object owner, which Windows can default to
- * BUILTIN\Administrators rather than the actual creating account), and treat
- * any failure to positively confirm a match as untrusted.
+ * The pipe name is derived from the user name by default (see
+ * util_get_socket_string), though it can be overridden via the
+ * ZOWE_DAEMON_PIPE environment variable. The default name is guessable by
+ * any other local account on a shared host, which could squat on it before
+ * our real daemon starts, causing us to hand it the command line,
+ * environment, stdin, and secure prompt replies that we intend for our own
+ * daemon. We identify the process on the other end of the pipe and compare
+ * its user SID to our own, treating any failure to positively confirm a
+ * match as untrusted.
  *
  * @param stream
  *      The already-connected pipe client.

--- a/zowex/src/comm.rs
+++ b/zowex/src/comm.rs
@@ -21,9 +21,19 @@ use tokio::io::AsyncWriteExt;
 use tokio::io::BufReader;
 
 #[cfg(target_family = "windows")]
+use std::os::windows::io::AsRawHandle;
+#[cfg(target_family = "windows")]
 use tokio::net::windows::named_pipe::{ClientOptions, NamedPipeClient};
 #[cfg(target_family = "windows")]
-use windows_sys::Win32::Foundation::ERROR_PIPE_BUSY;
+use windows_sys::Win32::Foundation::{CloseHandle, LocalFree, ERROR_PIPE_BUSY, HANDLE, PSID};
+#[cfg(target_family = "windows")]
+use windows_sys::Win32::Security::Authorization::{GetSecurityInfo, SE_KERNEL_OBJECT};
+#[cfg(target_family = "windows")]
+use windows_sys::Win32::Security::{
+    EqualSid, GetTokenInformation, TokenUser, OWNER_SECURITY_INFORMATION, TOKEN_QUERY, TOKEN_USER,
+};
+#[cfg(target_family = "windows")]
+use windows_sys::Win32::System::Threading::{GetCurrentProcess, OpenProcessToken};
 
 extern crate base64;
 use base64::prelude::*;
@@ -77,7 +87,22 @@ pub async fn comm_establish_connection(
 
         #[cfg(target_family = "windows")]
         match ClientOptions::new().open(daemon_socket) {
-            Ok(stream) => break stream,
+            Ok(stream) => {
+                if windows_pipe_owned_by_current_user(&stream) {
+                    break stream;
+                }
+                // A pipe with our daemon's name exists, but it was not created by
+                // the current user. Since the pipe name is predictable, another
+                // local account could have squatted on it before our real daemon
+                // started, in order to capture what we would otherwise send to
+                // it. Drop this connection and keep retrying/starting our own
+                // daemon instead of trusting it.
+                eprintln!(
+                    "Warning: The Zowe daemon pipe at {} is not owned by the current user. Ignoring it.",
+                    daemon_socket
+                );
+                drop(stream);
+            }
             // Two possible errors when calling ClientOptions::open:
             // https://docs.rs/tokio/latest/tokio/net/windows/named_pipe/struct.ClientOptions.html#method.open
             Err(e)
@@ -150,6 +175,88 @@ pub async fn comm_establish_connection(
     };
 
     Ok(stream)
+}
+
+/**
+ * Confirm that the named pipe we just connected to was created by the
+ * current Windows user.
+ *
+ * The pipe name is derived from the user name (see util_get_socket_string),
+ * so it is guessable by any other local account on a shared host. That
+ * account could squat on the pipe name before our real daemon starts,
+ * causing us to hand it the command line, environment, stdin, and secure
+ * prompt replies that we intend for our own daemon. We compare the pipe's
+ * owning SID to our own, and treat any failure to positively confirm a
+ * match as untrusted.
+ *
+ * @param stream
+ *      The already-connected pipe client.
+ *
+ * @returns
+ *      true only if the pipe's owning security principal is the current user.
+ */
+#[cfg(target_family = "windows")]
+fn windows_pipe_owned_by_current_user(stream: &NamedPipeClient) -> bool {
+    unsafe {
+        let pipe_handle = stream.as_raw_handle() as HANDLE;
+
+        let mut pipe_owner_sid: PSID = std::ptr::null_mut();
+        let mut unused_group_sid: PSID = std::ptr::null_mut();
+        let mut security_descriptor: *mut core::ffi::c_void = std::ptr::null_mut();
+
+        let sec_info_result = GetSecurityInfo(
+            pipe_handle,
+            SE_KERNEL_OBJECT,
+            OWNER_SECURITY_INFORMATION,
+            &mut pipe_owner_sid,
+            &mut unused_group_sid,
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+            &mut security_descriptor,
+        );
+        if sec_info_result != 0 || pipe_owner_sid.is_null() {
+            eprintln!("Warning: Unable to verify the owner of the Zowe daemon pipe.");
+            return false;
+        }
+
+        let mut current_user_token: HANDLE = 0;
+        if OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &mut current_user_token) == 0 {
+            eprintln!("Warning: Unable to determine the identity of the current user.");
+            LocalFree(security_descriptor as _);
+            return false;
+        }
+
+        let mut token_user_len: u32 = 0;
+        GetTokenInformation(
+            current_user_token,
+            TokenUser,
+            std::ptr::null_mut(),
+            0,
+            &mut token_user_len,
+        );
+        let mut token_user_buf: Vec<u8> = vec![0; token_user_len as usize];
+        let got_token_user = GetTokenInformation(
+            current_user_token,
+            TokenUser,
+            token_user_buf.as_mut_ptr() as *mut core::ffi::c_void,
+            token_user_len,
+            &mut token_user_len,
+        );
+        CloseHandle(current_user_token);
+
+        if got_token_user == 0 {
+            eprintln!("Warning: Unable to read the identity of the current user.");
+            LocalFree(security_descriptor as _);
+            return false;
+        }
+
+        let current_user_sid = (*(token_user_buf.as_ptr() as *const TOKEN_USER)).User.Sid;
+        let owned_by_current_user = EqualSid(pipe_owner_sid, current_user_sid) != 0;
+
+        LocalFree(security_descriptor as _);
+
+        owned_by_current_user
+    }
 }
 
 /**


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->
Refuses to connect to a pipe that exists with the same name as Zowe daemon but belongs to a different user account.

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->
Test that you can issue commands with daemon mode enabled on Windows.

Also see that integration tests which use daemon mode are passing for Windows CI after the changes 😋 

**Review Checklist**
I certify that I have:
- [ ] updated the changelog
- [ ] manually tested my changes
- [ ] added/updated automated unit/integration tests
- [ ] created/ran system tests (provide build number if applicable)
- [ ] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
