### PR TITLE
Normalize the Windows project directory to its real path

### DIFF
--- a/packages/imperative/CHANGELOG.md
+++ b/packages/imperative/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to the Imperative package will be documented in this file.
 
 ## Recent Changes
 
+- BugFix: Fixed an issue on Windows where running a command from the same directory with different casing, such as `ops` in CMD and `OPS` in Git Bash, stored a separate set of credentials in the secure credential store for each. The project directory is now resolved to its real path, so one directory has one set of credentials. [#2604](https://github.com/zowe/zowe-cli/issues/2604)
 - BugFix: Fixed an issue where passing an object with `null` values to the `Censor.mCensorObject` function caused a runtime error. Now, only non-null values are recursively handled in this function. [#2784](https://github.com/zowe/zowe-cli/pull/2784)
 
 ## `8.33.2`

--- a/packages/imperative/src/config/__tests__/Config.unit.test.ts
+++ b/packages/imperative/src/config/__tests__/Config.unit.test.ts
@@ -918,6 +918,59 @@ describe("Config tests", () => {
             Object.defineProperty(process, 'platform', { value: os.platform(), configurable: true });
         });
 
+        it("should normalize the current working directory on Windows when projectDir is not supplied", async () => {
+            // Regression test for #2604. Windows paths are case insensitive, so `chdir ops` and
+            // `cd OPS` land in the same directory but `process.cwd()` reports the casing that was
+            // typed. The project directory becomes the layer path, which is the secure credential
+            // store key, so an unnormalized cwd produces a second vault entry for one directory.
+            Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+
+            const typedCwd = "C:\\users\\test\\OPS";
+            const realCwd = "C:\\users\\test\\ops";
+            jest.spyOn(process, "cwd").mockReturnValue(typedCwd);
+            const realPathSpy = jest.spyOn(fs.realpathSync, "native").mockReturnValue(realCwd as any);
+
+            const config = new (Config as any)();
+            config.mApp = MY_APP;
+            config.mLayers = [];
+
+            jest.spyOn(ConfigLayers.prototype, "read").mockImplementation(() => {});
+            jest.spyOn(ConfigSecure.prototype, "load").mockResolvedValue(undefined);
+
+            await config.reload();
+
+            expect(realPathSpy).toHaveBeenCalledWith(typedCwd);
+            expect(config.mProjectDir).toBe(realCwd);
+
+            Object.defineProperty(process, 'platform', { value: os.platform(), configurable: true });
+        });
+
+        it("should keep the directory as-is on Windows when it cannot be resolved", async () => {
+            // A directory that does not exist yet, such as the home directory on a first run,
+            // must not cause reload to throw.
+            Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+
+            const missingDir = "C:\\users\\test\\does-not-exist";
+            jest.spyOn(fs.realpathSync, "native").mockImplementation(() => {
+                const err: NodeJS.ErrnoException = new Error("ENOENT");
+                err.code = "ENOENT";
+                throw err;
+            });
+
+            const config = new (Config as any)();
+            config.mApp = MY_APP;
+            config.mLayers = [];
+
+            jest.spyOn(ConfigLayers.prototype, "read").mockImplementation(() => {});
+            jest.spyOn(ConfigSecure.prototype, "load").mockResolvedValue(undefined);
+
+            await config.reload({ projectDir: missingDir });
+
+            expect(config.mProjectDir).toBe(missingDir);
+
+            Object.defineProperty(process, 'platform', { value: os.platform(), configurable: true });
+        });
+
         it("should NOT normalize projectDir if not on Windows", async () => {
             Object.defineProperty(process, 'platform', { value: 'darwin', configurable: true });
             const testPath = "/home/user/project";

--- a/packages/imperative/src/config/src/Config.ts
+++ b/packages/imperative/src/config/src/Config.ts
@@ -183,20 +183,22 @@ export class Config {
      * @throws An ImperativeError if the configuration does not load successfully
      */
     public async reload(opts?: IConfigOpts) {
-        // Normalize projectDir and homeDir for Windows before loading the config
-        if (process.platform === 'win32') {
-            if(opts?.projectDir) {
-                opts.projectDir = fs.realpathSync.native(opts.projectDir);
-            }
-            if(opts?.homeDir) {
-                opts.homeDir = fs.realpathSync.native(opts.homeDir);
-            }
-        }
-
         this.mLayers = [];
         this.mEnvVarManaged = [];
         this.mHomeDir = opts?.homeDir ?? this.mHomeDir ?? path.join(os.homedir(), `.${this.mApp}`);
         this.mProjectDir = opts?.projectDir ?? process.cwd();
+
+        // Normalize after the directories have been resolved, not just when they were passed in
+        // through `opts`. Windows paths are case insensitive, so `chdir ops` and `cd OPS` reach the
+        // same directory but report differently from `process.cwd()`. The project directory ends up
+        // in the layer path, which is the key the secure credential store is written under, so
+        // without this the same directory produces two separate vault entries.
+        if (typeof this.mHomeDir === "string") {
+            this.mHomeDir = Config.normalizePath(this.mHomeDir);
+        }
+        if (typeof this.mProjectDir === "string") {
+            this.mProjectDir = Config.normalizePath(this.mProjectDir);
+        }
 
         // Populate configuration file layers
         for (const layer of [
@@ -298,6 +300,26 @@ export class Config {
      * @internal
      * @param layer Enum value for config layer
      */
+    /**
+     * Resolve a directory to its real, canonically cased path on Windows.
+     *
+     * Returns the path unchanged on other platforms, and also when it cannot be resolved, which
+     * happens legitimately for a directory that does not exist yet, such as the home directory on
+     * a first run.
+     * @param dir The directory to normalize
+     * @returns The normalized directory
+     */
+    private static normalizePath(dir: string): string {
+        if (process.platform !== "win32") {
+            return dir;
+        }
+        try {
+            return fs.realpathSync.native(dir);
+        } catch (_err) {
+            return dir;
+        }
+    }
+
     private layerPath(layer: Layers): string {
         switch (layer) {
             case Layers.ProjectUser: {


### PR DESCRIPTION
**What It Does**

Fixes #2604.

Windows paths are case insensitive, so `chdir ops` in CMD and `cd OPS` in Git Bash land in the same directory, but `process.cwd()` reports back whatever casing was typed. That value becomes `mProjectDir`, which `layerPath()` turns into the layer path, which in turn is the key the secure credential store is written under. So one real directory ends up with two vault entries, which is what the issue reports.

`Config.reload` already normalized paths on Windows, but only when they were passed in through `opts`:

```ts
if (process.platform === 'win32') {
    if (opts?.projectDir) {
        opts.projectDir = fs.realpathSync.native(opts.projectDir);
    }
    ...
}
...
this.mProjectDir = opts?.projectDir ?? process.cwd();
```

The ordinary CLI invocation doesn't pass `projectDir`, so it falls through to the un-normalized `process.cwd()` and the normalization never runs for the case that actually triggers the bug.

This moves the normalization to after the directories are resolved, so it covers both the explicit and the `process.cwd()` paths.

`realpathSync.native` throws for a path that doesn't exist, which is legitimate for the home directory on a first run, so the helper returns the path unchanged in that case rather than letting `reload` fail.

**How to Test**

Unit: `npx jest packages/imperative/src/config/__tests__/Config.unit.test.ts`

Added two tests:
- "should normalize the current working directory on Windows when projectDir is not supplied" is the regression test. It fails on `master` (`Expected: "C:\users\test\OPS"`, i.e. the raw cwd is used) and passes with this change.
- "should keep the directory as-is on Windows when it cannot be resolved" covers the non-existent directory case, so a first run can't start throwing.

The two existing normalization tests are unchanged and still pass.

End to end on Windows, as in the issue: `mkdir ops`, `chdir ops`, `zowe config secure`, then from Git Bash `cd OPS`, `zowe config secure`. Before this change the vault gains a second entry keyed on the upper-case path; after it, both resolve to the same entry.

**Review Checklist**
I certify that I have:
- [x] updated the changelog
- [x] manually tested my changes
- [x] added/updated automated unit/integration tests
- [ ] created/ran system tests (provide build number if applicable)
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)

**Additional Comments**

I did not run the z/OS system tests, since they need a live mainframe connection I don't have. This change is confined to local path handling in `packages/imperative` with no mainframe interaction.

Verified on Windows 11 (Node 22), which is the platform the bug is specific to: the `Config` suite is 66 passed / 9 snapshots, the whole config package is 424 passed across 12 suites, and `npm run lint` is clean.

One note on scope: this normalizes the directory used for the layer path, so credentials saved *before* this change under a differently cased path won't be found afterwards. That is the same as any other change of the vault key, and it self-corrects the next time the user runs `zowe config secure`. Happy to add a migration or a warning if you'd rather handle that explicitly.
