### PR TITLE
Use random file names for etag-refresh step for `zowe files edit`

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -9351,8 +9351,8 @@
       "license": "MIT"
     },
     "node_modules/linkify-it": {
-      "version": "5.0.1",
-      "integrity": "sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==",
+      "version": "5.0.2",
+      "integrity": "sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==",
       "funding": [
         {
           "type": "github",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2873,15 +2873,15 @@
       }
     },
     "node_modules/@npmcli/package-json/node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.8",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/@npmcli/package-json/node_modules/glob": {
@@ -4923,15 +4923,15 @@
       }
     },
     "node_modules/cacache/node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.8",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/cacache/node_modules/glob": {
@@ -10096,8 +10096,8 @@
       "optional": true
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.16",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "funding": [
         {
           "type": "github",
@@ -10926,8 +10926,8 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.14",
-      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+      "version": "8.5.23",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "funding": [
         {
           "type": "opencollective",
@@ -10944,7 +10944,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -11477,14 +11477,14 @@
       }
     },
     "node_modules/rimraf/node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.8",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/rimraf/node_modules/glob": {
@@ -11637,8 +11637,8 @@
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "7.8.4",
-      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
+      "version": "7.8.5",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -12355,8 +12355,8 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.20",
-      "integrity": "sha512-9FcyK4PA6+WbzlTM9WhQm6vB5W7cP7dUiPsv1g7YDwEQnQ1CGpK3MGlKk/ITVWMk05kHZuBhmVhiv8LZoy/PFQ==",
+      "version": "7.5.22",
+      "integrity": "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
@@ -12540,8 +12540,8 @@
       }
     },
     "node_modules/ts-jest": {
-      "version": "29.4.11",
-      "integrity": "sha512-IrFl7l9AuB/qrNw5quqvAv/hmKMb8dhWOH4jQOGo0Oq8tCeo1O86/iTFG1FaRimgUkF13l4PcepO8ATFT6Ns4g==",
+      "version": "29.4.12",
+      "integrity": "sha512-Ov6ClY53Fflh6BGAnY2DlTq1hYDrTycz2PVTXBWFW2CU+9zrEqAp9fWdGXl42EXO5RLSFAcAZ2JFKbP+zBTFfw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12551,7 +12551,7 @@
         "json5": "^2.2.3",
         "lodash.memoize": "^4.1.2",
         "make-error": "^1.3.6",
-        "semver": "^7.8.0",
+        "semver": "^7.8.5",
         "type-fest": "^4.41.0",
         "yargs-parser": "^21.1.1"
       },
@@ -13579,14 +13579,14 @@
       }
     },
     "packages/cli/node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.8",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "packages/cli/node_modules/isexe": {
@@ -13856,14 +13856,14 @@
       }
     },
     "packages/zosfiles/node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.8",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "packages/zosfiles/node_modules/minimatch": {

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to the Zowe CLI package will be documented in this file.
 
 ## Recent Changes
 
+- BugFix: Hardened temporary file handling in the `zowe zos-files edit` command so the etag-refresh step no longer writes to a shared, predictable path in the OS temp directory. [#2823](https://github.com/zowe/zowe-cli/pull/2823)
 - BugFix: Updated various dependencies for technical currency. [#2817](https://github.com/zowe/zowe-cli/pull/2817)
 
 ## `8.33.3`

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the Zowe CLI package will be documented in this file.
 
 ## Recent Changes
 
-- BugFix: Hardened temporary file handling in the `zowe zos-files edit` command so the etag-refresh step no longer writes to a shared, predictable path in the OS temp directory. [#2823](https://github.com/zowe/zowe-cli/pull/2823)
+- BugFix: Hardened temporary file handling for the `zowe zos-files edit` command: the etag-refresh step no longer uses a shared, fixed path; edit temp directories are now scoped per user (so co-tenants on a shared temp location no longer conflict) and owner-only access is enforced on all platforms; and the downloaded working file is restricted to the owner. [#2823](https://github.com/zowe/zowe-cli/pull/2823)
 - BugFix: Updated various dependencies for technical currency. [#2817](https://github.com/zowe/zowe-cli/pull/2817)
 
 ## `8.33.3`

--- a/packages/cli/__tests__/zosfiles/__unit__/edit/Edit.utils.unit.test.ts
+++ b/packages/cli/__tests__/zosfiles/__unit__/edit/Edit.utils.unit.test.ts
@@ -276,26 +276,6 @@ describe("Files Edit Utilities", () => {
             expect(EditUtilities.destroyTempFile).toHaveBeenCalledTimes(0);
         });
 
-        it("should restrict the freshly downloaded stash file to the owner (0600) - [useStash = false]", async () => {
-            //TEST SETUP
-            const localFile = cloneDeep(localFileDS);
-            localFile.tempPath = "someStashPath";
-            downloadDataSetSpy.mockImplementation(jest.fn(async () => {
-                return zosResp;
-            }));
-            const chmodSpy = jest.spyOn(fs, "chmodSync").mockImplementation(jest.fn());
-
-            //TEST CONFIRMATION
-            await EditUtilities.localDownload(REAL_SESSION, localFile, false);
-            if (process.platform === "win32") {
-                // chmod mode is a no-op on Windows; the 0700 dir + icacls handle it there
-                expect(chmodSpy).not.toHaveBeenCalled();
-            } else {
-                expect(chmodSpy).toHaveBeenCalledWith("someStashPath", 0o600);
-            }
-            chmodSpy.mockRestore();
-        });
-
         it("localDownload should properly pass non-falsy binary option to Download.dataSet", async () => {
             //TEST SETUP
             const localFile = cloneDeep(localFileDS);

--- a/packages/cli/__tests__/zosfiles/__unit__/edit/Edit.utils.unit.test.ts
+++ b/packages/cli/__tests__/zosfiles/__unit__/edit/Edit.utils.unit.test.ts
@@ -240,6 +240,16 @@ describe("Files Edit Utilities", () => {
             const response = await EditUtilities.localDownload(REAL_SESSION, localFileUSS, true);
             expect(response.zosResp?.apiResponse.etag).toContain('remote etag');
             expect(EditUtilities.destroyTempFile).toHaveBeenCalledTimes(1);
+
+            //test that the etag refresh downloads to a safe, unique scratch path - not a shared/predictable one
+            const safeDir = (ZosFilesUtils.ensureSafeTempDir as jest.Mock).mock.calls[0][0];
+            expect(safeDir).toContain("zowe-edit-uss");
+            const scratchPath = downloadUssFileSpy.mock.calls[0][2]?.file as string;
+            expect(scratchPath).toContain(safeDir);
+            expect(path.basename(scratchPath)).toMatch(/^\.etag-refresh-[0-9a-f]+$/);
+            expect(scratchPath).not.toContain("toDelete.txt");
+            //the unique scratch file (not the stash) is the one destroyed
+            expect(EditUtilities.destroyTempFile).toHaveBeenCalledWith(scratchPath);
         });
 
         it("should download etag and copy of remote - [fileType = 'ds', useStash = false]", async () => {

--- a/packages/cli/__tests__/zosfiles/__unit__/edit/Edit.utils.unit.test.ts
+++ b/packages/cli/__tests__/zosfiles/__unit__/edit/Edit.utils.unit.test.ts
@@ -98,6 +98,13 @@ describe("Files Edit Utilities", () => {
             const response = await EditUtilities.buildTempPath(localFileDS, commandParametersDs);
             expect(response).toContain(".txt");
         });
+        it("should use a per-user temp directory name so co-tenants on a shared tmp don't collide", async () => {
+            await EditUtilities.buildTempPath(localFileDS, commandParametersDs);
+            const dirArg = (ZosFilesUtils.ensureSafeTempDir as jest.Mock).mock.calls[0][0];
+            // per-user token (cross-platform, hashed) - not a bare shared name
+            expect(dirArg.endsWith(`zowe-edit-ds-${ZosFilesUtils.getUserTempToken()}`)).toBe(true);
+            expect(dirArg).toMatch(/zowe-edit-ds-[0-9a-f]{10}$/);
+        });
     });
     describe("checkForStash()", () => {
         const existsSyncSpy = jest.spyOn(fs, "existsSync");
@@ -267,6 +274,26 @@ describe("Files Edit Utilities", () => {
             const response = await EditUtilities.localDownload(REAL_SESSION, localFile, false);
             expect(response.zosResp?.apiResponse.etag).toContain('remote etag');
             expect(EditUtilities.destroyTempFile).toHaveBeenCalledTimes(0);
+        });
+
+        it("should restrict the freshly downloaded stash file to the owner (0600) - [useStash = false]", async () => {
+            //TEST SETUP
+            const localFile = cloneDeep(localFileDS);
+            localFile.tempPath = "someStashPath";
+            downloadDataSetSpy.mockImplementation(jest.fn(async () => {
+                return zosResp;
+            }));
+            const chmodSpy = jest.spyOn(fs, "chmodSync").mockImplementation(jest.fn());
+
+            //TEST CONFIRMATION
+            await EditUtilities.localDownload(REAL_SESSION, localFile, false);
+            if (process.platform === "win32") {
+                // chmod mode is a no-op on Windows; the 0700 dir + icacls handle it there
+                expect(chmodSpy).not.toHaveBeenCalled();
+            } else {
+                expect(chmodSpy).toHaveBeenCalledWith("someStashPath", 0o600);
+            }
+            chmodSpy.mockRestore();
         });
 
         it("localDownload should properly pass non-falsy binary option to Download.dataSet", async () => {

--- a/packages/cli/src/zosfiles/edit/Edit.utils.ts
+++ b/packages/cli/src/zosfiles/edit/Edit.utils.ts
@@ -162,8 +162,18 @@ export class EditUtilities {
      * @returns {ILocalFile}
      */
     public static async localDownload(session: AbstractSession, lfFile: ILocalFile, useStash: boolean): Promise<ILocalFile>{
-        // account for both useStash|!useStash and uss|ds when downloading
-        const tempPath = useStash ? path.posix.join(tmpdir(), "toDelete.txt") : lfFile.tempPath;
+        // account for both useStash|!useStash and uss|ds when downloading.
+        // When only refreshing the etag (useStash), download to a throwaway scratch file with a
+        // unique, unpredictable name inside the safe temp dir rather than a shared, predictable path.
+        let scratchPath!: string;
+        if (useStash) {
+            const crypto = require("crypto");
+            const randomNameBytes = 16;
+            const scratchDir = path.join(tmpdir(), `zowe-edit-${lfFile.fileType}`);
+            ZosFilesUtils.ensureSafeTempDir(scratchDir);
+            scratchPath = path.join(scratchDir, `.etag-refresh-${crypto.randomBytes(randomNameBytes).toString("hex")}`);
+        }
+        const tempPath = useStash ? scratchPath : lfFile.tempPath;
         const args: [AbstractSession, string, IDownloadOptions] = [
             session,
             lfFile.fileName,
@@ -183,7 +193,7 @@ export class EditUtilities {
         }
 
         if (useStash){
-            await this.destroyTempFile(path.posix.join(tmpdir(), "toDelete.txt"));
+            await this.destroyTempFile(scratchPath);
         }
         return lfFile;
     }

--- a/packages/cli/src/zosfiles/edit/Edit.utils.ts
+++ b/packages/cli/src/zosfiles/edit/Edit.utils.ts
@@ -13,7 +13,7 @@ import { Download, Upload, IZosFilesResponse, IDownloadOptions, IUploadOptions, 
 import { AbstractSession, IHandlerParameters, ImperativeError, ProcessUtils, GuiResult,
     TextUtils, IDiffNameOptions, CliUtils } from "@zowe/imperative";
 import { CompareBaseHelper } from "../compare/CompareBaseHelper";
-import { chmodSync, existsSync, unlinkSync } from "fs";
+import { existsSync, unlinkSync } from "fs";
 import { tmpdir } from "os";
 import * as path from "path";
 import LocalfileDatasetHandler from "../compare/lf-ds/LocalfileDataset.handler";

--- a/packages/cli/src/zosfiles/edit/Edit.utils.ts
+++ b/packages/cli/src/zosfiles/edit/Edit.utils.ts
@@ -206,17 +206,6 @@ export class EditUtilities {
             lfFile.zosResp = await Download.dataSet(...args);
         }
 
-        if (!useStash && tempPath && process.platform !== "win32") {
-            // The stash now holds remote contents; restrict it to the owner (defense-in-depth atop
-            // the 0700 dir). Best-effort: the enclosing directory already blocks other-user access.
-            const ownerReadWrite = 0o600;
-            try {
-                chmodSync(tempPath, ownerReadWrite);
-            } catch (err) {
-                // ignore - the 0700 temp directory is the primary protection
-            }
-        }
-
         if (useStash){
             await this.destroyTempFile(scratchPath);
         }

--- a/packages/cli/src/zosfiles/edit/Edit.utils.ts
+++ b/packages/cli/src/zosfiles/edit/Edit.utils.ts
@@ -13,7 +13,7 @@ import { Download, Upload, IZosFilesResponse, IDownloadOptions, IUploadOptions, 
 import { AbstractSession, IHandlerParameters, ImperativeError, ProcessUtils, GuiResult,
     TextUtils, IDiffNameOptions, CliUtils } from "@zowe/imperative";
 import { CompareBaseHelper } from "../compare/CompareBaseHelper";
-import { existsSync, unlinkSync } from "fs";
+import { chmodSync, existsSync, unlinkSync } from "fs";
 import { tmpdir } from "os";
 import * as path from "path";
 import LocalfileDatasetHandler from "../compare/lf-ds/LocalfileDataset.handler";
@@ -64,6 +64,23 @@ export interface ILocalFile {
  */
 export class EditUtilities {
     /**
+     * Build the per-user temp directory for edit files and ensure it is safe to use.
+     * The directory name includes a per-user token so co-tenants on a shared OS temp location get
+     * separate directories. With a shared name the first user to run would own the directory and
+     * {@link ZosFilesUtils.ensureSafeTempDir} would then reject it for everyone else. The token is
+     * derived from the current user (not random) so the path stays stable across runs and the
+     * stash remains re-findable.
+     * @param {EditFileType} fileType - "uss" or "ds"
+     * @returns {string} - absolute path to the ensured, per-user temp directory
+     * @memberof EditUtilities
+     */
+    private static ensureEditTempDir(fileType: EditFileType): string {
+        const dir = path.join(tmpdir(), `zowe-edit-${fileType}-${ZosFilesUtils.getUserTempToken()}`);
+        ZosFilesUtils.ensureSafeTempDir(dir);
+        return dir;
+    }
+
+    /**
      * Builds a temp path where local file will be saved. If uss file, file name will be hashed
      * to prevent any conflicts with file naming. A given filename will always result in the
      * same unique file path.
@@ -83,12 +100,10 @@ export class EditUtilities {
             // shorten hash
             const hashLen = 10;
             hash = hash.slice(0, hashLen);
-            const ussDir = path.join(tmpdir(), "zowe-edit-uss");
-            ZosFilesUtils.ensureSafeTempDir(ussDir);
+            const ussDir = this.ensureEditTempDir("uss");
             return path.join(ussDir, path.parse(lfFile.fileName).name + '_' + hash + ext);
         }
-        const dsDir = path.join(tmpdir(), "zowe-edit-ds");
-        ZosFilesUtils.ensureSafeTempDir(dsDir);
+        const dsDir = this.ensureEditTempDir("ds");
         return path.join(dsDir, lfFile.fileName + ext);
     }
 
@@ -169,8 +184,7 @@ export class EditUtilities {
         if (useStash) {
             const crypto = require("crypto");
             const randomNameBytes = 16;
-            const scratchDir = path.join(tmpdir(), `zowe-edit-${lfFile.fileType}`);
-            ZosFilesUtils.ensureSafeTempDir(scratchDir);
+            const scratchDir = this.ensureEditTempDir(lfFile.fileType);
             scratchPath = path.join(scratchDir, `.etag-refresh-${crypto.randomBytes(randomNameBytes).toString("hex")}`);
         }
         const tempPath = useStash ? scratchPath : lfFile.tempPath;
@@ -190,6 +204,17 @@ export class EditUtilities {
             lfFile.encoding = args[2].encoding;
         }else{
             lfFile.zosResp = await Download.dataSet(...args);
+        }
+
+        if (!useStash && tempPath && process.platform !== "win32") {
+            // The stash now holds remote contents; restrict it to the owner (defense-in-depth atop
+            // the 0700 dir). Best-effort: the enclosing directory already blocks other-user access.
+            const ownerReadWrite = 0o600;
+            try {
+                chmodSync(tempPath, ownerReadWrite);
+            } catch (err) {
+                // ignore - the 0700 temp directory is the primary protection
+            }
         }
 
         if (useStash){

--- a/packages/imperative/CHANGELOG.md
+++ b/packages/imperative/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Imperative package will be documented in this file.
 
+## Recent Changes
+
+- Enhancement: Added `IO.hasOwnerOnlyAccess` to check whether a file or directory's access is restricted to the current user only, cross-platform (POSIX mode bits/owner; Windows `icacls` ACL). [#2823](https://github.com/zowe/zowe-cli/pull/2823)
+
 ## `8.34.0`
 
 - Enhancement: Added the `zowe config export-redacted` command to export Zowe configuration layers with sensitive values redacted for troubleshooting and sharing purposes. [#2732](https://github.com/zowe/zowe-cli/pull/2732)

--- a/packages/imperative/CHANGELOG.md
+++ b/packages/imperative/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the Imperative package will be documented in this file.
 
 ## Recent Changes
 
-- Enhancement: Added `IO.hasOwnerOnlyAccess` to check whether a file or directory's access is restricted to the current user only, cross-platform (POSIX mode bits/owner; Windows `icacls` ACL). [#2823](https://github.com/zowe/zowe-cli/pull/2823)
+- Enhancement: Added a `IO.hasOwnerOnlyAccess` utility function to check whether a file or directory's access is restricted to the current user only, cross-platform (POSIX mode bits/owner; Windows `icacls` ACL). [#2823](https://github.com/zowe/zowe-cli/pull/2823)
 
 ## `8.34.0`
 

--- a/packages/imperative/src/io/__tests__/IO.unit.test.ts
+++ b/packages/imperative/src/io/__tests__/IO.unit.test.ts
@@ -517,6 +517,30 @@ describe("IO tests", () => {
             });
         } // end win32
 
+        if (sysInfo.platform === "win32") {
+            it("should restrict file access on Windows when icacls reports its summary in a non-English locale", () => {
+                let caughtError;
+                let spawnSpy: any;
+                try {
+                    // Simulate that the file exists
+                    jest.spyOn(IO, "existsSync").mockReturnValue(true);
+
+                    // the summary line's wording varies by Windows display language; only its
+                    // "<n> processed; <n> failed" shape should matter, not its text content
+                    spawnSpy = jest.spyOn(ExecUtils, "spawnAndGetOutput");
+                    spawnSpy.mockReturnValue("Número de archivos procesados: 1; Errores encontrados: 0");
+
+                    const testPermFile = __dirname + "/onlyUserAccess.txt";
+                    IO.giveAccessOnlyToOwner(testPermFile);
+                } catch (thrownError) {
+                    caughtError = thrownError;
+                }
+
+                expect(caughtError).toBeUndefined();
+                expect(spawnSpy).toHaveBeenCalledTimes(1);
+            });
+        } // end win32
+
         if (sysInfo.platform !== "win32") {
             it("should restrict file access with execute permission on Posix", () => {
                 const testPermFile = __dirname + "/onlyUserAccess.txt";
@@ -626,17 +650,17 @@ describe("IO tests", () => {
             beforeEach(() => {
                 jest.spyOn(IO, "existsSync").mockReturnValue(true);
                 jest.spyOn(os, "platform").mockReturnValue("win32");
-                jest.spyOn(os, "userInfo").mockReturnValue({ username: "fernando" } as any);
+                jest.spyOn(os, "userInfo").mockReturnValue({ username: "rubyTheDog" } as any);
             });
             it("should return true when icacls shows only the current user", () => {
                 jest.spyOn(ExecUtils, "spawnAndGetOutput").mockReturnValue(
-                    "C:\\Temp\\dir fernando:(F)\r\nSuccessfully processed 1 files; Failed processing 0 files" as any
+                    "C:\\Temp\\dir rubyTheDog:(F)\r\nSuccessfully processed 1 files; Failed processing 0 files" as any
                 );
                 expect(IO.hasOwnerOnlyAccess("C:\\Temp\\dir")).toBe(true);
             });
             it("should return true for a domain-qualified current user", () => {
                 jest.spyOn(ExecUtils, "spawnAndGetOutput").mockReturnValue(
-                    "C:\\Temp\\dir MYDOMAIN\\fernando:(F)\r\nSuccessfully processed 1 files; Failed processing 0 files" as any
+                    "C:\\Temp\\dir MYDOMAIN\\rubyTheDog:(F)\r\nSuccessfully processed 1 files; Failed processing 0 files" as any
                 );
                 expect(IO.hasOwnerOnlyAccess("C:\\Temp\\dir")).toBe(true);
             });
@@ -644,16 +668,24 @@ describe("IO tests", () => {
                 jest.spyOn(ExecUtils, "spawnAndGetOutput").mockReturnValue(
                     "C:\\Temp\\dir NT AUTHORITY\\SYSTEM:(F)\r\n" +
                     "          BUILTIN\\Administrators:(F)\r\n" +
-                    "          fernando:(F)\r\n" +
+                    "          rubyTheDog:(F)\r\n" +
                     "Successfully processed 1 files; Failed processing 0 files" as any
                 );
                 expect(IO.hasOwnerOnlyAccess("C:\\Temp\\dir")).toBe(false);
             });
             it("should return false when the single access entry is a different user", () => {
                 jest.spyOn(ExecUtils, "spawnAndGetOutput").mockReturnValue(
-                    "C:\\Temp\\dir someoneelse:(F)\r\nSuccessfully processed 1 files; Failed processing 0 files" as any
+                    "C:\\Temp\\dir monaTheCat:(F)\r\nSuccessfully processed 1 files; Failed processing 0 files" as any
                 );
                 expect(IO.hasOwnerOnlyAccess("C:\\Temp\\dir")).toBe(false);
+            });
+            it("should return true when icacls reports its summary line in a non-English locale", () => {
+                // the summary line's wording varies by Windows display language; only its
+                // shape (no "identity:(perms)" pattern) should matter, not its text content
+                jest.spyOn(ExecUtils, "spawnAndGetOutput").mockReturnValue(
+                    "C:\\Temp\\dir rubyTheDog:(F)\r\nNúmero de archivos procesados: 1; Errores encontrados: 0" as any
+                );
+                expect(IO.hasOwnerOnlyAccess("C:\\Temp\\dir")).toBe(true);
             });
         });
     }); // end hasOwnerOnlyAccess

--- a/packages/imperative/src/io/__tests__/IO.unit.test.ts
+++ b/packages/imperative/src/io/__tests__/IO.unit.test.ts
@@ -572,4 +572,89 @@ describe("IO tests", () => {
             });
         } // end win32
     }); // end giveAccessOnlyToOwner
+
+    describe("hasOwnerOnlyAccess", () => {
+        afterEach(() => {
+            jest.restoreAllMocks();
+        });
+
+        it("should throw when no file name is provided", () => {
+            let caughtError;
+            try {
+                IO.hasOwnerOnlyAccess("   ");
+            } catch (thrownError) {
+                caughtError = thrownError;
+            }
+            expect(caughtError.message).toContain("Expect Error: Required parameter 'fileName' must not be blank");
+        });
+
+        it("should return false when the path does not exist", () => {
+            jest.spyOn(IO, "existsSync").mockReturnValue(false);
+            expect(IO.hasOwnerOnlyAccess("/no/such/path")).toBe(false);
+        });
+
+        it("should return false when access cannot be read", () => {
+            jest.spyOn(IO, "existsSync").mockReturnValue(true);
+            jest.spyOn(os, "platform").mockReturnValue("linux");
+            jest.spyOn(fs, "statSync").mockImplementation(() => { throw new Error("boom"); });
+            expect(IO.hasOwnerOnlyAccess("/tmp/whatever")).toBe(false);
+        });
+
+        // The POSIX branch reads process.getuid(), which is undefined on Windows; gate to POSIX.
+        if (process.platform !== "win32") {
+            describe("POSIX", () => {
+                beforeEach(() => {
+                    jest.spyOn(IO, "existsSync").mockReturnValue(true);
+                    jest.spyOn(os, "platform").mockReturnValue("linux");
+                });
+                it("should return true for an owner-only path owned by the current user", () => {
+                    jest.spyOn(fs, "statSync").mockReturnValue({ mode: 0o700, uid: process.getuid!() } as any);
+                    expect(IO.hasOwnerOnlyAccess("/tmp/dir")).toBe(true);
+                });
+                it("should return false when group or others have any access", () => {
+                    jest.spyOn(fs, "statSync").mockReturnValue({ mode: 0o755, uid: process.getuid!() } as any);
+                    expect(IO.hasOwnerOnlyAccess("/tmp/dir")).toBe(false);
+                });
+                it("should return false when owned by a different user", () => {
+                    jest.spyOn(fs, "statSync").mockReturnValue({ mode: 0o700, uid: process.getuid!() + 1 } as any);
+                    expect(IO.hasOwnerOnlyAccess("/tmp/dir")).toBe(false);
+                });
+            });
+        }
+
+        describe("Windows", () => {
+            beforeEach(() => {
+                jest.spyOn(IO, "existsSync").mockReturnValue(true);
+                jest.spyOn(os, "platform").mockReturnValue("win32");
+                jest.spyOn(os, "userInfo").mockReturnValue({ username: "fernando" } as any);
+            });
+            it("should return true when icacls shows only the current user", () => {
+                jest.spyOn(ExecUtils, "spawnAndGetOutput").mockReturnValue(
+                    "C:\\Temp\\dir fernando:(F)\r\nSuccessfully processed 1 files; Failed processing 0 files" as any
+                );
+                expect(IO.hasOwnerOnlyAccess("C:\\Temp\\dir")).toBe(true);
+            });
+            it("should return true for a domain-qualified current user", () => {
+                jest.spyOn(ExecUtils, "spawnAndGetOutput").mockReturnValue(
+                    "C:\\Temp\\dir MYDOMAIN\\fernando:(F)\r\nSuccessfully processed 1 files; Failed processing 0 files" as any
+                );
+                expect(IO.hasOwnerOnlyAccess("C:\\Temp\\dir")).toBe(true);
+            });
+            it("should return false when more than one access entry is present", () => {
+                jest.spyOn(ExecUtils, "spawnAndGetOutput").mockReturnValue(
+                    "C:\\Temp\\dir NT AUTHORITY\\SYSTEM:(F)\r\n" +
+                    "          BUILTIN\\Administrators:(F)\r\n" +
+                    "          fernando:(F)\r\n" +
+                    "Successfully processed 1 files; Failed processing 0 files" as any
+                );
+                expect(IO.hasOwnerOnlyAccess("C:\\Temp\\dir")).toBe(false);
+            });
+            it("should return false when the single access entry is a different user", () => {
+                jest.spyOn(ExecUtils, "spawnAndGetOutput").mockReturnValue(
+                    "C:\\Temp\\dir someoneelse:(F)\r\nSuccessfully processed 1 files; Failed processing 0 files" as any
+                );
+                expect(IO.hasOwnerOnlyAccess("C:\\Temp\\dir")).toBe(false);
+            });
+        });
+    }); // end hasOwnerOnlyAccess
 });

--- a/packages/imperative/src/io/src/IO.ts
+++ b/packages/imperative/src/io/src/IO.ts
@@ -356,8 +356,14 @@ export class IO {
                 const stdout = ExecUtils.spawnAndGetOutput("icacls",
                     [ fileName, "/inheritancelevel:r", "/grant:r", `${os.userInfo().username}:F`, "/c" ],
                     { encoding: "utf8"}
-                );
-                if (!stdout.includes("Successfully processed 1 files; Failed processing 0 files")) {
+                ).toString();
+                // icacls can exit 0 while still failing to process the file, so its summary line
+                // must be checked too. Match the "<n> processed; <n> failed" shape instead of the
+                // English wording (which varies by Windows display language) - the failure count
+                // is always the second number in the semicolon-separated summary.
+                const summaryLine = stdout.split(/\r?\n/).map((line) => line.trim()).find((line) => /\d+[^;]*;[^;]*\d+/.test(line));
+                const failedCount = Number(summaryLine?.match(/\d+/g)?.[1]);
+                if (failedCount !== 0) {
                     throw new Error(`icacls reports that it could not change file access:\n${stdout}`);
                 }
             } else { // we are on Posix
@@ -399,7 +405,10 @@ export class IO {
                 const aces: string[] = stdout.split(/\r?\n/)
                     .map((line: string) => line.startsWith(fileName) ? line.slice(fileName.length) : line)
                     .map((line: string) => line.trim())
-                    .filter((line: string) => line.length > 0 && !line.startsWith("Successfully processed"));
+                    // Keep only ACE lines (identity followed by a parenthesized permission set, e.g.
+                    // "DESKTOP-XYZ\username:(OI)(CI)(F)"). The localized summary line never has this shape,
+                    // so this drops it without matching its wording, which varies by Windows display language.
+                    .filter((line: string) => line.includes(":(") && line.endsWith(")"));
                 if (aces.length !== 1) {
                     return false;
                 }

--- a/packages/imperative/src/io/src/IO.ts
+++ b/packages/imperative/src/io/src/IO.ts
@@ -376,6 +376,47 @@ export class IO {
     }
 
     /**
+     * Determine whether a file or directory's access is restricted to its owner only.
+     * On POSIX, this means the mode bits grant no permissions to group or others, and
+     * the file is owned by the current user. On Windows, this means `icacls` reports a
+     * single access control entry - restricted to the current user - with inheritance
+     * disabled (i.e. exactly what {@link IO.giveAccessOnlyToOwner} sets up).
+     *
+     * @param  {string} fileName - file or directory to check.
+     * @returns {boolean} - true if only the current user has access, false otherwise
+     *                       (including if the path does not exist or cannot be read).
+     */
+    public static hasOwnerOnlyAccess(fileName: string): boolean {
+        ImperativeExpect.toBeDefinedAndNonBlank(fileName, "fileName");
+        try {
+            if (!IO.existsSync(fileName)) {
+                return false;
+            }
+            if (os.platform() === IO.OS_WIN32) {
+                // On windows, ask icacls for the current ACL and confirm it grants
+                // access to nobody but the current user (mirrors what giveAccessOnlyToOwner sets).
+                const stdout = ExecUtils.spawnAndGetOutput("icacls", [ fileName ], { encoding: "utf8" }).toString();
+                const aces: string[] = stdout.split(/\r?\n/)
+                    .map((line: string) => line.startsWith(fileName) ? line.slice(fileName.length) : line)
+                    .map((line: string) => line.trim())
+                    .filter((line: string) => line.length > 0 && !line.startsWith("Successfully processed"));
+                if (aces.length !== 1) {
+                    return false;
+                }
+                const identity = aces[0].split(":")[0].trim().toLowerCase();
+                const username = os.userInfo().username.toLowerCase();
+                return identity === username || identity.endsWith(`\\${username}`);
+            } else { // we are on Posix
+                const stat = fs.statSync(fileName);
+                const noGroupOrOtherAccess = (stat.mode & (fs.constants.S_IRWXG | fs.constants.S_IRWXO)) === 0;
+                return noGroupOrOtherAccess && stat.uid === process.getuid!();
+            }
+        } catch (errObj) {
+            return false;
+        }
+    }
+
+    /**
      * Create a file asynchronously
      * @static
      * @param  {string} file    - file to create

--- a/packages/imperative/src/io/src/IO.ts
+++ b/packages/imperative/src/io/src/IO.ts
@@ -420,7 +420,7 @@ export class IO {
                 const noGroupOrOtherAccess = (stat.mode & (fs.constants.S_IRWXG | fs.constants.S_IRWXO)) === 0;
                 return noGroupOrOtherAccess && stat.uid === process.getuid!();
             }
-        } catch (errObj) {
+        } catch (error_) {
             return false;
         }
     }

--- a/packages/zosfiles/CHANGELOG.md
+++ b/packages/zosfiles/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Zowe z/OS files SDK package will be documented in this file.
 
+## Recent Changes
+
+- BugFix: Hardened temporary directory handling for partitioned data set copy so the staging directory is scoped per user (co-tenants on a shared temp location no longer conflict) and owner-only access is enforced and re-verified on all platforms. [#2823](https://github.com/zowe/zowe-cli/pull/2823)
+
 ## `8.33.1`
 
 - BugFix: Reduced the encoding of URIs to the minimum that still allows Zowe SDK operations to work successfully in the current z/OS environment. [#2758](https://github.com/zowe/zowe-cli/pull/2758)

--- a/packages/zosfiles/__tests__/__system__/methods/copy/Copy.system.test.ts
+++ b/packages/zosfiles/__tests__/__system__/methods/copy/Copy.system.test.ts
@@ -11,7 +11,7 @@
 
 import { Create, Upload, Delete, CreateDataSetTypeEnum, Copy, ZosFilesMessages, Get, IDataSet,
     ICrossLparCopyDatasetOptions, IGetOptions, IZosFilesResponse,
-    List } from "../../../../src";
+    List, ZosFilesUtils } from "../../../../src";
 import { Imperative, Session } from "@zowe/imperative";
 import { inspect } from "util";
 import { TestEnvironment } from "../../../../../../__tests__/__src__/environment/TestEnvironment";
@@ -133,7 +133,7 @@ describe("Copy", () => {
                     try {
                         await Delete.dataSet(REAL_SESSION, fromDataSetName);
                         await Delete.dataSet(REAL_SESSION, toDataSetName);
-                        fs.rmSync(join(tmpdir(), 'zowe-copy-pds', fromDataSetName, 'truncatedMembers.txt'));
+                        fs.rmSync(join(tmpdir(), `zowe-copy-pds-${ZosFilesUtils.getUserTempToken()}`, fromDataSetName, 'truncatedMembers.txt'));
                     } catch (err) {
                         Imperative.console.info(`Error: ${inspect(err)}`);
                     }
@@ -142,7 +142,7 @@ describe("Copy", () => {
                 it("Should copy a partitioned data set", async () => {
                     let error;
                     let response;
-                    const truncatedMembersFile = path.join(tmpdir(), 'zowe-copy-pds', fromDataSetName, 'truncatedMembers.txt');
+                    const truncatedMembersFile = path.join(tmpdir(), `zowe-copy-pds-${ZosFilesUtils.getUserTempToken()}`, fromDataSetName, 'truncatedMembers.txt');
                     fs.mkdirSync(path.dirname(truncatedMembersFile), { recursive: true, mode: 0o700 });
                     fs.writeFileSync(truncatedMembersFile, "");
                     try {

--- a/packages/zosfiles/__tests__/__unit__/methods/copy/Copy.unit.test.ts
+++ b/packages/zosfiles/__tests__/__unit__/methods/copy/Copy.unit.test.ts
@@ -831,9 +831,10 @@ describe("Copy", () => {
         const uploadSpy = jest.spyOn(Upload, "streamToDataSet");
         const fileListPathSpy = jest.spyOn(ZosFilesUtils, "getFileListFromPath");
         const generateMemName = jest.spyOn(ZosFilesUtils, "generateMemberName");
-        const ensureSafeTempDirSpy = jest.spyOn(ZosFilesUtils, "ensureSafeTempDir").mockImplementation();
-        const giveAccessOnlyToOwnerSpy = jest.spyOn(IO, "giveAccessOnlyToOwner").mockImplementation();
-        const writeFileSyncSpy = jest.spyOn(fs, "writeFileSync").mockImplementation();
+        jest.spyOn(ZosFilesUtils, "ensureSafeTempDir").mockImplementation();
+        jest.spyOn(IO, "giveAccessOnlyToOwner").mockImplementation();
+        jest.spyOn(fs, "writeFileSync").mockImplementation();
+        
         const fromDataSetName = "USER.DATA.FROM";
         const toDataSetName = "USER.DATA.TO";
         const readStream = jest.spyOn(IO, "createReadStream");

--- a/packages/zosfiles/__tests__/__unit__/methods/copy/Copy.unit.test.ts
+++ b/packages/zosfiles/__tests__/__unit__/methods/copy/Copy.unit.test.ts
@@ -831,6 +831,9 @@ describe("Copy", () => {
         const uploadSpy = jest.spyOn(Upload, "streamToDataSet");
         const fileListPathSpy = jest.spyOn(ZosFilesUtils, "getFileListFromPath");
         const generateMemName = jest.spyOn(ZosFilesUtils, "generateMemberName");
+        const ensureSafeTempDirSpy = jest.spyOn(ZosFilesUtils, "ensureSafeTempDir").mockImplementation();
+        const giveAccessOnlyToOwnerSpy = jest.spyOn(IO, "giveAccessOnlyToOwner").mockImplementation();
+        const writeFileSyncSpy = jest.spyOn(fs, "writeFileSync").mockImplementation();
         const fromDataSetName = "USER.DATA.FROM";
         const toDataSetName = "USER.DATA.TO";
         const readStream = jest.spyOn(IO, "createReadStream");
@@ -965,7 +968,7 @@ describe("Copy", () => {
             });
         });
         it("should handle truncation errors and log them to a file", async () => {
-            const truncatedMembersFilePath = path.join(tmpdir(), "zowe-copy-pds", fromDataSetName, "truncatedMembers.txt");
+            const truncatedMembersFilePath = path.join(tmpdir(), `zowe-copy-pds-${ZosFilesUtils.getUserTempToken()}`, fromDataSetName, "truncatedMembers.txt");
             let response;
             const sourceResponse = {
                 apiResponse: {

--- a/packages/zosfiles/__tests__/__unit__/utils/ZosFilesUtils.unit.test.ts
+++ b/packages/zosfiles/__tests__/__unit__/utils/ZosFilesUtils.unit.test.ts
@@ -284,4 +284,78 @@ describe("ZosFilesUtils", () => {
         });
     });
 
+    describe("getUserTempToken", () => {
+        it("should return a stable, filesystem-safe per-user token", () => {
+            const token = ZosFilesUtils.getUserTempToken();
+            // 10-char lowercase hex, safe on any platform/filesystem
+            expect(token).toMatch(/^[0-9a-f]{10}$/);
+            // stable across calls so per-user temp paths stay re-findable
+            expect(ZosFilesUtils.getUserTempToken()).toEqual(token);
+        });
+        it("should fall back to a token when the OS user cannot be determined", () => {
+            const os = require("os");
+            const userInfoSpy = jest.spyOn(os, "userInfo").mockImplementation(() => {
+                throw new Error("no account entry");
+            });
+            const token = ZosFilesUtils.getUserTempToken();
+            expect(token).toMatch(/^[0-9a-f]{10}$/);
+            userInfoSpy.mockRestore();
+        });
+    });
+
+    describe("ensureSafeTempDir", () => {
+        const realPlatform = process.platform;
+        const setPlatform = (value: string) => Object.defineProperty(process, "platform", { value, configurable: true });
+        let existsSyncSpy: jest.SpyInstance;
+        let lstatSyncSpy: jest.SpyInstance;
+        let mkdirSyncSpy: jest.SpyInstance;
+        let giveAccessSpy: jest.SpyInstance;
+        let hasOwnerOnlyAccessSpy: jest.SpyInstance;
+        beforeEach(() => {
+            existsSyncSpy = jest.spyOn(fs, "existsSync");
+            lstatSyncSpy = jest.spyOn(fs, "lstatSync");
+            mkdirSyncSpy = jest.spyOn(fs, "mkdirSync").mockImplementation(jest.fn());
+            giveAccessSpy = jest.spyOn(IO, "giveAccessOnlyToOwner").mockImplementation(jest.fn());
+            hasOwnerOnlyAccessSpy = jest.spyOn(IO, "hasOwnerOnlyAccess").mockImplementation(jest.fn());
+        });
+        afterEach(() => {
+            setPlatform(realPlatform);
+            jest.restoreAllMocks();
+        });
+
+        it("should create the directory owner-only when it does not exist (POSIX)", () => {
+            setPlatform("linux");
+            existsSyncSpy.mockReturnValue(false);
+            ZosFilesUtils.ensureSafeTempDir("/tmp/zowe-edit-ds-abc");
+            expect(mkdirSyncSpy).toHaveBeenCalledWith("/tmp/zowe-edit-ds-abc", { recursive: true, mode: 0o700 });
+            expect(giveAccessSpy).not.toHaveBeenCalled();
+            expect(hasOwnerOnlyAccessSpy).not.toHaveBeenCalled();
+        });
+        it("should set an owner-only ACL when creating on Windows", () => {
+            setPlatform("win32");
+            existsSyncSpy.mockReturnValue(false);
+            ZosFilesUtils.ensureSafeTempDir("C:\\Temp\\zowe-edit-ds-abc");
+            expect(giveAccessSpy).toHaveBeenCalledWith("C:\\Temp\\zowe-edit-ds-abc");
+        });
+        it("should accept a pre-existing directory whose access is restricted to the current user (any platform)", () => {
+            existsSyncSpy.mockReturnValue(true);
+            lstatSyncSpy.mockReturnValue({ isDirectory: () => true } as any);
+            hasOwnerOnlyAccessSpy.mockReturnValue(true);
+            expect(() => ZosFilesUtils.ensureSafeTempDir("/tmp/zowe-edit-ds-abc")).not.toThrow();
+            expect(hasOwnerOnlyAccessSpy).toHaveBeenCalledWith("/tmp/zowe-edit-ds-abc");
+        });
+        it("should reject a pre-existing directory that is not restricted to the current user (any platform)", () => {
+            existsSyncSpy.mockReturnValue(true);
+            lstatSyncSpy.mockReturnValue({ isDirectory: () => true } as any);
+            hasOwnerOnlyAccessSpy.mockReturnValue(false);
+            expect(() => ZosFilesUtils.ensureSafeTempDir("/tmp/zowe-edit-ds-abc")).toThrow(/Unsafe temp directory/);
+        });
+        it("should reject when the path exists but is not a directory (e.g. a planted symlink)", () => {
+            existsSyncSpy.mockReturnValue(true);
+            lstatSyncSpy.mockReturnValue({ isDirectory: () => false } as any);
+            expect(() => ZosFilesUtils.ensureSafeTempDir("/tmp/zowe-edit-ds-abc")).toThrow(/Unsafe temp directory/);
+            expect(hasOwnerOnlyAccessSpy).not.toHaveBeenCalled();
+        });
+    });
+
 });

--- a/packages/zosfiles/src/methods/copy/Copy.ts
+++ b/packages/zosfiles/src/methods/copy/Copy.ts
@@ -265,7 +265,12 @@ export class Copy {
                 };
             }
 
-            const downloadDir = path.join(tmpdir(), "zowe-copy-pds", fromPds);
+            // Per-user parent dir so co-tenants on a shared tmp don't collide on a shared,
+            // foreign-owned directory (which ensureSafeTempDir would reject). Validate the parent
+            // (0700, owned by us) before creating the per-PDS staging dir inside it.
+            const copyBaseDir = path.join(tmpdir(), `zowe-copy-pds-${ZosFilesUtils.getUserTempToken()}`);
+            ZosFilesUtils.ensureSafeTempDir(copyBaseDir);
+            const downloadDir = path.join(copyBaseDir, fromPds);
             ZosFilesUtils.ensureSafeTempDir(downloadDir);
             await Download.allMembers(session, fromPds, {directory:downloadDir});
             const uploadFileList: string[] = ZosFilesUtils.getFileListFromPath(downloadDir);

--- a/packages/zosfiles/src/utils/ZosFilesUtils.ts
+++ b/packages/zosfiles/src/utils/ZosFilesUtils.ts
@@ -11,6 +11,8 @@
 
 import * as path from "path";
 import * as fs from "fs";
+import * as crypto from "crypto";
+import { userInfo } from "os";
 import { IO, Logger, IHeaderContent, EncodeUri, AbstractSession, ImperativeExpect, Headers, ImperativeError } from "@zowe/imperative";
 import { ZosFilesConstants } from "../constants/ZosFiles.constants";
 import { ZosFilesMessages } from "../constants/ZosFiles.messages";
@@ -62,11 +64,36 @@ export class ZosFilesUtils {
     }
 
     /**
+     * Returns a short, filesystem-safe token that is unique per OS user, for building per-user
+     * temp directory names. Deriving the name from the user (rather than a random per-run value)
+     * keeps the path stable across invocations - so features like edit stash-resume still work -
+     * while ensuring co-tenants on a shared temp location get separate directories. The username
+     * is hashed so the token is path-safe for any username and works on every platform (numeric
+     * uids aren't available on Windows).
+     * @returns {string} - a hex token derived from the current OS user
+     */
+    public static getUserTempToken(): string {
+        let id = "default";
+        try {
+            id = userInfo().username;
+        } catch (err) {
+            // userInfo() can throw when the current user has no OS account entry; fall back to uid or a constant
+            if (typeof process.getuid === "function") {
+                id = String(process.getuid());
+            }
+        }
+        const tokenLen = 10;
+        return crypto.createHash("sha256").update(id).digest("hex").slice(0, tokenLen);
+    }
+
+    /**
      * Ensures a temp directory exists and is safe to use, creating it if necessary.
-     * On POSIX systems, verifies the directory isn't a pre-existing, loosely-permissioned
-     * directory planted by another local user sharing the same tmp location. On Windows,
-     * os.tmpdir() already resolves to a per-user directory whose ACLs prevent other local
-     * users from writing to it, so that co-tenancy risk doesn't apply and the check is skipped.
+     * When creating, the directory is restricted to the owner (mode 0700 on POSIX; on Windows
+     * `fs.mkdirSync`'s `mode` is a no-op, so an owner-only ACL is set via {@link IO.giveAccessOnlyToOwner}).
+     * When the directory already exists, it is rejected unless it is a real directory whose access is
+     * restricted to the current user - verified the same way on every platform via
+     * {@link IO.hasOwnerOnlyAccess} - so a directory planted by another local user sharing the same
+     * tmp location is refused.
      * @param {string} dir - the temp directory to validate or create
      * @throws {ImperativeError} - when the directory exists but is not safe to use
      */
@@ -78,12 +105,8 @@ export class ZosFilesUtils {
             }
             return;
         }
-        const st = fs.lstatSync(dir);
-        if (!st.isDirectory()) {
-            throw new ImperativeError({ msg: `Unsafe temp directory detected at ${dir}` });
-        }
-        // eslint-disable-next-line @typescript-eslint/no-magic-numbers
-        if (process.platform !== "win32" && ((st.mode & 0o777) !== 0o700 || st.uid !== process.getuid!())) {
+        // Reject a planted symlink/non-directory (lstat does not follow symlinks) before checking access.
+        if (!fs.lstatSync(dir).isDirectory() || !IO.hasOwnerOnlyAccess(dir)) {
             throw new ImperativeError({ msg: `Unsafe temp directory detected at ${dir}` });
         }
     }


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->
- Follow-up to #2821. 
  - That PR moved the `zowe zos-files edit` working files into a safe temp location. 
  - This PR extends the same behavior to the temporary file used to refresh the etag during an edit.
- Added a new cross-platform utility to verify if a given file or directory has owner-only access.
- Added a per-user temp directory to avoid DoS for co-tenants

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->

Run the unit tests: `npx jest packages/cli/__tests__/zosfiles/__unit__/`

**Review Checklist**
I certify that I have:
- [x] updated the changelog
- [x] manually tested my changes
- [x] added/updated automated unit/integration tests
- [x] created/ran system tests (provide build number if applicable)
  - `2467`
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
