### PR TITLE
daemon: Fix "Access is denied" error when running CLI commands on Windows

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to the Zowe CLI package will be documented in this file.
 - BugFix: Censored sensitive connection properties from the diagnostic details serialized into workflow and job submission command errors. [#2784](https://github.com/zowe/zowe-cli/pull/2784)
 - BugFix: Prevented the daemon client from connecting to a Windows named pipe that belongs to a different user. [#2790](https://github.com/zowe/zowe-cli/pull/2790)
 - BugFix: Hardened daemon client authentication so that another local user cannot drive a daemon they do not own. The daemon now generates a random secret token at startup, stores it in the owner-only `daemon_pid.json` file, and requires every client request to echo it back (compared in constant time). Because only the owner can read that file, this closes a gap on Windows, where the named pipe can be opened by local users other than the owner and the previously self-asserted user name check was insufficient. [#2743](https://github.com/zowe/zowe-cli/pull/2743)
+- BugFix: Fixed "Access is denied" error when running CLI commands on Windows if daemon mode is active. [#2808](https://github.com/zowe/zowe-cli/issues/2808)
 
 ## `8.33.1`
 

--- a/zowex/src/run.rs
+++ b/zowex/src/run.rs
@@ -25,6 +25,8 @@ use base64::prelude::*;
 use is_terminal::IsTerminal;
 
 #[cfg(target_family = "windows")]
+use std::path::Path;
+#[cfg(target_family = "windows")]
 extern crate fslock;
 #[cfg(target_family = "windows")]
 extern crate home;
@@ -308,7 +310,7 @@ pub async fn run_daemon_command(
     let daemon_dir = util_get_daemon_dir()?;
 
     #[cfg(target_family = "windows")]
-    let mut lock_file = get_win_lock_file(daemon_dir)?;
+    let mut lock_file = get_win_lock_file(&daemon_dir)?;
 
     #[cfg(target_family = "windows")]
     let mut locked = false;
@@ -652,8 +654,8 @@ fn form_win_cmd_script_arg_vec<'a>(
 }
 
 #[cfg(target_family = "windows")]
-fn get_win_lock_file(daemon_dir: str) -> Result<LockFile, i32> {
-    let mut lock_path: PathBuf = daemon_dir;
+fn get_win_lock_file(daemon_dir: &Path) -> Result<LockFile, i32> {
+    let mut lock_path: PathBuf = daemon_dir.to_path_buf();
     lock_path.push("daemon.lock");
 
     if let Err(err_val) = File::create(&lock_path) {

--- a/zowex/src/run.rs
+++ b/zowex/src/run.rs
@@ -305,14 +305,14 @@ pub async fn run_daemon_command(
         Ok(ok_val) => ok_val,
         Err(err_val) => return Err(err_val),
     };
+    let daemon_dir = util_get_daemon_dir()?;
 
     #[cfg(target_family = "windows")]
-    let mut lock_file = get_win_lock_file()?;
+    let mut lock_file = get_win_lock_file(daemon_dir)?;
 
     #[cfg(target_family = "windows")]
     let mut locked = false;
 
-    let daemon_dir = util_get_daemon_dir()?;
     loop {
         #[cfg(target_family = "windows")]
         if !locked {
@@ -652,12 +652,8 @@ fn form_win_cmd_script_arg_vec<'a>(
 }
 
 #[cfg(target_family = "windows")]
-fn get_win_lock_file() -> Result<LockFile, i32> {
-    let mut lock_path: PathBuf;
-    match util_get_daemon_dir() {
-        Ok(ok_val) => lock_path = ok_val,
-        Err(err_val) => return Err(err_val),
-    }
+fn get_win_lock_file(daemon_dir: str) -> Result<LockFile, i32> {
+    let mut lock_path: PathBuf = daemon_dir;
     lock_path.push("daemon.lock");
 
     if let Err(err_val) = File::create(&lock_path) {


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->
Fixes #2808

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->
(Windows only)
1. Build the daemon client: `cd zowex && cargo build`
2. Delete the `~/.zowe/daemon` directory
3. Copy the `zowe.exe` binary from the `target/debug` directory into `~/.zowe/bin`
4. Issue multiple CLI commands with the binary

**Review Checklist**
I certify that I have:
- [x] updated the changelog
- [x] manually tested my changes
- [ ] added/updated automated unit/integration tests
- [ ] created/ran system tests (provide build number if applicable)
- [ ] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
