### PR TITLE
Strip color escape sequences from the JSON response

### DIFF
--- a/packages/imperative/CHANGELOG.md
+++ b/packages/imperative/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to the Imperative package will be documented in this file.
 
 ## Recent Changes
 
+- BugFix: Fixed an issue where color escape sequences appeared inside the output of commands run with `--response-format-json`, so tools consuming that JSON read the escape codes back as part of the text. [#2615](https://github.com/zowe/zowe-cli/issues/2615)
 - BugFix: Fixed an issue where passing an object with `null` values to the `Censor.mCensorObject` function caused a runtime error. Now, only non-null values are recursively handled in this function. [#2784](https://github.com/zowe/zowe-cli/pull/2784)
 
 ## `8.33.2`

--- a/packages/imperative/src/cmd/__tests__/response/CommandResponse.unit.test.ts
+++ b/packages/imperative/src/cmd/__tests__/response/CommandResponse.unit.test.ts
@@ -1026,6 +1026,32 @@ describe("Command Response", () => {
         expect(response.buildJsonResponse()).toMatchSnapshot();
     });
 
+    it("should strip ANSI color codes from the JSON response", () => {
+        // Regression test for #2615. Console output is colorized for a terminal, and those buffers
+        // are what writeJsonResponse serializes, so without stripping, the escape sequences survive
+        // into the JSON string values and anything parsing --response-format-json reads them back
+        // as part of the text. The escapes are written directly here rather than produced by chalk,
+        // which this suite mocks.
+        const ESC = String.fromCharCode(27);
+        const red = `${ESC}[31m`;
+        const reset = `${ESC}[39m`;
+
+        const response = new CommandResponse({ responseFormat: "json", silent: true });
+        response.console.error(`${red}Syntax Error:${reset} something went wrong`);
+        response.console.log(`${red}All done${reset}`);
+        response.data.setMessage(`${red}finished${reset}`);
+
+        const json = response.writeJsonResponse();
+
+        expect(json.stderr.toString()).not.toContain(ESC);
+        expect(json.stdout.toString()).not.toContain(ESC);
+        expect(json.message).not.toContain(ESC);
+
+        expect(json.stderr.toString()).toContain("Syntax Error: something went wrong");
+        expect(json.stdout.toString()).toContain("All done");
+        expect(json.message).toBe("finished");
+    });
+
     describe("format APIs", () => {
         describe("error checking", () => {
             it("should detect missing parameters", () => {

--- a/packages/imperative/src/cmd/src/response/CommandResponse.ts
+++ b/packages/imperative/src/cmd/src/response/CommandResponse.ts
@@ -21,6 +21,7 @@ import { IHandlerProgressApi } from "../doc/response/api/handler/IHandlerProgres
 import { IProgressBarParms } from "../doc/response/parms/IProgressBarParms";
 import { Constants } from "../../../constants";
 import { ImperativeExpect } from "../../../expect";
+import stripAnsi = require("strip-ansi");
 import { IHandlerFormatOutputApi } from "../doc/response/api/handler/IHandlerFormatOutputApi";
 import { ICommandOutputFormat, OUTPUT_FORMAT } from "../doc/response/response/ICommandOutputFormat";
 import { Arguments } from "yargs";
@@ -952,9 +953,12 @@ export class CommandResponse implements ICommandResponseApi {
         let response: ICommandResponse;
         try {
             response = this.buildJsonResponse();
-            (response.stderr as any) = response.stderr.toString();
-            (response.stdout as any) = response.stdout.toString();
-            response.message = Censor.censorRawData(response.message, "json");
+            // Console output is colorized for a terminal, and those buffers are what get
+            // serialized here. Left alone, the ANSI escapes survive into the JSON string values,
+            // so anything consuming `--response-format-json` reads them back as part of the text.
+            (response.stderr as any) = stripAnsi(response.stderr.toString());
+            (response.stdout as any) = stripAnsi(response.stdout.toString());
+            response.message = stripAnsi(Censor.censorRawData(response.message, "json"));
             response.data =  response.data ? JSON.parse(Censor.censorRawData(JSON.stringify(response.data), "json")) : undefined;
             response.error = response.error ? JSON.parse(Censor.censorRawData(JSON.stringify(response.error), "json")) : undefined;
 


### PR DESCRIPTION
**What It Does**

Fixes #2615.

Console output is colorized for a terminal, and those same buffers are what `writeJsonResponse` serializes. Nothing strips the escape sequences on the way, so they survive into the JSON string values:

```
"stderr": "[31mSyntax Error:[39m something went wrong\n"
```

The document is still valid JSON, so this doesn't fail a parser, which is probably why it went unnoticed. But anything consuming `--response-format-json` reads the colour codes back as part of the text, so they end up in logs, comparisons and anything rendering the value.

This strips ANSI from `stdout`, `stderr` and `message` in `writeJsonResponse`, which is the point where the response is serialized for JSON output. `buildJsonResponse` is left alone, since its other callers deal with the in-process response object rather than the JSON text.

`strip-ansi` is already a dependency of `@zowe/imperative` and is already used elsewhere in the package (`DefaultHelpGenerator`, `ConvertV1Profiles`), so this adds an import rather than a dependency.

**How to Test**

Unit: `npx jest packages/imperative/src/cmd/__tests__/response/CommandResponse.unit.test.ts`

Added "should strip ANSI color codes from the JSON response". It fails on `master`, where `stderr` comes back as `[31mSyntax Error:[39m something went wrong`, and passes with this change.

The test writes the escape sequences directly rather than producing them through chalk, because this suite calls `jest.mock("chalk")`, so a chalk-driven test would pass vacuously whether or not the fix is present. Writing the escapes explicitly tests the stripping itself and is independent of whether the process has a TTY.

End to end: run any failing command with `--response-format-json` from a terminal where colour is enabled (or with `FORCE_COLOR=1`) and pipe it through a JSON consumer. Before this change the `stderr` value carries the escape codes; after it, it is plain text.

**Review Checklist**
I certify that I have:
- [x] updated the changelog
- [x] manually tested my changes
- [x] added/updated automated unit/integration tests
- [ ] created/ran system tests (provide build number if applicable)
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)

**Additional Comments**

I did not run the z/OS system tests, since they need a live mainframe connection I don't have. This change is confined to how the response is serialized in `packages/imperative`, with no mainframe interaction.

Verified on Windows 11 (Node 22): the `cmd` package is 303 passed across 14 suites with 276 snapshots, and `npm run lint` is clean.

One scoping question for maintainers: I limited this to `stdout`, `stderr` and `message`, which are the buffers the console APIs colorize. `error` and `data` can in principle carry colorized strings too if a handler puts them there deliberately, but stripping those felt like it could destroy data a caller meant to keep, so I left them. Happy to widen it if you'd prefer.
