### PR TITLE
refactor: reject unsafe fields in config

### DIFF
--- a/packages/imperative/CHANGELOG.md
+++ b/packages/imperative/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the Imperative package will be documented in this file.
 
 ## Recent Changes
 
-- BugFix: `Config.set`, `ConfigProfiles.set`, and the `ConfigSecure` property walkers now reject dotted paths whose segments use reserved property names. [#2807](https://github.com/zowe/zowe-cli/pull/2807)
+- BugFix: The `Config.set` function, `ConfigProfiles.set` function, and the `ConfigSecure` property walkers now reject dotted paths whose segments use reserved property names. [#2807](https://github.com/zowe/zowe-cli/pull/2807)
 - BugFix: Escaped regular-expression metacharacters in secure values before masking them in the `Censor.censorRawData` function. [#2799](https://github.com/zowe/zowe-cli/pull/2799)
 - BugFix: Redacted sensitive environment variables and command-line arguments from the diagnostic information written to the log when a command handler fails to load or throws an error. This prevents credentials supplied via environment variables (for example, `ZOWE_OPT_PASSWORD`) from being persisted to disk in plain text. [#2788](https://github.com/zowe/zowe-cli/pull/2788)
 - BugFix: Fixed an issue where passing an object with `null` values to the `Censor.mCensorObject` function caused a runtime error. Now, only non-null values are recursively handled in this function. [#2784](https://github.com/zowe/zowe-cli/pull/2784)

--- a/packages/imperative/CHANGELOG.md
+++ b/packages/imperative/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the Imperative package will be documented in this file.
 
 ## Recent Changes
 
-- BugFix: Prevented prototype pollution when setting config or profile properties. `Config.set`, `ConfigProfiles.set`, and the `ConfigSecure` property walkers now reject dotted paths whose segments use reserved property names.
+- BugFix: `Config.set`, `ConfigProfiles.set`, and the `ConfigSecure` property walkers now reject dotted paths whose segments use reserved property names. [#2807](https://github.com/zowe/zowe-cli/pull/2807)
 - BugFix: Escaped regular-expression metacharacters in secure values before masking them in the `Censor.censorRawData` function. [#2799](https://github.com/zowe/zowe-cli/pull/2799)
 - BugFix: Redacted sensitive environment variables and command-line arguments from the diagnostic information written to the log when a command handler fails to load or throws an error. This prevents credentials supplied via environment variables (for example, `ZOWE_OPT_PASSWORD`) from being persisted to disk in plain text. [#2788](https://github.com/zowe/zowe-cli/pull/2788)
 - BugFix: Fixed an issue where passing an object with `null` values to the `Censor.mCensorObject` function caused a runtime error. Now, only non-null values are recursively handled in this function. [#2784](https://github.com/zowe/zowe-cli/pull/2784)

--- a/packages/imperative/CHANGELOG.md
+++ b/packages/imperative/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the Imperative package will be documented in this file.
 
 ## Recent Changes
 
-- BugFix: The `Config.set` function, `ConfigProfiles.set` function, and the `ConfigSecure` property walkers now reject dotted paths whose segments use reserved property names. [#2807](https://github.com/zowe/zowe-cli/pull/2807)
+- BugFix: The `Config.set` function, `ConfigProfiles.set` function, and the `ConfigSecure` property walkers now reject dotted paths whose segments are empty or use reserved property names. [#2807](https://github.com/zowe/zowe-cli/pull/2807)
 - BugFix: Escaped regular-expression metacharacters in secure values before masking them in the `Censor.censorRawData` function. [#2799](https://github.com/zowe/zowe-cli/pull/2799)
 - BugFix: Redacted sensitive environment variables and command-line arguments from the diagnostic information written to the log when a command handler fails to load or throws an error. This prevents credentials supplied via environment variables (for example, `ZOWE_OPT_PASSWORD`) from being persisted to disk in plain text. [#2788](https://github.com/zowe/zowe-cli/pull/2788)
 - BugFix: Fixed an issue where passing an object with `null` values to the `Censor.mCensorObject` function caused a runtime error. Now, only non-null values are recursively handled in this function. [#2784](https://github.com/zowe/zowe-cli/pull/2784)

--- a/packages/imperative/CHANGELOG.md
+++ b/packages/imperative/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to the Imperative package will be documented in this file.
 
 ## Recent Changes
 
+- BugFix: Prevented prototype pollution when setting config or profile properties. `Config.set`, `ConfigProfiles.set`, and the `ConfigSecure` property walkers now reject dotted paths whose segments use reserved property names.
 - BugFix: Escaped regular-expression metacharacters in secure values before masking them in the `Censor.censorRawData` function. [#2799](https://github.com/zowe/zowe-cli/pull/2799)
 - BugFix: Redacted sensitive environment variables and command-line arguments from the diagnostic information written to the log when a command handler fails to load or throws an error. This prevents credentials supplied via environment variables (for example, `ZOWE_OPT_PASSWORD`) from being persisted to disk in plain text. [#2788](https://github.com/zowe/zowe-cli/pull/2788)
 - BugFix: Fixed an issue where passing an object with `null` values to the `Censor.mCensorObject` function caused a runtime error. Now, only non-null values are recursively handled in this function. [#2784](https://github.com/zowe/zowe-cli/pull/2784)

--- a/packages/imperative/src/config/__tests__/Config.api.unit.test.ts
+++ b/packages/imperative/src/config/__tests__/Config.api.unit.test.ts
@@ -133,6 +133,21 @@ describe("Config API tests", () => {
                 const profile = profilesApi.get("grape");
                 expect(profile).toEqual({});
             });
+            it.each(["__proto__", "constructor", "prototype", "fruit.__proto__"])(
+                "should reject a profile path containing the reserved segment '%s'", async (badPath) => {
+                    const config = await Config.load(MY_APP);
+                    const fakeProfile: IConfigProfile = { type: "fruit", profiles: {}, properties: { color: "green" } };
+                    let caughtError: Error;
+                    try {
+                        config.api.profiles.set(badPath, fakeProfile);
+                    } catch (error) {
+                        caughtError = error;
+                    }
+                    expect(caughtError).toBeDefined();
+                    expect(caughtError.message).toContain("reserved property names");
+                    expect(({} as any).color).toBeUndefined();
+                    expect(({} as any).properties).toBeUndefined();
+                });
         });
         describe("get", () => {
             it("should get a first level profile", async () => {
@@ -228,6 +243,30 @@ describe("Config API tests", () => {
                 const profilePath = "profiles.zosmf";
                 expect(config.api.profiles.getProfilePathFromName(profilePath)).toEqual("profiles.profiles.profiles.zosmf");
             });
+            it.each(["__proto__", "constructor", "prototype", "lpar1.__proto__.zosmf"])(
+                "should reject a profile name containing the reserved segment '%s'", async (badName) => {
+                    const config = await Config.load(MY_APP);
+                    let caughtError: Error;
+                    try {
+                        config.api.profiles.getProfilePathFromName(badName);
+                    } catch (error) {
+                        caughtError = error;
+                    }
+                    expect(caughtError).toBeDefined();
+                    expect(caughtError.message).toContain("Invalid profile name");
+                });
+            it.each(["", ".lpar1", "lpar1.", "lpar1..zosmf"])(
+                "should reject a profile name with empty segments: '%s'", async (badName) => {
+                    const config = await Config.load(MY_APP);
+                    let caughtError: Error;
+                    try {
+                        config.api.profiles.getProfilePathFromName(badName);
+                    } catch (error) {
+                        caughtError = error;
+                    }
+                    expect(caughtError).toBeDefined();
+                    expect(caughtError.message).toContain("Invalid profile name");
+                });
         });
         describe("getProfileNameFromPath", () => {
             it("should shrink profile paths", async () => {

--- a/packages/imperative/src/config/__tests__/Config.api.unit.test.ts
+++ b/packages/imperative/src/config/__tests__/Config.api.unit.test.ts
@@ -148,6 +148,19 @@ describe("Config API tests", () => {
                     expect(({} as any).color).toBeUndefined();
                     expect(({} as any).properties).toBeUndefined();
                 });
+            it.each(["", ".fruit", "fruit.", "fruit..apple"])(
+                "should reject a profile path with an empty segment: '%s'", async (badPath) => {
+                    const config = await Config.load(MY_APP);
+                    const fakeProfile: IConfigProfile = { type: "fruit", profiles: {}, properties: { color: "green" } };
+                    let caughtError: Error;
+                    try {
+                        config.api.profiles.set(badPath, fakeProfile);
+                    } catch (error) {
+                        caughtError = error;
+                    }
+                    expect(caughtError).toBeDefined();
+                    expect(caughtError.message).toContain("Invalid profile path");
+                });
         });
         describe("get", () => {
             it("should get a first level profile", async () => {

--- a/packages/imperative/src/config/__tests__/Config.secure.unit.test.ts
+++ b/packages/imperative/src/config/__tests__/Config.secure.unit.test.ts
@@ -122,6 +122,40 @@ describe("Config secure tests", () => {
         expect(mockSecureSave).toHaveBeenCalledTimes(0);
     });
 
+    describe("prototype pollution (defense-in-depth)", () => {
+        afterEach(() => {
+            delete (Object.prototype as any).polluted;
+        });
+
+        it("loadCached should skip a secure path that contains a reserved segment", () => {
+            const config = new (Config as any)();
+            config.mLayers = [{ user: false, global: false, path: "fakePath", properties: { profiles: {} } }];
+            config.mVault = mockVault;
+            config.mEnvVarManaged = [];
+            // Without the guard, walking "__proto__.polluted" would assign onto Object.prototype
+            config.mSecure = { fakePath: { "__proto__.polluted": "evil" } };
+            jest.spyOn(config.api.secure, "secureFields").mockReturnValue(["__proto__.polluted"]);
+
+            (config.api.secure as any).loadCached({ user: false, global: false });
+
+            expect(Object.getOwnPropertyNames(Object.prototype)).not.toContain("polluted");
+            expect(({} as any).polluted).toBeUndefined();
+        });
+
+        it("cacheAndPrune should skip a secure path that contains a reserved segment", () => {
+            const config = new (Config as any)();
+            config.mLayers = [{ user: false, global: false, path: "fakePath", properties: { profiles: {} } }];
+            config.mVault = mockVault;
+            config.mSecure = {};
+            config.mEnvVarManaged = [];
+            jest.spyOn(config.api.secure, "secureFields").mockReturnValue(["__proto__.polluted"]);
+
+            expect(() => (config.api.secure as any).cacheAndPrune({ user: false, global: false })).not.toThrow();
+            expect(config.mSecure.fakePath).toBeUndefined();
+            expect(Object.getOwnPropertyNames(Object.prototype)).not.toContain("polluted");
+        });
+    });
+
     it("should load and save all secure properties", async () => {
         jest.spyOn(Config, "search").mockReturnValueOnce(projectUserConfigPath).mockReturnValueOnce(projectConfigPath);
         jest.spyOn(fs, "existsSync").mockReturnValueOnce(false).mockReturnValueOnce(true).mockReturnValue(false);

--- a/packages/imperative/src/config/__tests__/Config.unit.test.ts
+++ b/packages/imperative/src/config/__tests__/Config.unit.test.ts
@@ -645,6 +645,23 @@ describe("Config tests", () => {
                 config.set("profiles.profiles.properties.color", "green");
                 expect(config.properties.profiles.profiles.properties.color).toBe("green");
             });
+
+            it.each([
+                "",
+                ".profiles.lpar1.properties.host",
+                "profiles.lpar1.properties.host.",
+                "profiles..properties.host"
+            ])("should reject the empty path segment in '%s'", async (badPath) => {
+                const config = await Config.load(MY_APP);
+                let caughtError: Error;
+                try {
+                    config.set(badPath, "some-value");
+                } catch (error) {
+                    caughtError = error;
+                }
+                expect(caughtError).toBeDefined();
+                expect(caughtError.message).toContain("may not be empty");
+            });
         });
     });
 

--- a/packages/imperative/src/config/__tests__/Config.unit.test.ts
+++ b/packages/imperative/src/config/__tests__/Config.unit.test.ts
@@ -596,6 +596,56 @@ describe("Config tests", () => {
             expect(caughtError).toBeDefined();
             expect(caughtError.message).toBe("The secure option is only valid when setting a single property");
         });
+
+        describe("prototype pollution", () => {
+            // Regression test for the auto-store prototype-pollution vector: a
+            // malicious project config could resolve a profile name to
+            // "__proto__", causing the auto-store path to call
+            // config.set("profiles.__proto__.properties.<prop>", value) and
+            // walk onto Object.prototype.
+            afterEach(() => {
+                // Ensure a leaked pollution in one assertion can't mask another
+                delete (Object.prototype as any).properties;
+            });
+
+            it.each([
+                "profiles.__proto__.properties.host",
+                "profiles.constructor.properties.host",
+                "profiles.prototype.properties.host",
+                "__proto__.polluted"
+            ])("should reject the reserved path segment in '%s'", async (badPath) => {
+                const config = await Config.load(MY_APP);
+                let caughtError: Error;
+                try {
+                    config.set(badPath, "attacker-value");
+                } catch (error) {
+                    caughtError = error;
+                }
+                expect(caughtError).toBeDefined();
+                expect(caughtError.message).toContain("reserved property names");
+                // The core guarantee: Object.prototype was NOT polluted
+                expect(Object.getOwnPropertyNames(Object.prototype)).not.toContain("properties");
+                expect(Object.getOwnPropertyNames(Object.prototype)).not.toContain("polluted");
+                expect(({} as any).properties).toBeUndefined();
+            });
+
+            it("should not pollute the prototype and should not create the malicious profile", async () => {
+                const config = await Config.load(MY_APP);
+                expect(() => config.set("profiles.__proto__.properties.host", "evil")).toThrow();
+                // A freshly created, unrelated object must not inherit anything
+                expect(({} as any).properties).toBeUndefined();
+                // Nothing was written into the active layer either
+                const layer = (config as any).layerActive();
+                expect(Object.getOwnPropertyNames(layer.properties.profiles)).not.toContain("__proto__");
+            });
+
+            it("should still set a legitimate property whose profile is literally named 'profiles'", async () => {
+                const config = await Config.load(MY_APP);
+                // "profiles" is a legal (if unusual) profile name and must not be blocked
+                config.set("profiles.profiles.properties.color", "green");
+                expect(config.properties.profiles.profiles.properties.color).toBe("green");
+            });
+        });
     });
 
     describe("set (with comments)", () => {

--- a/packages/imperative/src/config/__tests__/ConfigUtils.unit.test.ts
+++ b/packages/imperative/src/config/__tests__/ConfigUtils.unit.test.ts
@@ -25,6 +25,26 @@ describe("Config Utils", () => {
         jest.restoreAllMocks();
     });
 
+    describe("hasUnsafeProperty", () => {
+        it("should flag paths that contain a reserved property name", () => {
+            expect(ConfigUtils.hasUnsafeProperty("profiles.__proto__.properties.host")).toBe(true);
+            expect(ConfigUtils.hasUnsafeProperty("profiles.constructor.properties.host")).toBe(true);
+            expect(ConfigUtils.hasUnsafeProperty("profiles.prototype.properties.host")).toBe(true);
+            expect(ConfigUtils.hasUnsafeProperty("__proto__")).toBe(true);
+        });
+
+        it("should not flag normal config property paths", () => {
+            expect(ConfigUtils.hasUnsafeProperty("profiles.lpar1.properties.host")).toBe(false);
+            // "profiles" as a profile name is legal and must not be flagged
+            expect(ConfigUtils.hasUnsafeProperty("profiles.profiles.properties.host")).toBe(false);
+            expect(ConfigUtils.hasUnsafeProperty("defaults.zosmf")).toBe(false);
+        });
+
+        it("should expose the reserved property names", () => {
+            expect([...ConfigUtils.UNSAFE_PROP_NAMES].sort()).toEqual(["__proto__", "constructor", "prototype"]);
+        });
+    });
+
     describe("coercePropValue", () => {
         it("should parse value when type is boolean", () => {
             expect(ConfigUtils.coercePropValue("false", "boolean")).toBe(false);

--- a/packages/imperative/src/config/__tests__/ConfigUtils.unit.test.ts
+++ b/packages/imperative/src/config/__tests__/ConfigUtils.unit.test.ts
@@ -25,19 +25,26 @@ describe("Config Utils", () => {
         jest.restoreAllMocks();
     });
 
-    describe("hasUnsafeProperty", () => {
+    describe("hasUnsafeOrEmptyProperty", () => {
         it("should flag paths that contain a reserved property name", () => {
-            expect(ConfigUtils.hasUnsafeProperty("profiles.__proto__.properties.host")).toBe(true);
-            expect(ConfigUtils.hasUnsafeProperty("profiles.constructor.properties.host")).toBe(true);
-            expect(ConfigUtils.hasUnsafeProperty("profiles.prototype.properties.host")).toBe(true);
-            expect(ConfigUtils.hasUnsafeProperty("__proto__")).toBe(true);
+            expect(ConfigUtils.hasUnsafeOrEmptyProperty("profiles.__proto__.properties.host")).toBe(true);
+            expect(ConfigUtils.hasUnsafeOrEmptyProperty("profiles.constructor.properties.host")).toBe(true);
+            expect(ConfigUtils.hasUnsafeOrEmptyProperty("profiles.prototype.properties.host")).toBe(true);
+            expect(ConfigUtils.hasUnsafeOrEmptyProperty("__proto__")).toBe(true);
+        });
+
+        it("should flag paths that contain an empty segment", () => {
+            expect(ConfigUtils.hasUnsafeOrEmptyProperty("")).toBe(true);
+            expect(ConfigUtils.hasUnsafeOrEmptyProperty(".lpar1")).toBe(true);
+            expect(ConfigUtils.hasUnsafeOrEmptyProperty("lpar1.")).toBe(true);
+            expect(ConfigUtils.hasUnsafeOrEmptyProperty("lpar1..zosmf")).toBe(true);
         });
 
         it("should not flag normal config property paths", () => {
-            expect(ConfigUtils.hasUnsafeProperty("profiles.lpar1.properties.host")).toBe(false);
+            expect(ConfigUtils.hasUnsafeOrEmptyProperty("profiles.lpar1.properties.host")).toBe(false);
             // "profiles" as a profile name is legal and must not be flagged
-            expect(ConfigUtils.hasUnsafeProperty("profiles.profiles.properties.host")).toBe(false);
-            expect(ConfigUtils.hasUnsafeProperty("defaults.zosmf")).toBe(false);
+            expect(ConfigUtils.hasUnsafeOrEmptyProperty("profiles.profiles.properties.host")).toBe(false);
+            expect(ConfigUtils.hasUnsafeOrEmptyProperty("defaults.zosmf")).toBe(false);
         });
 
         it("should expose the reserved property names", () => {

--- a/packages/imperative/src/config/src/Config.ts
+++ b/packages/imperative/src/config/src/Config.ts
@@ -484,12 +484,14 @@ export class Config {
     public set(propertyPath: string, value: any, opts?: { parseString?: boolean; secure?: boolean }) {
         opts = opts || {};
 
-        // Guard the hand-rolled path walker below against prototype pollution.
-        // A path such as "profiles.__proto__.properties.host" would otherwise
-        // walk onto Object.prototype and assign properties there.
-        if (ConfigUtils.hasUnsafeProperty(propertyPath)) {
+        // Guard the hand-rolled path walker below against prototype pollution
+        // and malformed paths. A path such as "profiles.__proto__.properties.host"
+        // would otherwise walk onto Object.prototype and assign properties there,
+        // and a path with an empty segment (e.g. "profiles..properties.host")
+        // would silently create a bogus "" key.
+        if (ConfigUtils.hasUnsafeOrEmptyProperty(propertyPath)) {
             throw new ImperativeError({
-                msg: `Invalid property path '${propertyPath}': path segments may not use ` +
+                msg: `Invalid property path '${propertyPath}': path segments may not be empty or use ` +
                     `the reserved property names ${ConfigUtils.UNSAFE_PROP_NAMES.join(", ")}.`
             });
         }

--- a/packages/imperative/src/config/src/Config.ts
+++ b/packages/imperative/src/config/src/Config.ts
@@ -484,6 +484,16 @@ export class Config {
     public set(propertyPath: string, value: any, opts?: { parseString?: boolean; secure?: boolean }) {
         opts = opts || {};
 
+        // Guard the hand-rolled path walker below against prototype pollution.
+        // A path such as "profiles.__proto__.properties.host" would otherwise
+        // walk onto Object.prototype and assign properties there.
+        if (ConfigUtils.hasUnsafeProperty(propertyPath)) {
+            throw new ImperativeError({
+                msg: `Invalid property path '${propertyPath}': path segments may not use ` +
+                    `the reserved property names ${ConfigUtils.UNSAFE_PROP_NAMES.join(", ")}.`
+            });
+        }
+
         const layer = this.layerActive();
         this.mEnvVarManaged.forEach((value) => {
             if (value.global == layer.global && value.user == layer.user && value.propPath == propertyPath) {

--- a/packages/imperative/src/config/src/ConfigUtils.ts
+++ b/packages/imperative/src/config/src/ConfigUtils.ts
@@ -37,13 +37,15 @@ export class ConfigUtils {
 
     /**
      * Determine whether a dotted config property path or profile name contains
-     * a segment that could be abused for prototype pollution.
+     * a segment that is empty (e.g. from a leading, trailing, or consecutive
+     * dot) or that could be abused for prototype pollution. Both flavors of bad
+     * segment are unsafe to hand to a hand-rolled dotted-path walker.
      * @param propertyPath Dotted path (e.g. "profiles.lpar1.properties.host")
      *                     or profile name (e.g. "lpar1.zosmf")
-     * @returns True if any segment is a reserved/unsafe property name
+     * @returns True if any segment is empty or a reserved/unsafe property name
      */
-    public static hasUnsafeProperty(propertyPath: string): boolean {
-        return propertyPath.split(".").some((segment) => ConfigUtils.UNSAFE_PROP_NAMES.includes(segment));
+    public static hasUnsafeOrEmptyProperty(propertyPath: string): boolean {
+        return propertyPath.split(".").some((segment) => segment.length === 0 || ConfigUtils.UNSAFE_PROP_NAMES.includes(segment));
     }
 
     /**

--- a/packages/imperative/src/config/src/ConfigUtils.ts
+++ b/packages/imperative/src/config/src/ConfigUtils.ts
@@ -28,6 +28,25 @@ import { IExtendersJsonOpts } from "./doc/IExtenderOpts";
 
 export class ConfigUtils {
     /**
+     * Property names that must never appear as a segment when walking a plain
+     * object with hand-rolled (non-lodash) dotted-path traversal. Dereferencing
+     * or assigning to any of these keys can mutate `Object.prototype`
+     * (prototype pollution) or otherwise corrupt the JS object graph.
+     */
+    public static readonly UNSAFE_PROP_NAMES: readonly string[] = ["__proto__", "constructor", "prototype"];
+
+    /**
+     * Determine whether a dotted config property path or profile name contains
+     * a segment that could be abused for prototype pollution.
+     * @param propertyPath Dotted path (e.g. "profiles.lpar1.properties.host")
+     *                     or profile name (e.g. "lpar1.zosmf")
+     * @returns True if any segment is a reserved/unsafe property name
+     */
+    public static hasUnsafeProperty(propertyPath: string): boolean {
+        return propertyPath.split(".").some((segment) => ConfigUtils.UNSAFE_PROP_NAMES.includes(segment));
+    }
+
+    /**
      * Retrieves the Zowe CLI home directory. In the situation Imperative has
      * not initialized it we use a default value.
      * @returns {string} - Returns the Zowe home directory

--- a/packages/imperative/src/config/src/api/ConfigProfiles.ts
+++ b/packages/imperative/src/config/src/api/ConfigProfiles.ts
@@ -30,12 +30,14 @@ export class ConfigProfiles extends ConfigApi {
      * @param profile The JSON profile object to set into the specified location,
      */
     public set(path: string, profile: IConfigProfile): void {
-        // Guard the hand-rolled path walker below against prototype pollution.
-        // A path such as "__proto__" would otherwise reparent the profiles
-        // object or write onto Object.prototype.
-        if (ConfigUtils.hasUnsafeProperty(path)) {
+        // Guard the hand-rolled path walker below against prototype pollution
+        // and malformed paths. A path such as "__proto__" would otherwise
+        // reparent the profiles object or write onto Object.prototype, and an
+        // empty segment (e.g. "lpar1..zosmf") would silently create a bogus
+        // "" profile.
+        if (ConfigUtils.hasUnsafeOrEmptyProperty(path)) {
             throw new ImperativeError({
-                msg: `Invalid profile path '${path}': path segments may not use ` +
+                msg: `Invalid profile path '${path}': path segments may not be empty or use ` +
                     `the reserved property names ${ConfigUtils.UNSAFE_PROP_NAMES.join(", ")}.`
             });
         }
@@ -118,12 +120,12 @@ export class ConfigProfiles extends ConfigApi {
      * @returns The expanded path.
      */
     public getProfilePathFromName(shortPath: string): string {
-        // Defense-in-depth: reject profile names that resolve to an unsafe
-        // JSON path before they reach any downstream path walker. This covers
-        // every source of a profile name (config `defaults`, the CLI
-        // `--<type>-profile` argument, base-profile fallbacks, and nested
+        // Defense-in-depth: reject profile names that resolve to an unsafe or
+        // malformed JSON path before they reach any downstream path walker.
+        // This covers every source of a profile name (config `defaults`, the
+        // CLI `--<type>-profile` argument, base-profile fallbacks, and nested
         // profile keys), not just `defaults`.
-        if (shortPath.split(".").some((segment) => segment.length === 0 || ConfigUtils.UNSAFE_PROP_NAMES.includes(segment))) {
+        if (ConfigUtils.hasUnsafeOrEmptyProperty(shortPath)) {
             throw new ImperativeError({
                 msg: `Invalid profile name '${shortPath}': profile names may not be empty, contain ` +
                     `leading, trailing, or consecutive dots, or use the reserved property names ` +

--- a/packages/imperative/src/config/src/api/ConfigProfiles.ts
+++ b/packages/imperative/src/config/src/api/ConfigProfiles.ts
@@ -13,6 +13,8 @@ import * as JSONC from "comment-json";
 import { ConfigConstants } from "../ConfigConstants";
 import { IConfigProfile } from "../doc/IConfigProfile";
 import { ConfigApi } from "./ConfigApi";
+import { ConfigUtils } from "../ConfigUtils";
+import { ImperativeError } from "../../../error";
 
 /**
  * API Class for manipulating config profiles.
@@ -28,6 +30,15 @@ export class ConfigProfiles extends ConfigApi {
      * @param profile The JSON profile object to set into the specified location,
      */
     public set(path: string, profile: IConfigProfile): void {
+        // Guard the hand-rolled path walker below against prototype pollution.
+        // A path such as "__proto__" would otherwise reparent the profiles
+        // object or write onto Object.prototype.
+        if (ConfigUtils.hasUnsafeProperty(path)) {
+            throw new ImperativeError({
+                msg: `Invalid profile path '${path}': path segments may not use ` +
+                    `the reserved property names ${ConfigUtils.UNSAFE_PROP_NAMES.join(", ")}.`
+            });
+        }
         profile.properties = profile.properties || {};
         const layer = this.mConfig.layerActive();
         const segments: string[] = path.split(".");
@@ -107,6 +118,18 @@ export class ConfigProfiles extends ConfigApi {
      * @returns The expanded path.
      */
     public getProfilePathFromName(shortPath: string): string {
+        // Defense-in-depth: reject profile names that resolve to an unsafe
+        // JSON path before they reach any downstream path walker. This covers
+        // every source of a profile name (config `defaults`, the CLI
+        // `--<type>-profile` argument, base-profile fallbacks, and nested
+        // profile keys), not just `defaults`.
+        if (shortPath.split(".").some((segment) => segment.length === 0 || ConfigUtils.UNSAFE_PROP_NAMES.includes(segment))) {
+            throw new ImperativeError({
+                msg: `Invalid profile name '${shortPath}': profile names may not be empty, contain ` +
+                    `leading, trailing, or consecutive dots, or use the reserved property names ` +
+                    `${ConfigUtils.UNSAFE_PROP_NAMES.join(", ")}.`
+            });
+        }
         return shortPath.replace(/(^|\.)/g, "$1profiles.");
     }
 

--- a/packages/imperative/src/config/src/api/ConfigSecure.ts
+++ b/packages/imperative/src/config/src/api/ConfigSecure.ts
@@ -83,8 +83,8 @@ export class ConfigSecure extends ConfigApi {
                     // Extract and set secure properties
                     for (const [sPath, sValue] of Object.entries(secureProps)) {
                         if (sPath === p) {
-                            // Defense-in-depth: never walk into a reserved key
-                            if (ConfigUtils.hasUnsafeProperty(sPath)) continue;
+                            // Defense-in-depth: never walk into a reserved or empty key
+                            if (ConfigUtils.hasUnsafeOrEmptyProperty(sPath)) continue;
                             const segments = sPath.split(".");
                             let obj: any = layer.properties;
                             for (let x = 0; x < segments.length; x++) {
@@ -162,8 +162,8 @@ export class ConfigSecure extends ConfigApi {
                 return element.global == layer.global && element.user == layer.user && element.propPath == path;
             });
             if (envVarManaged) { continue; }
-            // Defense-in-depth: never walk into a reserved key
-            if (ConfigUtils.hasUnsafeProperty(path)) continue;
+            // Defense-in-depth: never walk into a reserved or empty key
+            if (ConfigUtils.hasUnsafeOrEmptyProperty(path)) continue;
             const segments = path.split(".");
             let obj: any = opts?.properties ?? layer.properties;
             for (let x = 0; x < segments.length; x++) {

--- a/packages/imperative/src/config/src/api/ConfigSecure.ts
+++ b/packages/imperative/src/config/src/api/ConfigSecure.ts
@@ -83,6 +83,8 @@ export class ConfigSecure extends ConfigApi {
                     // Extract and set secure properties
                     for (const [sPath, sValue] of Object.entries(secureProps)) {
                         if (sPath === p) {
+                            // Defense-in-depth: never walk into a reserved key
+                            if (ConfigUtils.hasUnsafeProperty(sPath)) continue;
                             const segments = sPath.split(".");
                             let obj: any = layer.properties;
                             for (let x = 0; x < segments.length; x++) {
@@ -160,6 +162,8 @@ export class ConfigSecure extends ConfigApi {
                 return element.global == layer.global && element.user == layer.user && element.propPath == path;
             });
             if (envVarManaged) { continue; }
+            // Defense-in-depth: never walk into a reserved key
+            if (ConfigUtils.hasUnsafeProperty(path)) continue;
             const segments = path.split(".");
             let obj: any = opts?.properties ?? layer.properties;
             for (let x = 0; x < segments.length; x++) {


### PR DESCRIPTION
**What It Does**

Same fix as #2806, ported to v3.

**How to Test**

Same test files as the v2 fix, since the config module layout didn't change:

```
npx jest packages/imperative/src/config/__tests__/Config.unit.test.ts packages/imperative/src/config/__tests__/Config.api.unit.test.ts packages/imperative/src/config/__tests__/ConfigUtils.unit.test.ts packages/imperative/src/config/__tests__/Config.secure.unit.test.ts
```

If you're checking out this branch fresh, run `npm install` first.

To confirm the tests aren't just green by luck, revert the four source files (`Config.ts`, `ConfigUtils.ts`, `ConfigProfiles.ts`, `ConfigSecure.ts`) while keeping the tests, then rerun. 18 cases should fail, same as on the v2 branch.

Manual repro after `npm run build`, from a node REPL in the repo root:

```js
const { Config } = require("./packages/imperative/lib/config/src/Config");
const config = await Config.load("test");
config.set("profiles.__proto__.properties.host", "x"); // throws instead of polluting Object.prototype
```

**Review Checklist**
I certify that I have:
- [x] updated the changelog
- [x] manually tested my changes
- [x] added/updated automated unit/integration tests
- [x] created/ran system tests (job number 2438)
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)
