### PR TITLE
fix(v2): redact sensitive environment vars and CLI args

### DIFF
--- a/packages/imperative/CHANGELOG.md
+++ b/packages/imperative/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the Imperative package will be documented in this file.
 
 ## Recent Changes
 
-- BugFix: Redacted sensitive environment variables and command-line arguments from the diagnostic information written to the log when a command handler fails to load or throws an error, preventing credentials supplied via environment variables (for example, `ZOWE_OPT_PASSWORD`) from being persisted to disk in plain text. [#2791](https://github.com/zowe/zowe-cli/pull/2791)
+- BugFix: Redacted sensitive environment variables and command-line arguments from the diagnostic information written to the log when a command handler fails to load or throws an error. This prevents credentials supplied via environment variables (for example, `ZOWE_OPT_PASSWORD`) from being persisted to disk in plain text. [#2791](https://github.com/zowe/zowe-cli/pull/2791)
 
 ## `5.27.20`
 

--- a/packages/imperative/CHANGELOG.md
+++ b/packages/imperative/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the Imperative package will be documented in this file.
 
 ## Recent Changes
 
-- BugFix: Redacted sensitive environment variables and command-line arguments from the diagnostic information written to the log when a command handler fails to load or throws an error, preventing credentials supplied via environment variables (for example, `ZOWE_OPT_PASSWORD`) from being persisted to disk in plain text. [#2788](https://github.com/zowe/zowe-cli/pull/2788)
+- BugFix: Redacted sensitive environment variables and command-line arguments from the diagnostic information written to the log when a command handler fails to load or throws an error, preventing credentials supplied via environment variables (for example, `ZOWE_OPT_PASSWORD`) from being persisted to disk in plain text. [#2791](https://github.com/zowe/zowe-cli/pull/2791)
 
 ## `5.27.20`
 

--- a/packages/imperative/CHANGELOG.md
+++ b/packages/imperative/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Imperative package will be documented in this file.
 
+## Recent Changes
+
+- BugFix: Redacted sensitive environment variables and command-line arguments from the diagnostic information written to the log when a command handler fails to load or throws an error, preventing credentials supplied via environment variables (for example, `ZOWE_OPT_PASSWORD`) from being persisted to disk in plain text. [#2788](https://github.com/zowe/zowe-cli/pull/2788)
+
 ## `5.27.20`
 
 - BugFix: Masked sensitive command-line options that are supplied in the equals-separated form (for example, `--user=example` or `-u=example`) before the command line is written to the log, and also mask secure values that contain embedded whitespace. [#2782](https://github.com/zowe/zowe-cli/pull/2782)

--- a/packages/imperative/src/cmd/__tests__/CommandProcessor.unit.test.ts
+++ b/packages/imperative/src/cmd/__tests__/CommandProcessor.unit.test.ts
@@ -1216,6 +1216,120 @@ describe("Command Processor", () => {
         expect(stringifiedError).toContain("handler");
     });
 
+    it("should redact sensitive environment variables from the handler-error diagnostic log", async () => {
+        // Allocate the command processor
+        const processor: CommandProcessor = new CommandProcessor({
+            envVariablePrefix: ENV_VAR_PREFIX,
+            fullDefinition: SAMPLE_COMPLEX_COMMAND,
+            definition: SAMPLE_COMMAND_REAL_HANDLER,
+            helpGenerator: FAKE_HELP_GENERATOR,
+            profileManagerFactory: FAKE_PROFILE_MANAGER_FACTORY,
+            rootCommandName: SAMPLE_ROOT_COMMAND,
+            commandLine: "",
+            promptPhrase: "dummydummy"
+        });
+
+        // Mock read stdin
+        (SharedOptions.readStdinIfRequested as any) = jest.fn((args, response, type) => {
+            // Nothing to do
+        });
+
+        // Mock the profile loader
+        (CommandProfileLoader.loader as any) = jest.fn((args) => {
+            return { loadProfiles: (profArgs: any) => { /* Nothing to do */ } };
+        });
+
+        // Capture everything written at ERROR level (the diagnostic block uses printf-style args)
+        let errorOutput = "";
+        const mockLogError = jest.fn((...args) => { errorOutput += args.join(" ") + "\n"; });
+        Object.defineProperty(processor, "log", {
+            get: () => ({ debug: jest.fn(), error: mockLogError, info: jest.fn(), trace: jest.fn() })
+        });
+
+        process.env.ZOWE_OPT_PASSWORD = "superSecretPwd";
+        process.env.MY_DIAG_TEST_HOST = "visibleHostValue";
+        // Inject an equals-form credential into argv to prove the diagnostic argv line is censored too
+        const originalArgv = process.argv;
+        process.argv = [...process.argv, "--password=argvSecretPwd"];
+        try {
+            const parms: any = {
+                arguments: { _: ["check", "for", "banana"], $0: "", valid: true, throwImperative: true },
+                responseFormat: "json",
+                silent: true
+            };
+            await processor.invoke(parms);
+
+            expect(errorOutput).toContain("Environmental variables:");
+            // Sensitive env value must be redacted; non-sensitive value preserved
+            expect(errorOutput).not.toContain("superSecretPwd");
+            expect(errorOutput).toContain(LoggerUtils.CENSOR_RESPONSE);
+            expect(errorOutput).toContain("visibleHostValue");
+            // Equals-form credential in argv must be redacted (via censorCommandLine)
+            expect(errorOutput).not.toContain("argvSecretPwd");
+            expect(errorOutput).toContain(`--password ${LoggerUtils.CENSOR_RESPONSE}`);
+        } finally {
+            process.argv = originalArgv;
+            delete process.env.ZOWE_OPT_PASSWORD;
+            delete process.env.MY_DIAG_TEST_HOST;
+        }
+    });
+
+    it("should redact sensitive environment variables from the handler-load-failure diagnostic log", async () => {
+        // SAMPLE_COMMAND_DEFINITION points at a non-existent handler, exercising attemptHandlerLoad's error path
+        const processor: CommandProcessor = new CommandProcessor({
+            envVariablePrefix: ENV_VAR_PREFIX,
+            fullDefinition: SAMPLE_COMPLEX_COMMAND,
+            definition: SAMPLE_COMMAND_DEFINITION,
+            helpGenerator: FAKE_HELP_GENERATOR,
+            profileManagerFactory: FAKE_PROFILE_MANAGER_FACTORY,
+            rootCommandName: SAMPLE_ROOT_COMMAND,
+            commandLine: "",
+            promptPhrase: "dummydummy"
+        });
+
+        // Mock read stdin
+        (SharedOptions.readStdinIfRequested as any) = jest.fn((args, response, type) => {
+            // Nothing to do
+        });
+
+        // Mock the profile loader
+        (CommandProfileLoader.loader as any) = jest.fn((args) => {
+            return { loadProfiles: (profArgs: any) => { /* Nothing to do */ } };
+        });
+
+        let errorOutput = "";
+        const mockLogError = jest.fn((...args) => { errorOutput += args.join(" ") + "\n"; });
+        Object.defineProperty(processor, "log", {
+            get: () => ({ debug: jest.fn(), error: mockLogError, info: jest.fn(), trace: jest.fn() })
+        });
+
+        process.env.AWS_SECRET_ACCESS_KEY = "awsSuperSecret";
+        process.env.MY_DIAG_TEST_PORT = "visiblePortValue";
+        // Inject an equals-form credential into argv to prove the diagnostic argv line is censored too
+        const originalArgv = process.argv;
+        process.argv = [...process.argv, "--token-value=argvSecretToken"];
+        try {
+            const parms: any = {
+                arguments: { _: ["check", "for", "banana"], $0: "", valid: true },
+                responseFormat: "json",
+                silent: true
+            };
+            await processor.invoke(parms);
+
+            expect(errorOutput).toContain("Environmental variables:");
+            expect(errorOutput).not.toContain("awsSuperSecret");
+            expect(errorOutput).toContain(LoggerUtils.CENSOR_RESPONSE);
+            expect(errorOutput).toContain("visiblePortValue");
+            // Equals-form credential in argv must be redacted (via censorCommandLine)
+            expect(errorOutput).not.toContain("argvSecretToken");
+            expect(errorOutput).toContain(`--token-value ${LoggerUtils.CENSOR_RESPONSE}`);
+        } finally {
+            process.argv = originalArgv;
+            delete process.env.AWS_SECRET_ACCESS_KEY;
+            delete process.env.MY_DIAG_TEST_PORT;
+        }
+    });
+
     it("should not strip tabs from the imperative error message", async () => {
         // Allocate the command processor
         const processor: CommandProcessor = new CommandProcessor({

--- a/packages/imperative/src/cmd/src/CommandProcessor.ts
+++ b/packages/imperative/src/cmd/src/CommandProcessor.ts
@@ -1104,8 +1104,8 @@ export class CommandProcessor {
             this.log.error("Diagnostic information:\n" +
                 "Platform: '%s', Architecture: '%s', Process.argv: '%s'\n" +
                 "Environmental variables: '%s'",
-            os.platform(), os.arch(), process.argv.join(" "),
-            JSON.stringify(process.env, null, 2));
+            os.platform(), os.arch(), LoggerUtils.censorCommandLine(process.argv.join(" ")),
+            LoggerUtils.censorEnvVariables());
             const errorMessage: string = TextUtils.formatMessage(couldNotInstantiateCommandHandler.message, {
                 commandHandler: nodePath.normalize(handlerPath) || "\"undefined or not specified\"",
                 definitionName: this.definition.name
@@ -1172,9 +1172,9 @@ export class CommandProcessor {
             "Platform: '%s', Architecture: '%s', Process.argv: '%s'\n" +
             "Node versions: '%s'" +
             "Environmental variables: '%s'",
-        os.platform(), os.arch(), process.argv.join(" "),
+        os.platform(), os.arch(), LoggerUtils.censorCommandLine(process.argv.join(" ")),
         JSON.stringify(process.versions, null, 2),
-        JSON.stringify(process.env, null, 2));
+        LoggerUtils.censorEnvVariables());
 
         // If this is an instance of an imperative error, then we are good to go and can formulate the response.
         // If it is an Error object, then something truly unexpected occurred in the handler.

--- a/packages/imperative/src/logger/__tests__/LoggerUtils.unit.test.ts
+++ b/packages/imperative/src/logger/__tests__/LoggerUtils.unit.test.ts
@@ -188,4 +188,67 @@ describe("LoggerUtils tests", () => {
             });
         });
     });
+
+    describe("isSecureEnvName", () => {
+        for (const name of ["ZOWE_OPT_PASSWORD", "ZOWE_OPT_TOKEN_VALUE", "ZOWE_OPT_CERT_FILE_PASSPHRASE",
+            "AWS_SECRET_ACCESS_KEY", "GITHUB_TOKEN", "MY_API_CREDENTIAL", "SOME_AUTH_HEADER", "private_key"]) {
+            it(`should identify "${name}" as sensitive`, () => {
+                expect(LoggerUtils.isSecureEnvName(name)).toBe(true);
+            });
+        }
+
+        for (const name of ["PATH", "HOME", "PWD", "ZOWE_OPT_HOST", "ZOWE_OPT_PORT", "ZOWE_OPT_USER", "LANG", "SHELL"]) {
+            it(`should not identify "${name}" as sensitive`, () => {
+                expect(LoggerUtils.isSecureEnvName(name)).toBe(false);
+            });
+        }
+
+        it("should not throw on a null or undefined name", () => {
+            expect(LoggerUtils.isSecureEnvName(null)).toBe(false);
+            expect(LoggerUtils.isSecureEnvName(undefined)).toBe(false);
+        });
+    });
+
+    describe("censorEnvVariables", () => {
+        beforeEach(() => {
+            jest.restoreAllMocks();
+            // Default: no usable config, so only name-based redaction applies
+            jest.spyOn(ImperativeConfig, "instance", "get").mockReturnValue({ config: { exists: false } } as any);
+        });
+
+        it("should redact env vars whose names match a credential pattern", () => {
+            const env = {
+                ZOWE_OPT_PASSWORD: "superSecret",
+                ZOWE_OPT_TOKEN_VALUE: "myToken",
+                AWS_SECRET_ACCESS_KEY: "awsSecret",
+                GITHUB_TOKEN: "ghToken"
+            } as any;
+            const received = JSON.parse(LoggerUtils.censorEnvVariables(env));
+            expect(received.ZOWE_OPT_PASSWORD).toEqual(LoggerUtils.CENSOR_RESPONSE);
+            expect(received.ZOWE_OPT_TOKEN_VALUE).toEqual(LoggerUtils.CENSOR_RESPONSE);
+            expect(received.AWS_SECRET_ACCESS_KEY).toEqual(LoggerUtils.CENSOR_RESPONSE);
+            expect(received.GITHUB_TOKEN).toEqual(LoggerUtils.CENSOR_RESPONSE);
+        });
+
+        it("should preserve env vars whose names are not sensitive", () => {
+            const env = { PATH: "/usr/bin", ZOWE_OPT_HOST: "example.com", ZOWE_OPT_PORT: "443" } as any;
+            const received = JSON.parse(LoggerUtils.censorEnvVariables(env));
+            expect(received.PATH).toEqual("/usr/bin");
+            expect(received.ZOWE_OPT_HOST).toEqual("example.com");
+            expect(received.ZOWE_OPT_PORT).toEqual("443");
+        });
+
+        it("should default to process.env when no environment is supplied", () => {
+            process.env.CENSOR_UNIT_TEST_PASSWORD = "shouldBeHidden";
+            process.env.CENSOR_UNIT_TEST_HOST = "shouldBeVisible";
+            try {
+                const received = JSON.parse(LoggerUtils.censorEnvVariables());
+                expect(received.CENSOR_UNIT_TEST_PASSWORD).toEqual(LoggerUtils.CENSOR_RESPONSE);
+                expect(received.CENSOR_UNIT_TEST_HOST).toEqual("shouldBeVisible");
+            } finally {
+                delete process.env.CENSOR_UNIT_TEST_PASSWORD;
+                delete process.env.CENSOR_UNIT_TEST_HOST;
+            }
+        });
+    });
 });

--- a/packages/imperative/src/logger/src/LoggerUtils.ts
+++ b/packages/imperative/src/logger/src/LoggerUtils.ts
@@ -43,6 +43,15 @@ export class LoggerUtils {
         "password", "pass", "pw", "token-value", "tokenValue", "tv",
         "cert-key-file", "certKeyFile", "cert-file-passphrase", "certFilePassphrase"];
 
+    /*
+    * Environment-variable NAME patterns that indicate a sensitive value.
+    * Environment variables never pass through the CLI-argument censoring path, so their values must be redacted by
+    * name before the environment is serialized into diagnostic output. This catches both the credential env vars that
+    * Zowe explicitly supports (e.g. ZOWE_OPT_PASSWORD, ZOWE_OPT_TOKEN_VALUE) and unrelated secrets that commonly
+    * share the same environment (e.g. AWS_SECRET_ACCESS_KEY, GITHUB_TOKEN).
+    */
+    private static readonly SECURE_ENV_NAME_PATTERN = /PASS|TOKEN|SECRET|KEY|CRED|AUTH/i;
+
     /**
      * Copy and censor any sensitive CLI arguments before logging/printing
      * @param {string[]} args
@@ -248,5 +257,35 @@ export class LoggerUtils {
                 newData = newData.replace(new RegExp(sec, "gi"), LoggerUtils.CENSOR_RESPONSE);
         }
         return newData;
+    }
+
+    /**
+     * Determine whether an environment-variable name indicates a sensitive value.
+     * @param {string} name - the environment-variable name to test
+     * @returns {boolean} - True if the variable should be redacted; False otherwise
+     */
+    public static isSecureEnvName(name: string): boolean {
+        return name != null && LoggerUtils.SECURE_ENV_NAME_PATTERN.test(name);
+    }
+
+    /**
+     * Copy and censor environment variables before logging/printing.
+     *
+     * Environment variables frequently hold credentials - Zowe explicitly supports supplying secure option values
+     * this way (e.g. ZOWE_OPT_PASSWORD, ZOWE_OPT_TOKEN_VALUE), and unrelated secrets (AWS_SECRET_ACCESS_KEY,
+     * GITHUB_TOKEN, etc.) commonly share the same environment. Because these values never pass through the
+     * CLI-argument censoring path, every variable whose name matches a credential pattern is redacted here. The
+     * serialized result is additionally routed through {@link LoggerUtils.censorRawData} so that any config-derived
+     * secure values are masked as well.
+     *
+     * @param {NodeJS.ProcessEnv} env - the environment to censor (defaults to process.env)
+     * @returns {string} - a censored, pretty-printed JSON string of the environment
+     */
+    public static censorEnvVariables(env: NodeJS.ProcessEnv = process.env): string {
+        const censored: Record<string, string> = {};
+        for (const [name, value] of Object.entries(env)) {
+            censored[name] = LoggerUtils.isSecureEnvName(name) ? LoggerUtils.CENSOR_RESPONSE : value;
+        }
+        return LoggerUtils.censorRawData(JSON.stringify(censored, null, 2));
     }
 }


### PR DESCRIPTION
**What It Does**

v2 port of #2788 

**How to Test**

- Run a command with input that causes an error to be thrown (or a bad command handler - harder to repro)
- Notice that any credentials supplied via env. vars are redacted in the log

**Review Checklist**
I certify that I have:
- [x] updated the changelog
- [x] manually tested my changes
- [x] added/updated automated unit/integration tests
- [x] created/ran system tests (job number 2418)
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)