### PR TITLE
refactor: avoid regex in `serviceId` checks

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the Zowe core SDK package will be documented in this file
 
 ## Recent Changes
 
-- BugFix: Improved the handling of APIML service base paths during `zowe config auto-init`. [#2819](https://github.com/zowe/zowe-cli/pull/2819)
+- BugFix: Improved the handling of APIML service base paths in the `Services.getServicesByConfig` function. [#2819](https://github.com/zowe/zowe-cli/pull/2819)
 
 ## `8.32.0`
 

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Zowe core SDK package will be documented in this file.
 
+## Recent Changes
+
+- BugFix: Improved the handling of APIML service base paths during `zowe config auto-init`. [#2819](https://github.com/zowe/zowe-cli/pull/2819)
+
 ## `8.32.0`
 
 - Enhancement: Added `certAccount` option to base profile options to support client certificate authentication using certificates stored in system keystores on macOS and Windows platforms. [#2325](https://github.com/zowe/zowe-cli/issues/2325)

--- a/packages/core/__tests__/apiml/__unit__/Services.unit.test.ts
+++ b/packages/core/__tests__/apiml/__unit__/Services.unit.test.ts
@@ -375,6 +375,74 @@ describe("APIML Services unit tests", () => {
                 }
             ]);
         });
+
+        it("should strip the service ID prefix literally when it contains regex metacharacters", async () => {
+            // The service ID "svc+" contains a regex metacharacter. Previously the prefix was
+            // stripped with a RegExp (`^/svc+/`), which treats "+" as a quantifier and fails to
+            // match the literal base path, causing the base path to be dropped incorrectly.
+            const services: IApimlService[] = [
+                genApimlService("fakeApi", "svc+", [1])
+            ];
+            const configs: IApimlSvcAttrsLoaded[] = [
+                {
+                    apiId: "fakeApi",
+                    connProfType: "fakeProfile",
+                    gatewayUrl: "api/v1",
+                    pluginName: "@zowe/fake-plugin"
+                }
+            ];
+
+            jest.spyOn(RestClient, "getExpectJSON").mockResolvedValueOnce(services);
+            const response = await Services.getServicesByConfig(tokenSession as any, configs);
+
+            expect(response).toEqual([
+                {
+                    profName: "svc+",
+                    profType: "fakeProfile",
+                    basePaths: ["/svc+/api/v1"],
+                    pluginConfigs: new Set(configs),
+                    gatewayUrlConflicts: {}
+                }
+            ]);
+        });
+
+        it("should not hang (ReDoS) when a service ID is a catastrophic-backtracking pattern", async () => {
+            const evilServiceId = "(a+)+";
+            const maliciousBasePath = "/" + "a".repeat(40) + "!";
+            const services: IApimlService[] = [
+                {
+                    serviceId: evilServiceId,
+                    status: "UP",
+                    apiml: {
+                        apiInfo: [
+                            { apiId: "fakeApi", gatewayUrl: "api/v1", basePath: maliciousBasePath }
+                        ] as any,
+                        service: null,
+                        authentication: [{ supportsSso: true } as any]
+                    },
+                    instances: []
+                }
+            ];
+            const configs: IApimlSvcAttrsLoaded[] = [
+                {
+                    apiId: "fakeApi",
+                    connProfType: "fakeProfile",
+                    gatewayUrl: "api/v1",
+                    pluginName: "@zowe/fake-plugin"
+                }
+            ];
+
+            jest.spyOn(RestClient, "getExpectJSON").mockResolvedValueOnce(services);
+
+            const start = Date.now();
+            const response = await Services.getServicesByConfig(tokenSession as any, configs);
+            const elapsed = Date.now() - start;
+
+            // The malicious base path does not match the "/<serviceId>/" prefix, so it is filtered out.
+            expect(response[0].profName).toEqual(evilServiceId);
+            expect(response[0].basePaths).toEqual([]);
+            expect(elapsed).toBeLessThan(1000);
+        });
     });
 
     describe("convertApimlProfileInfoToProfileConfig", () => {

--- a/packages/core/src/apiml/Services.ts
+++ b/packages/core/src/apiml/Services.ts
@@ -140,9 +140,14 @@ export class Services {
                 .reduce((a, b) => a.filter(x => b.includes(x)));
 
             if (commonGatewayUrls.length > 0) {
-                const serviceIdPrefix = new RegExp(`^/${profInfo.profName}/`);
-                profInfo.basePaths = profInfo.basePaths.filter(basePath =>
-                    commonGatewayUrls.includes(basePath.replace(serviceIdPrefix, "")));
+                // Strip the literal "/<serviceId>/" prefix from each base path.
+                const serviceIdPrefix = `/${profInfo.profName}/`;
+                profInfo.basePaths = profInfo.basePaths.filter(basePath => {
+                    const strippedBasePath = basePath.startsWith(serviceIdPrefix)
+                        ? basePath.slice(serviceIdPrefix.length)
+                        : basePath;
+                    return commonGatewayUrls.includes(strippedBasePath);
+                });
                 profInfo.gatewayUrlConflicts = {};
             }
         }


### PR DESCRIPTION
**What It Does**

Avoids using regex in `serviceId` checks in favor of using `startsWith` and splicing to achieve the same result.

**How to Test**

- All unit and system tests should pass
- `zowe config auto-init` command behaves identically to before this change

**Review Checklist**
I certify that I have:
- [x] updated the changelog
- [x] manually tested my changes
- [x] added/updated automated unit/integration tests
- [x] created/ran system tests (job number 2458)
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)