### PR TITLE
Ensure safe tmp directory for copy and edit

### DIFF
--- a/packages/cli/__tests__/zosfiles/__unit__/edit/Edit.utils.unit.test.ts
+++ b/packages/cli/__tests__/zosfiles/__unit__/edit/Edit.utils.unit.test.ts
@@ -16,7 +16,7 @@ import { EditDefinition } from "../../../../src/zosfiles/edit/Edit.definition";
 import { EditUtilities, ILocalFile, Prompt } from "../../../../src/zosfiles/edit/Edit.utils";
 import { cloneDeep } from "lodash";
 import * as fs from "fs";
-import { Download, IZosFilesResponse, Upload } from "@zowe/zos-files-for-zowe-sdk";
+import { Download, IZosFilesResponse, Upload, ZosFilesUtils } from "@zowe/zos-files-for-zowe-sdk";
 import LocalfileDatasetHandler from "../../../../src/zosfiles/compare/lf-ds/LocalfileDataset.handler";
 import { CompareBaseHelper } from "../../../../src/zosfiles/compare/CompareBaseHelper";
 import LocalfileUssHandler from "../../../../src/zosfiles/compare/lf-uss/LocalfileUss.handler";
@@ -76,6 +76,7 @@ describe("Files Edit Utilities", () => {
 
     beforeEach(async () => {
         jest.resetAllMocks();
+        jest.spyOn(ZosFilesUtils, "ensureSafeTempDir").mockImplementation();
     });
     describe("buildTempPath()", () => {
         it("should be able to build the correct temp path with ext argument - uss", async () => {

--- a/packages/cli/src/zosfiles/edit/Edit.utils.ts
+++ b/packages/cli/src/zosfiles/edit/Edit.utils.ts
@@ -9,11 +9,11 @@
 *
 */
 
-import { Download, Upload, IZosFilesResponse, IDownloadOptions, IUploadOptions } from "@zowe/zos-files-for-zowe-sdk";
+import { Download, Upload, IZosFilesResponse, IDownloadOptions, IUploadOptions, ZosFilesUtils } from "@zowe/zos-files-for-zowe-sdk";
 import { AbstractSession, IHandlerParameters, ImperativeError, ProcessUtils, GuiResult,
     TextUtils, IDiffNameOptions, CliUtils } from "@zowe/imperative";
 import { CompareBaseHelper } from "../compare/CompareBaseHelper";
-import { existsSync, lstatSync, mkdirSync, unlinkSync } from "fs";
+import { existsSync, unlinkSync } from "fs";
 import { tmpdir } from "os";
 import * as path from "path";
 import LocalfileDatasetHandler from "../compare/lf-ds/LocalfileDataset.handler";
@@ -84,36 +84,14 @@ export class EditUtilities {
             const hashLen = 10;
             hash = hash.slice(0, hashLen);
             const ussDir = path.join(tmpdir(), "zowe-edit-uss");
-            EditUtilities.ensureSafeTempDir(ussDir);
+            ZosFilesUtils.ensureSafeTempDir(ussDir);
             return path.join(ussDir, path.parse(lfFile.fileName).name + '_' + hash + ext);
         }
         const dsDir = path.join(tmpdir(), "zowe-edit-ds");
-        EditUtilities.ensureSafeTempDir(dsDir);
+        ZosFilesUtils.ensureSafeTempDir(dsDir);
         return path.join(dsDir, lfFile.fileName + ext);
     }
 
-    /**
-     * Ensures a temp directory exists and is safe to use, creating it if necessary.
-     * On POSIX systems, verifies the directory isn't a pre-existing, loosely-permissioned
-     * directory planted by another local user sharing the same tmp location. On Windows,
-     * os.tmpdir() already resolves to a per-user directory whose ACLs prevent other local
-     * users from writing to it, so that co-tenancy risk doesn't apply and the check is skipped.
-     * @param {string} dir - the temp directory to validate or create
-     * @memberof EditUtilities
-     */
-    private static ensureSafeTempDir(dir: string): void {
-        if (!existsSync(dir)) {
-            mkdirSync(dir, { recursive: true, mode: 0o700 });
-            return;
-        }
-        const st = lstatSync(dir);
-        if (!st.isDirectory()) {
-            throw new ImperativeError({ msg: `Unsafe temp directory detected at ${dir}` });
-        }
-        if (process.platform !== "win32" && ((st.mode & 0o777) !== 0o700 || st.uid !== process.getuid!())) {
-            throw new ImperativeError({ msg: `Unsafe temp directory detected at ${dir}` });
-        }
-    }
     /**
      * Check for temp path's existence (check if previously 'stashed'/temp edits exist)
      * @param {string} tempPath - unique file path for local file (stash/temp file)

--- a/packages/cli/src/zosfiles/edit/Edit.utils.ts
+++ b/packages/cli/src/zosfiles/edit/Edit.utils.ts
@@ -13,7 +13,7 @@ import { Download, Upload, IZosFilesResponse, IDownloadOptions, IUploadOptions }
 import { AbstractSession, IHandlerParameters, ImperativeError, ProcessUtils, GuiResult,
     TextUtils, IDiffNameOptions, CliUtils } from "@zowe/imperative";
 import { CompareBaseHelper } from "../compare/CompareBaseHelper";
-import { existsSync, unlinkSync } from "fs";
+import { existsSync, lstatSync, mkdirSync, unlinkSync } from "fs";
 import { tmpdir } from "os";
 import * as path from "path";
 import LocalfileDatasetHandler from "../compare/lf-ds/LocalfileDataset.handler";
@@ -83,11 +83,37 @@ export class EditUtilities {
             // shorten hash
             const hashLen = 10;
             hash = hash.slice(0, hashLen);
-            return path.join(tmpdir(), path.parse(lfFile.fileName).name + '_' + hash + ext);
+            const ussDir = path.join(tmpdir(), "zowe-edit-uss");
+            EditUtilities.ensureSafeTempDir(ussDir);
+            return path.join(ussDir, path.parse(lfFile.fileName).name + '_' + hash + ext);
         }
-        return path.join(tmpdir(), lfFile.fileName + ext);
+        const dsDir = path.join(tmpdir(), "zowe-edit-ds");
+        EditUtilities.ensureSafeTempDir(dsDir);
+        return path.join(dsDir, lfFile.fileName + ext);
     }
 
+    /**
+     * Ensures a temp directory exists and is safe to use, creating it if necessary.
+     * On POSIX systems, verifies the directory isn't a pre-existing, loosely-permissioned
+     * directory planted by another local user sharing the same tmp location. On Windows,
+     * os.tmpdir() already resolves to a per-user directory whose ACLs prevent other local
+     * users from writing to it, so that co-tenancy risk doesn't apply and the check is skipped.
+     * @param {string} dir - the temp directory to validate or create
+     * @memberof EditUtilities
+     */
+    private static ensureSafeTempDir(dir: string): void {
+        if (!existsSync(dir)) {
+            mkdirSync(dir, { recursive: true, mode: 0o700 });
+            return;
+        }
+        const st = lstatSync(dir);
+        if (!st.isDirectory()) {
+            throw new ImperativeError({ msg: `Unsafe temp directory detected at ${dir}` });
+        }
+        if (process.platform !== "win32" && ((st.mode & 0o777) !== 0o700 || st.uid !== process.getuid!())) {
+            throw new ImperativeError({ msg: `Unsafe temp directory detected at ${dir}` });
+        }
+    }
     /**
      * Check for temp path's existence (check if previously 'stashed'/temp edits exist)
      * @param {string} tempPath - unique file path for local file (stash/temp file)

--- a/packages/zosfiles/__tests__/__system__/methods/copy/Copy.system.test.ts
+++ b/packages/zosfiles/__tests__/__system__/methods/copy/Copy.system.test.ts
@@ -133,7 +133,7 @@ describe("Copy", () => {
                     try {
                         await Delete.dataSet(REAL_SESSION, fromDataSetName);
                         await Delete.dataSet(REAL_SESSION, toDataSetName);
-                        fs.rmSync(join(tmpdir(), 'truncatedMembers.txt'));
+                        fs.rmSync(join(tmpdir(), 'zowe-copy-pds', fromDataSetName, 'truncatedMembers.txt'));
                     } catch (err) {
                         Imperative.console.info(`Error: ${inspect(err)}`);
                     }
@@ -142,7 +142,8 @@ describe("Copy", () => {
                 it("Should copy a partitioned data set", async () => {
                     let error;
                     let response;
-                    const truncatedMembersFile = path.join(tmpdir(), 'truncatedMembers.txt');
+                    const truncatedMembersFile = path.join(tmpdir(), 'zowe-copy-pds', fromDataSetName, 'truncatedMembers.txt');
+                    fs.mkdirSync(path.dirname(truncatedMembersFile), { recursive: true, mode: 0o700 });
                     fs.writeFileSync(truncatedMembersFile, "");
                     try {
                         response = await Copy.dataSet(

--- a/packages/zosfiles/__tests__/__unit__/methods/copy/Copy.unit.test.ts
+++ b/packages/zosfiles/__tests__/__unit__/methods/copy/Copy.unit.test.ts
@@ -965,7 +965,7 @@ describe("Copy", () => {
             });
         });
         it("should handle truncation errors and log them to a file", async () => {
-            const truncatedMembersFilePath = path.join(tmpdir(), "truncatedMembers.txt");
+            const truncatedMembersFilePath = path.join(tmpdir(), "zowe-copy-pds", fromDataSetName, "truncatedMembers.txt");
             let response;
             const sourceResponse = {
                 apiResponse: {

--- a/packages/zosfiles/src/methods/copy/Copy.ts
+++ b/packages/zosfiles/src/methods/copy/Copy.ts
@@ -265,7 +265,9 @@ export class Copy {
                 };
             }
 
-            const downloadDir = path.join(tmpdir(), fromPds);
+            const safeTmpDir = path.join(tmpdir(), "zowe-copy-pds");
+            ZosFilesUtils.ensureSafeTempDir(safeTmpDir);
+            const downloadDir = path.join(safeTmpDir, fromPds);
             await Download.allMembers(session, fromPds, {directory:downloadDir});
             const uploadFileList: string[] = ZosFilesUtils.getFileListFromPath(downloadDir);
             const truncatedMembers: string[] = [];
@@ -296,11 +298,11 @@ export class Copy {
                     continue;
                 }
             }
-            const truncatedMembersFile = path.join(tmpdir(), 'truncatedMembers.txt');
+            const truncatedMembersFile = path.join(downloadDir, 'truncatedMembers.txt');
             if(truncatedMembers.length > 0) {
                 // eslint-disable-next-line @typescript-eslint/no-magic-numbers
                 const firstTenMembers = truncatedMembers.slice(0, 10);
-                fs.writeFileSync(truncatedMembersFile, truncatedMembers.join('\n'), {flag: 'w'});
+                fs.writeFileSync(truncatedMembersFile, truncatedMembers.join('\n'), {flag: 'w', mode: 0o600});
                 const numMembers = truncatedMembers.length - firstTenMembers.length;
                 return {
                     success: true,
@@ -313,7 +315,6 @@ export class Copy {
                 };
             }
             fs.rmSync(downloadDir, {recursive: true});
-            fs.rmSync(truncatedMembersFile, {force: true});
             return {
                 success:true,
                 commandResponse: ZosFilesMessages.datasetCopiedSuccessfully.message

--- a/packages/zosfiles/src/methods/copy/Copy.ts
+++ b/packages/zosfiles/src/methods/copy/Copy.ts
@@ -265,9 +265,8 @@ export class Copy {
                 };
             }
 
-            const safeTmpDir = path.join(tmpdir(), "zowe-copy-pds");
-            ZosFilesUtils.ensureSafeTempDir(safeTmpDir);
-            const downloadDir = path.join(safeTmpDir, fromPds);
+            const downloadDir = path.join(tmpdir(), "zowe-copy-pds", fromPds);
+            ZosFilesUtils.ensureSafeTempDir(downloadDir);
             await Download.allMembers(session, fromPds, {directory:downloadDir});
             const uploadFileList: string[] = ZosFilesUtils.getFileListFromPath(downloadDir);
             const truncatedMembers: string[] = [];

--- a/packages/zosfiles/src/methods/copy/Copy.ts
+++ b/packages/zosfiles/src/methods/copy/Copy.ts
@@ -301,12 +301,6 @@ export class Copy {
             if(truncatedMembers.length > 0) {
                 // eslint-disable-next-line @typescript-eslint/no-magic-numbers
                 const firstTenMembers = truncatedMembers.slice(0, 10);
-                if (!fs.existsSync(downloadDir)) {
-                    fs.mkdirSync(downloadDir, {recursive: true, mode: 0o700});
-                    if (process.platform === "win32") {
-                        IO.giveAccessOnlyToOwner(downloadDir);
-                    }
-                }
                 fs.writeFileSync(truncatedMembersFile, truncatedMembers.join('\n'), {flag: 'w', mode: 0o600});
                 if (process.platform === "win32") {
                     IO.giveAccessOnlyToOwner(truncatedMembersFile);

--- a/packages/zosfiles/src/methods/copy/Copy.ts
+++ b/packages/zosfiles/src/methods/copy/Copy.ts
@@ -304,8 +304,14 @@ export class Copy {
                 const firstTenMembers = truncatedMembers.slice(0, 10);
                 if (!fs.existsSync(downloadDir)) {
                     fs.mkdirSync(downloadDir, {recursive: true, mode: 0o700});
+                    if (process.platform === "win32") {
+                        IO.giveAccessOnlyToOwner(downloadDir);
+                    }
                 }
                 fs.writeFileSync(truncatedMembersFile, truncatedMembers.join('\n'), {flag: 'w', mode: 0o600});
+                if (process.platform === "win32") {
+                    IO.giveAccessOnlyToOwner(truncatedMembersFile);
+                }
                 const numMembers = truncatedMembers.length - firstTenMembers.length;
                 return {
                     success: true,

--- a/packages/zosfiles/src/methods/copy/Copy.ts
+++ b/packages/zosfiles/src/methods/copy/Copy.ts
@@ -302,6 +302,9 @@ export class Copy {
             if(truncatedMembers.length > 0) {
                 // eslint-disable-next-line @typescript-eslint/no-magic-numbers
                 const firstTenMembers = truncatedMembers.slice(0, 10);
+                if (!fs.existsSync(downloadDir)) {
+                    fs.mkdirSync(downloadDir, {recursive: true, mode: 0o700});
+                }
                 fs.writeFileSync(truncatedMembersFile, truncatedMembers.join('\n'), {flag: 'w', mode: 0o600});
                 const numMembers = truncatedMembers.length - firstTenMembers.length;
                 return {

--- a/packages/zosfiles/src/utils/ZosFilesUtils.ts
+++ b/packages/zosfiles/src/utils/ZosFilesUtils.ts
@@ -61,6 +61,29 @@ export class ZosFilesUtils {
         return localDirectory;
     }
 
+    /**
+     * Ensures a temp directory exists and is safe to use, creating it if necessary.
+     * On POSIX systems, verifies the directory isn't a pre-existing, loosely-permissioned
+     * directory planted by another local user sharing the same tmp location. On Windows,
+     * os.tmpdir() already resolves to a per-user directory whose ACLs prevent other local
+     * users from writing to it, so that co-tenancy risk doesn't apply and the check is skipped.
+     * @param {string} dir - the temp directory to validate or create
+     * @throws {ImperativeError} - when the directory exists but is not safe to use
+     */
+    public static ensureSafeTempDir(dir: string): void {
+        if (!fs.existsSync(dir)) {
+            fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+            return;
+        }
+        const st = fs.lstatSync(dir);
+        if (!st.isDirectory()) {
+            throw new ImperativeError({ msg: `Unsafe temp directory detected at ${dir}` });
+        }
+        // eslint-disable-next-line @typescript-eslint/no-magic-numbers
+        if (process.platform !== "win32" && ((st.mode & 0o777) !== 0o700 || st.uid !== process.getuid!())) {
+            throw new ImperativeError({ msg: `Unsafe temp directory detected at ${dir}` });
+        }
+    }
 
     /**
      * Get fullpath name from input path.

--- a/packages/zosfiles/src/utils/ZosFilesUtils.ts
+++ b/packages/zosfiles/src/utils/ZosFilesUtils.ts
@@ -73,6 +73,9 @@ export class ZosFilesUtils {
     public static ensureSafeTempDir(dir: string): void {
         if (!fs.existsSync(dir)) {
             fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+            if (process.platform === "win32") {
+                IO.giveAccessOnlyToOwner(dir);
+            }
             return;
         }
         const st = fs.lstatSync(dir);


### PR DESCRIPTION
**What It Does**
- Ensure safe temporary directory when executing a PDS copy or zosfiles edit

**How to Test**
Run `npx jest packages/zosfiles/__tests__/__unit__/methods/copy/Copy.unit.test.ts`

**Review Checklist**
I certify that I have:
- [ ] updated the changelog
- [x] manually tested my changes
- [x] added/updated automated unit/integration tests
- [x] created/ran system tests (provide build number if applicable)
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)
