### PR TITLE
fix auto init comment escaping

### DIFF
--- a/packages/core/__tests__/apiml/__unit__/Services.unit.test.ts
+++ b/packages/core/__tests__/apiml/__unit__/Services.unit.test.ts
@@ -868,6 +868,52 @@ describe("APIML Services unit tests", () => {
 
             expect(actualJson).toContain("//\"basePath\": \"test1/v2\\n\\\"badProp\\\": \\\"badString\\\"\"");
         });
+
+        it("should escape newlines and quotes in gatewayUrlConflicts (basePath conflict) comments", () => {
+            const testCase: IApimlProfileInfo[] = [{
+                profName: "test1",
+                profType: "type1",
+                basePaths: [
+                    "test1/v1",
+                    "test1/v2"
+                ],
+                pluginConfigs: new Set(),
+                gatewayUrlConflicts: {
+                    "pluginA": ["v1"],
+                    "pluginB\n\"badKey\": \"badValue": ["v1\",\n\"bad\": \"data"]
+                }
+            }];
+            const actualJson = JSONC.stringify(Services.convertApimlProfileInfoToProfileConfig(testCase), null, ConfigConstants.INDENT);
+
+            const parsed = JSONC.parse(actualJson) as any;
+            expect(parsed.profiles.test1.properties.bad).toBeUndefined();
+            expect(parsed.profiles.test1.properties.badKey).toBeUndefined();
+        });
+
+        it("should escape newlines and quotes in a conflicting default profile type", () => {
+            const badProfType = "type1\",\n\"bad\": \"data";
+            const testCase: IApimlProfileInfo[] = [
+                {
+                    profName: "test1",
+                    profType: badProfType,
+                    basePaths: ["test1/v1"],
+                    pluginConfigs: new Set(),
+                    gatewayUrlConflicts: {}
+                },
+                {
+                    profName: "test2",
+                    profType: badProfType,
+                    basePaths: ["test2/v1"],
+                    pluginConfigs: new Set(),
+                    gatewayUrlConflicts: {}
+                }
+            ];
+            const actualJson = JSONC.stringify(Services.convertApimlProfileInfoToProfileConfig(testCase), null, ConfigConstants.INDENT);
+
+            const parsed = JSONC.parse(actualJson) as any;
+            expect(parsed.defaults.bad).toBeUndefined();
+            expect(parsed.defaults[badProfType]).toBe("test1");
+        });
     });
 
 });

--- a/packages/core/src/apiml/Services.ts
+++ b/packages/core/src/apiml/Services.ts
@@ -243,9 +243,14 @@ export class Services {
                 const basePathConflicts = Object.keys(profileInfo.gatewayUrlConflicts);
                 let conflictingPluginsList = "";
                 basePathConflicts.forEach((element) => {
+                    // Escape to prevent breaking out of the comment (newlines/quotes)
+                    const escapedElement = JSON.stringify(element).slice(1, -1);
+                    const escapedGatewayUrls = profileInfo.gatewayUrlConflicts[element]
+                        .map((url) => JSON.stringify(url).slice(1, -1))
+                        .join('", "');
                     // The new-line before the // "element"  is required in order to properly format the comment-json object
                     conflictingPluginsList += `
-                    //     "${element}": "${profileInfo.gatewayUrlConflicts[element].join('", "')}"`;
+                    //     "${escapedElement}": "${escapedGatewayUrls}"`;
                 });
 
                 // Typecasting because of this issue: https://github.com/kaelzhang/node-comment-json/issues/42
@@ -286,9 +291,11 @@ export class Services {
                         // Multiple services were detected.
                         // Uncomment one of the lines below to set a different default.`;
                 }
+                // Escape to prevent breaking out of the comment/JSON key via embedded newlines or quotes in the profile type.
+                const escapedDefaultKey = JSON.stringify(defaultKey).slice(1, -1);
                 jsonString += `
-                    ${_genCommentsHelper(defaultKey, conflictingDefaults[defaultKey])}
-                    "${defaultKey}": ${JSON.stringify(trueDefault)}`;
+                    ${_genCommentsHelper(escapedDefaultKey, conflictingDefaults[defaultKey])}
+                    "${escapedDefaultKey}": ${JSON.stringify(trueDefault)}`;
                 // Terminate the JSON string
                 jsonString += '\n}';
                 configDefaults = JSONC.parse(jsonString) as any;


### PR DESCRIPTION
**What It Does**
Fixed a bug where written basePath comments could unescaped

**How to Test**
Run `npx jest -- packages/core/__tests__/apiml/__unit__/Services.unit.test.ts`

**Review Checklist**
I certify that I have:
- [ ] updated the changelog
- [x] manually tested my changes
- [x] added/updated automated unit/integration tests
- [ ] created/ran system tests (provide build number if applicable)
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)