### PR TITLE
refactor(v2): Invalidate config cache in LoggerUtils

### DIFF
--- a/packages/imperative/CHANGELOG.md
+++ b/packages/imperative/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Imperative package will be documented in this file.
 
+## Recent Changes
+
+- BugFix: Recomputed the set of secure property paths to redact on every log call instead of caching it at first use. [#2803](https://github.com/zowe/zowe-cli/pull/2803)
+
 ## `5.27.21`
 
 - BugFix: Redacted sensitive environment variables and command-line arguments from the diagnostic information written to the log when a command handler fails to load or throws an error. This prevents credentials supplied via environment variables (for example, `ZOWE_OPT_PASSWORD`) from being persisted to disk in plain text. [#2791](https://github.com/zowe/zowe-cli/pull/2791)

--- a/packages/imperative/src/logger/__tests__/LoggerUtils.unit.test.ts
+++ b/packages/imperative/src/logger/__tests__/LoggerUtils.unit.test.ts
@@ -187,6 +187,96 @@ describe("LoggerUtils tests", () => {
                 expect(received).toEqual(expected);
             });
         });
+
+        // A persistent daemon reloads the active team config before each command, so a change
+        // to the on-disk "secure" arrays has to take effect on the next command rather than 
+        // being frozen at first use.
+        describe("should reflect on-disk secure arrays on every call (daemon cache invalidation)", () => {
+            beforeEach(() => {
+                impConfigSpy.mockReturnValue(impConfig);
+                envSettingsReadSpy.mockReturnValue({ maskOutput: { value: "TRUE" } });
+            });
+
+            it("recomputes the secure field set on every call rather than caching it once", () => {
+                secureFields.mockReturnValue(["profiles.lpar1.properties.apiKey"]);
+                layersGet.mockReturnValue({ properties: { profiles: { lpar1: { properties: { apiKey: secrets[1] } } } } });
+
+                LoggerUtils.censorRawData(`api: ${secrets[1]}`);
+                LoggerUtils.censorRawData(`api: ${secrets[1]}`);
+
+                // If the path set were memoized, secureFields() would be invoked at most once.
+                expect(secureFields).toHaveBeenCalledTimes(2);
+                // layers.get() is likewise re-read per call so masked values stay current.
+                expect(layersGet).toHaveBeenCalledTimes(2);
+            });
+
+            it("masks a value whose property becomes secure after the first call (simulated config edit + reload)", () => {
+                // First command: only the (special, app-masked) password is marked secure on disk.
+                // The custom apiKey is not yet secure, so its value is present in the output verbatim.
+                secureFields.mockReturnValueOnce(["profiles.lpar1.properties.password"]);
+                layersGet.mockReturnValueOnce({
+                    properties: { profiles: { lpar1: { properties: { password: secrets[0] } } } }
+                });
+                const first = LoggerUtils.censorRawData(`pw: ${secrets[0]}, api: ${secrets[1]}`);
+                expect(first).toEqual(`pw: ${secrets[0]}, api: ${secrets[1]}`);
+
+                // The user edits zowe.config.json to also mark apiKey secure; the daemon reloads
+                // the team config before the next command, so secureFields()/layers now include it.
+                secureFields.mockReturnValueOnce([
+                    "profiles.lpar1.properties.password",
+                    "profiles.lpar1.properties.apiKey"
+                ]);
+                layersGet.mockReturnValueOnce({
+                    properties: { profiles: { lpar1: { properties: { password: secrets[0], apiKey: secrets[1] } } } }
+                });
+                const second = LoggerUtils.censorRawData(`pw: ${secrets[0]}, api: ${secrets[1]}`);
+
+                // Regression: the newly-secured value must be redacted on the very next command,
+                // not leaked until the daemon is restarted.
+                expect(second).toEqual(`pw: ${secrets[0]}, api: ${LoggerUtils.CENSOR_RESPONSE}`);
+                expect(second).not.toContain(secrets[1]);
+            });
+
+            it("stops masking a value once its property is removed from the secure set on reload", () => {
+                secureFields.mockReturnValueOnce(["profiles.lpar1.properties.apiKey"]);
+                layersGet.mockReturnValueOnce({
+                    properties: { profiles: { lpar1: { properties: { apiKey: secrets[1] } } } }
+                });
+                expect(LoggerUtils.censorRawData(`api: ${secrets[1]}`)).toEqual(`api: ${LoggerUtils.CENSOR_RESPONSE}`);
+
+                // Property de-secured on disk, then reloaded: the value is no longer masked.
+                secureFields.mockReturnValueOnce([]);
+                layersGet.mockReturnValueOnce({
+                    properties: { profiles: { lpar1: { properties: { apiKey: secrets[1] } } } }
+                });
+                expect(LoggerUtils.censorRawData(`api: ${secrets[1]}`)).toEqual(`api: ${secrets[1]}`);
+            });
+
+            it("picks up the current config object each call instead of a stale cached reference", () => {
+                // First call binds to the initial config instance.
+                secureFields.mockReturnValueOnce(["profiles.lpar1.properties.apiKey"]);
+                layersGet.mockReturnValueOnce({
+                    properties: { profiles: { lpar1: { properties: { apiKey: secrets[1] } } } }
+                });
+                expect(LoggerUtils.censorRawData(`api: ${secrets[1]}`)).toEqual(`api: ${LoggerUtils.CENSOR_RESPONSE}`);
+
+                // Simulate the config object being replaced (rather than reloaded in place). A
+                // stale cached mConfig would keep reading the old, empty secure set.
+                const freshSecureFields = jest.fn().mockReturnValue(["profiles.lpar1.properties.apiKey"]);
+                const freshLayersGet = jest.fn().mockReturnValue({
+                    properties: { profiles: { lpar1: { properties: { apiKey: secrets[0] } } } }
+                });
+                impConfigSpy.mockReturnValue({
+                    config: {
+                        exists: true,
+                        api: { layers: { get: freshLayersGet }, secure: { secureFields: freshSecureFields } }
+                    }
+                });
+                expect(LoggerUtils.censorRawData(`api: ${secrets[0]}`)).toEqual(`api: ${LoggerUtils.CENSOR_RESPONSE}`);
+                expect(freshSecureFields).toHaveBeenCalled();
+                expect(freshLayersGet).toHaveBeenCalled();
+            });
+        });
     });
 
     describe("isSecureEnvName", () => {

--- a/packages/imperative/src/logger/src/LoggerUtils.ts
+++ b/packages/imperative/src/logger/src/LoggerUtils.ts
@@ -150,11 +150,19 @@ export class LoggerUtils {
     }
 
     /**
-     * Singleton implementation of an internal reference of ImperativeConfig.instance.config
+     * Internal reference to ImperativeConfig.instance.config.
+     *
+     * Read fresh on every access. In persistent/daemon mode a single process
+     * serves many commands and reloads the active team config in place before
+     * each command (see CommandProcessor.invoke -> config.reload()). Caching a
+     * reference here is unnecessary for correctness (reload mutates the same
+     * object) but would break if the config object is ever replaced, so we
+     * always read the current instance - mirroring the {@link LoggerUtils.layer}
+     * and {@link LoggerUtils.secureFields} getters.
      */
     private static mConfig: Config = null;
     private static get config(): Config {
-        if (LoggerUtils.mConfig == null) LoggerUtils.mConfig = ImperativeConfig.instance.config;
+        LoggerUtils.mConfig = ImperativeConfig.instance.config;
         return LoggerUtils.mConfig;
     }
 
@@ -171,11 +179,19 @@ export class LoggerUtils {
     }
 
     /**
-     * Singleton implementation of an internal reference to the secure fields stored in the config
+     * Internal reference to the secure fields stored in the config.
+     *
+     * Recomputed on every access. The set of property paths to redact must
+     * reflect the on-disk secure arrays at the time of each log call, not at
+     * first use. In persistent/daemon mode the active team config is reloaded
+     * before each command, so a user marking an additional property as secure
+     * (or removing one) takes effect on the very next command. Memoizing this
+     * would freeze the first command's view for the life of the process and
+     * leak newly-secured values to the logs until a restart.
      */
     private static mSecureFields: string[] = null;
     private static get secureFields(): string[] {
-        if (LoggerUtils.mSecureFields == null) LoggerUtils.mSecureFields = LoggerUtils.config.api.secure.secureFields();
+        LoggerUtils.mSecureFields = LoggerUtils.config.api.secure.secureFields();
         return LoggerUtils.mSecureFields;
     }
 


### PR DESCRIPTION
**What It Does**

Invalidates the `mConfig` cache in `LoggerUtils` to ensure that the latest secure property paths are fetched when in daemon mode.

**How to Test**

The unit tests cover the core behavior:

```
npm test --prefix packages/imperative -- LoggerUtils.unit.test.ts
```

For a manual check in daemon mode:

1. Enable daemon mode (`zowe daemon enable`) and confirm it's running with `zowe daemon status`.
2. In your team config, add a custom property to a profile with a recognizable value, e.g. `customToken: "SECRET123"`. Don't use user/password/tokenValue/keyPassphrase, those already get masked separately as special values and won't exercise this path.
3. Run a command that echoes the value back (`zowe config list --rfj` works) and confirm SECRET123 shows up in plain text, since it isn't secure yet.
4. Leaving the daemon running, mark the property secure: `zowe config set "profiles.lpar1.properties.customToken" "SECRET123" --secure`.
5. Run the same command again. On zowe-v2-lts the value keeps leaking until you restart the daemon; with this change it comes back masked as `****`.

Removing the property from the secure array and rerunning should show the value again, confirming de-securing also takes effect on the next command.

**Review Checklist**
I certify that I have:
- [x] updated the changelog
- [x] manually tested my changes
- [x] added/updated automated unit/integration tests
- [x] created/ran system tests (job number 2429)
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)
