### PR TITLE
refactor: improve censor mask to cover regex metacharacters

### DIFF
--- a/packages/imperative/CHANGELOG.md
+++ b/packages/imperative/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to the Imperative package will be documented in this file.
 
 ## Recent Changes
 
+- BugFix: Escaped regular-expression metacharacters in secure values before masking them in the `Censor.censorRawData` function. [#2788](https://github.com/zowe/zowe-cli/pull/2788)
 - BugFix: Redacted sensitive environment variables and command-line arguments from the diagnostic information written to the log when a command handler fails to load or throws an error. This prevents credentials supplied via environment variables (for example, `ZOWE_OPT_PASSWORD`) from being persisted to disk in plain text. [#2788](https://github.com/zowe/zowe-cli/pull/2788)
 - BugFix: Fixed an issue where passing an object with `null` values to the `Censor.mCensorObject` function caused a runtime error. Now, only non-null values are recursively handled in this function. [#2784](https://github.com/zowe/zowe-cli/pull/2784)
 

--- a/packages/imperative/CHANGELOG.md
+++ b/packages/imperative/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the Imperative package will be documented in this file.
 
 ## Recent Changes
 
-- BugFix: Escaped regular-expression metacharacters in secure values before masking them in the `Censor.censorRawData` function. [#2788](https://github.com/zowe/zowe-cli/pull/2788)
+- BugFix: Escaped regular-expression metacharacters in secure values before masking them in the `Censor.censorRawData` function. [#2799](https://github.com/zowe/zowe-cli/pull/2799)
 - BugFix: Redacted sensitive environment variables and command-line arguments from the diagnostic information written to the log when a command handler fails to load or throws an error. This prevents credentials supplied via environment variables (for example, `ZOWE_OPT_PASSWORD`) from being persisted to disk in plain text. [#2788](https://github.com/zowe/zowe-cli/pull/2788)
 - BugFix: Fixed an issue where passing an object with `null` values to the `Censor.mCensorObject` function caused a runtime error. Now, only non-null values are recursively handled in this function. [#2784](https://github.com/zowe/zowe-cli/pull/2784)
 

--- a/packages/imperative/src/censor/__tests__/Censor.unit.test.ts
+++ b/packages/imperative/src/censor/__tests__/Censor.unit.test.ts
@@ -183,6 +183,16 @@ describe("Censor tests", () => {
         it.each([null, undefined, ""])("should return %p unchanged", (input) => {
             expect(Censor.censorCommandLine(input as any)).toEqual(input);
         });
+
+        it("should censor a value that contains regex metacharacters without throwing", () => {
+            const secret = "p@$$(w)ord[1]*";
+            let result: string;
+            expect(() => {
+                result = Censor.censorCommandLine(`zowe cmd --password ${secret}`, { _: [], $0: "", password: secret });
+            }).not.toThrow();
+            expect(result).not.toContain(secret);
+            expect(result).toContain(Censor.CENSOR_RESPONSE);
+        });
     });
 
     describe("censorSession", () => {
@@ -451,6 +461,55 @@ describe("Censor tests", () => {
                 const received = Censor.censorRawData(`masked secret: ${secrets[1]}`, "This is not the console");
                 const expected = `masked secret: ${Censor.CENSOR_RESPONSE}`;
                 expect(received).toEqual(expected);
+            });
+
+            describe("secure values containing regex metacharacters (regression for unescaped RegExp)", () => {
+                beforeEach(() => {
+                    // A sibling test above assigns a cached Censor.mConfig; clear it so censorRawData falls back to
+                    // the mocked ImperativeConfig.instance.config where each test below defines its own secret value.
+                    (Censor as any).mConfig = null;
+                    (Censor as any).addCensoredOption("secret");
+                });
+
+                const trickySecrets = [
+                    "pa$$word",     // $ - end-of-input anchor
+                    "se(cret",      // ( - unterminated group
+                    "se[cret",      // [ - unterminated character class
+                    "p+ass*word?",  // +, *, ? - quantifiers
+                    "back\\slash",  // \\ - escape character
+                    "a.b.c",        // . - any-char wildcard
+                    "^caret$",      // ^, $ - anchors
+                    "pipe|value",   // | - alternation
+                    "brace{2}"      // {} - quantifier braces
+                ];
+
+                for (const secret of trickySecrets) {
+                    it(`masks the literal secret "${secret}" and never throws`, () => {
+                        findSecure.mockReturnValue(["profiles.secret.properties.secret"]);
+                        impConfig.config.mProperties.profiles.secret.properties = { secret };
+
+                        let received: string;
+                        expect(() => { received = Censor.censorRawData(`masked secret: ${secret}`, "log"); }).not.toThrow();
+                        expect(received).toEqual(`masked secret: ${Censor.CENSOR_RESPONSE}`);
+                        expect(received).not.toContain(secret);
+                    });
+                }
+
+                it("does not throw a SyntaxError for a secret with multiple unbalanced regex constructs", () => {
+                    findSecure.mockReturnValue(["profiles.secret.properties.secret"]);
+                    const secret = "unterminated(group[class";
+                    impConfig.config.mProperties.profiles.secret.properties = { secret };
+                    expect(() => Censor.censorRawData(`value: ${secret}`, "log")).not.toThrow();
+                    expect(Censor.censorRawData(`value: ${secret}`, "log")).toEqual(`value: ${Censor.CENSOR_RESPONSE}`);
+                });
+
+                it("matches the secret literally and does not over-censor regex-equivalent text", () => {
+                    findSecure.mockReturnValue(["profiles.secret.properties.secret"]);
+                    impConfig.config.mProperties.profiles.secret.properties = { secret: "a.c" };
+                    // "axc" matches the wildcard pattern /a.c/ but is NOT the real secret; it must remain visible.
+                    const received = Censor.censorRawData("literal: a.c, lookalike: axc", "log");
+                    expect(received).toEqual(`literal: ${Censor.CENSOR_RESPONSE}, lookalike: axc`);
+                });
             });
         });
     });

--- a/packages/imperative/src/censor/src/Censor.ts
+++ b/packages/imperative/src/censor/src/Censor.ts
@@ -235,6 +235,17 @@ export class Censor {
         return this.CENSORED_OPTIONS.includes(prop);
     }
 
+    /**
+     * Escape every regular-expression metacharacter in a string so it can be safely embedded in a `RegExp` as a
+     * literal. Secure values and option names are user-supplied and can frequently contain these characters.
+     * 
+     * @param {string} value - The literal string to escape
+     * @returns {string} - The escaped string, safe to pass to `new RegExp`
+     */
+    private static escapeRegExp(value: string): string {
+        return `${value}`.replace(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`);
+    }
+
     /****************************************************************************************
      * Bread and butter functions, setting up the class and performing censorship of values *
      ****************************************************************************************/
@@ -367,7 +378,7 @@ export class Censor {
         // consuming the leading boundary, and normalizes the separator to a
         // space in the censored output.
         for (const secureArg of this.CENSORED_OPTIONS) {
-            const escapedArg = secureArg.replace(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`);
+            const escapedArg = this.escapeRegExp(secureArg);
             const dashes = secureArg.length > 1 ? "--" : "-";
             const regex = new RegExp(String.raw`(?<=^|\s)${dashes}${escapedArg}[=\s]\S+`, "gi");
             censoredLine = censoredLine.replace(regex, `${dashes}${secureArg} ${this.CENSOR_RESPONSE}`);
@@ -404,7 +415,9 @@ export class Censor {
         for (const prop of secureFields) {
             const sec = lodash.get(config.mProperties, prop);
             if (sec && typeof sec !== "object" && !this.isSpecialValue(prop) && this.isSecureValue(prop.split(".").pop())) {
-                newData = newData.replace(new RegExp(sec, "gi"), this.CENSOR_RESPONSE);
+                // Escape the secret so regex metacharacters (e.g. `$`, `(`, `\`) are matched literally instead of
+                // being interpreted as regex syntax, which would leave the value unmasked or throw a SyntaxError.
+                newData = newData.replace(new RegExp(this.escapeRegExp(sec), "gi"), this.CENSOR_RESPONSE);
             }
         }
         return newData;


### PR DESCRIPTION
**What It Does**

Improves the pre-existing Censor masking logic to escape regular-expression metacharacters.

**How to Test**

- Secure credentials containing regex meta characters are properly censored (reach out for some test examples or refer to added tests)
- Run new regex metacharacter tests: `npx jest --config jest.config.js packages/imperative/src/censor/__tests__/Censor.unit.test.ts -t "regex metacharacters"`. All tests should pass

**Review Checklist**
I certify that I have:
- [x] updated the changelog
- [x] manually tested my changes
- [x] added/updated automated unit/integration tests
- [x] created/ran system tests (job number 2427)
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)