### PR TITLE
Align numeric columns to the right in TextUtils.getTable

### DIFF
--- a/packages/imperative/CHANGELOG.md
+++ b/packages/imperative/CHANGELOG.md
@@ -2,9 +2,12 @@
 
 All notable changes to the Imperative package will be documented in this file.
 
-## `8.36.0`
+## Recent Changes
 
 - Enhancement: Updated `TextUtils.getTable` to detect numeric columns and right-align them using `cli-table3` colAligns support. [#2825](https://github.com/zowe/zowe-cli/pull/2825)
+
+## `8.36.0`
+
 - Enhancement: Added an `--allow-scripts` option to the `zowe plugins install` and `zowe plugins update` commands. [#2839](https://github.com/zowe/zowe-cli/issues/2839)
 - BugFix: Addressed an issue that caused the `npm pack` command to fail, since `npm` v12 changed the command's JSON output from an array to an object. [#2840](https://github.com/zowe/zowe-cli/pull/2840)
 

--- a/packages/imperative/CHANGELOG.md
+++ b/packages/imperative/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to the Imperative package will be documented in this file.
 
 ## Recent Changes
 
+- Enhancement: Updated `TextUtils.getTable` to detect numeric columns and right-align them using `cli-table3` colAligns support. [#2825](https://github.com/zowe/zowe-cli/pull/2825)
 - Enhancement: Added an `--allow-scripts` option to the `zowe plugins install` and `zowe plugins update` commands. [#2839](https://github.com/zowe/zowe-cli/issues/2839)
 - BugFix: Addressed an issue that caused the `npm pack` command to fail, since `npm` v12 changed the command's JSON output from an array to an object. [#2840](https://github.com/zowe/zowe-cli/pull/2840)
 

--- a/packages/imperative/__tests__/__integration__/cmd/__tests__/integration/cli/auto-format/__snapshots__/Cmd.cli.auto-format.table.integration.test.ts.snap
+++ b/packages/imperative/__tests__/__integration__/cmd/__tests__/integration/cli/auto-format/__snapshots__/Cmd.cli.auto-format.table.integration.test.ts.snap
@@ -2,8 +2,8 @@
 
 exports[`cmd-cli auto-format table should allow extraction of properties within each entry of an array 1`] = `
 "name         details            attributes.amount
-strawberries what a great fruit 1000             
-blueberries  super tasty        10               
-banana       amazing!           1                
+strawberries what a great fruit              1000
+blueberries  super tasty                       10
+banana       amazing!                           1
 "
 `;

--- a/packages/imperative/src/utilities/__tests__/TextUtils.unit.test.ts
+++ b/packages/imperative/src/utilities/__tests__/TextUtils.unit.test.ts
@@ -75,6 +75,28 @@ describe("TextUtils", () => {
         expect(table).toContain("row1");
     });
 
+    it("should right-align numeric columns and left-align non-numeric columns", () => {
+        TextUtils.chalk.level = 0;
+        const numericTableObjects = [
+            { item: "Widget A", quantity: 15, price: "12.50" },
+            { item: "Widget B", quantity: 120, price: "3.00" }
+        ];
+        const table = TextUtils.getTable(numericTableObjects, "yellow");
+        expect(table).toContain("Widget A         15   12.50");
+        expect(table).toContain("Widget B        120    3.00");
+    });
+
+    it("should left-align columns with mixed numeric and non-numeric data", () => {
+        TextUtils.chalk.level = 0;
+        const mixedTableObjects = [
+            { item: "Widget A", code: "100" },
+            { item: "Widget B", code: "N/A" }
+        ];
+        const table = TextUtils.getTable(mixedTableObjects, "yellow");
+        expect(table).toContain("Widget A  100");
+        expect(table).toContain("Widget B  N/A");
+    });
+
     it(".wordWrap should properly wrap any given text", () => {
         TextUtils.chalk.level = 0; // turn off color
         const text = "testing can be interesting";

--- a/packages/imperative/src/utilities/__tests__/TextUtils.unit.test.ts
+++ b/packages/imperative/src/utilities/__tests__/TextUtils.unit.test.ts
@@ -75,6 +75,28 @@ describe("TextUtils", () => {
         expect(table).toContain("row1");
     });
 
+    it("should right-align numeric columns and left-align non-numeric columns", () => {
+        TextUtils.chalk.level = 0;
+        const numericTableObjects = [
+            { item: "Widget A", quantity: 15, price: "12.50" },
+            { item: "Widget B", quantity: 120, price: "3.00" }
+        ];
+        const table = TextUtils.getTable(numericTableObjects, "yellow");
+        expect(table).toContain("Widget A       15 12.50");
+        expect(table).toContain("Widget B      120  3.00");
+    });
+
+    it("should left-align columns with mixed numeric and non-numeric data", () => {
+        TextUtils.chalk.level = 0;
+        const mixedTableObjects = [
+            { item: "Widget A", code: "100" },
+            { item: "Widget B", code: "N/A" }
+        ];
+        const table = TextUtils.getTable(mixedTableObjects, "yellow");
+        expect(table).toContain("Widget A 100");
+        expect(table).toContain("Widget B N/A");
+    });
+
     it(".wordWrap should properly wrap any given text", () => {
         TextUtils.chalk.level = 0; // turn off color
         const text = "testing can be interesting";

--- a/packages/imperative/src/utilities/src/TextUtils.ts
+++ b/packages/imperative/src/utilities/src/TextUtils.ts
@@ -186,6 +186,30 @@ export class TextUtils {
                 "left": "", "left-mid": "", "mid": "", "mid-mid": "",
                 "right": "", "right-mid": "", "middle": " "
             };
+        const colAligns: ("left" | "right")[] = headers.map((header) => {
+            let hasNumeric = false;
+            for (const obj of objects) {
+                const val = obj[header];
+                if (val == null || val === "") {
+                    continue;
+                }
+                let isNum = false;
+                if (typeof val === "number") {
+                    isNum = !isNaN(val);
+                } else if (typeof val === "string") {
+                    const trimmed = val.trim();
+                    if (trimmed.length > 0 && !isNaN(Number(trimmed))) {
+                        isNum = true;
+                    }
+                }
+                if (!isNum) {
+                    return "left";
+                }
+                hasNumeric = true;
+            }
+            return hasNumeric ? "right" : "left";
+        });
+
         const table = new Table({
             // colWidths: headers.map((header) => {
             //     return header.length > maxColWidth ? maxColWidth + pad : header.length + pad;
@@ -196,12 +220,14 @@ export class TextUtils {
                     maxColumnWidth, "", hardWrap);
             }) : [],
             chars: borderChars,
+            colAligns,
             style: {"padding-left": 0, "padding-right": 0, "head": [], "border": includeBorders ? [] : undefined}
         });
 
         for (const obj of objects) {
             const row = headers.map((header) => {
-                return TextUtils.wordWrap(obj[header] ?? "", maxColumnWidth, "", hardWrap);
+                const cellVal = obj[header] ?? "";
+                return TextUtils.wordWrap(cellVal, maxColumnWidth, "", hardWrap);
             });
             table.push(row);
         }

--- a/packages/imperative/src/utilities/src/TextUtils.ts
+++ b/packages/imperative/src/utilities/src/TextUtils.ts
@@ -226,8 +226,7 @@ export class TextUtils {
 
         for (const obj of objects) {
             const row = headers.map((header) => {
-                const cellVal = obj[header] ?? "";
-                return TextUtils.wordWrap(cellVal, maxColumnWidth, "", hardWrap);
+                return TextUtils.wordWrap(obj[header] ?? "", maxColumnWidth, "", hardWrap);
             });
             table.push(row);
         }


### PR DESCRIPTION
## What It Does

- Automatically detects columns where all non-empty values are numeric.
- Right-aligns numeric columns using `cli-table3`'s native `colAligns` support.
- Preserves left alignment for text and mixed-content columns.
- Adds unit tests covering numeric and mixed-content alignment.

Fixes #2746

## How to Test

- Generate a table with numeric and text columns.
- Verify numeric columns (including their headers) are right-aligned.
- Verify text and mixed-content columns remain left-aligned.
- Run the existing `TextUtils` unit tests.

## Review Checklist

- [x] Manually reviewed the changes
- [x] Added/updated unit tests
- [ ] Updated the changelog (if required by maintainers)
- [ ] Added/updated integration tests (not applicable)

## Additional Comments

This implementation uses `cli-table3`'s built-in `colAligns` option instead of manual padding, preserving existing behavior while improving numeric column formatting.