### PR TITLE
fix(v2): Use random file names for etag-refresh step

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -78,55 +78,45 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/@ampproject/remapping": {
-      "version": "2.3.0",
-      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
-      "dev": true,
-      "dependencies": {
-        "@jridgewell/gen-mapping": "^0.3.5",
-        "@jridgewell/trace-mapping": "^0.3.24"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
     "node_modules/@babel/code-frame": {
-      "version": "7.26.2",
-      "integrity": "sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==",
+      "version": "7.29.7",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.25.9",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
-        "picocolors": "^1.0.0"
+        "picocolors": "^1.1.1"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.23.5",
-      "integrity": "sha512-uU27kfDRlhfKl+w1U6vp16IuvSLtjAxdArVXPa9BvLkrr7CYIsxH5adpHObeAGY/41+syctUWOZ140a2Rvkgjw==",
+      "version": "7.29.7",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.24.0",
-      "integrity": "sha512-fQfkg0Gjkza3nf0c7/w6Xf34BW4YvzNfACRLmmb7XRLa6XHdR+K9AlJlxneFfWYf6uhOzuzZVTjF/8KfndZANw==",
+      "version": "7.29.7",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@ampproject/remapping": "^2.2.0",
-        "@babel/code-frame": "^7.23.5",
-        "@babel/generator": "^7.23.6",
-        "@babel/helper-compilation-targets": "^7.23.6",
-        "@babel/helper-module-transforms": "^7.23.3",
-        "@babel/helpers": "^7.24.0",
-        "@babel/parser": "^7.24.0",
-        "@babel/template": "^7.24.0",
-        "@babel/traverse": "^7.24.0",
-        "@babel/types": "^7.24.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/remapping": "^2.3.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -155,27 +145,30 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.23.6",
-      "integrity": "sha512-qrSfCYxYQB5owCmGLbl8XRpX1ytXlpueOb0N0UmQwA073KZxejgQTzAmJezxvpwQD9uGtK2shHdi55QT+MbjIw==",
+      "version": "7.29.7",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.23.6",
-        "@jridgewell/gen-mapping": "^0.3.2",
-        "@jridgewell/trace-mapping": "^0.3.17",
-        "jsesc": "^2.5.1"
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.23.6",
-      "integrity": "sha512-9JB548GZoQVmzrFgp8o7KxdgkTGm6xs9DW0o/Pim72UDjzr5ObUQ6ZzYPqA+g9OTS2bBQoctLJrky0RDCAWRgQ==",
+      "version": "7.29.7",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.23.5",
-        "@babel/helper-validator-option": "^7.23.5",
-        "browserslist": "^4.22.2",
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
+        "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
       },
@@ -187,6 +180,7 @@
       "version": "5.1.1",
       "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
       }
@@ -195,62 +189,42 @@
       "version": "6.3.1",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       }
     },
-    "node_modules/@babel/helper-environment-visitor": {
-      "version": "7.22.20",
-      "integrity": "sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA==",
+    "node_modules/@babel/helper-globals": {
+      "version": "7.29.7",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
       "dev": true,
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-function-name": {
-      "version": "7.23.0",
-      "integrity": "sha512-OErEqsrxjZTJciZ4Oo+eoZqeW9UIiOcuYKRJA4ZAgV9myA+pOXhhmpfNCKjEH/auVfEYVFJ6y1Tc4r0eIApqiw==",
-      "dev": true,
-      "dependencies": {
-        "@babel/template": "^7.22.15",
-        "@babel/types": "^7.23.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-hoist-variables": {
-      "version": "7.22.5",
-      "integrity": "sha512-wGjk9QZVzvknA6yKIUURb8zY3grXCcOZt+/7Wcy8O2uctxhplmUPkOdlgoNhmdVee2c92JXbf1xpMtVNbfoxRw==",
-      "dev": true,
-      "dependencies": {
-        "@babel/types": "^7.22.5"
-      },
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.22.15",
-      "integrity": "sha512-0pYVBnDKZO2fnSPCrgM/6WMc7eS20Fbok+0r88fp+YtWVLZrp4CkafFGIp+W0VKw4a22sgebPT99y+FDNMdP4w==",
+      "version": "7.29.7",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.22.15"
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.23.3",
-      "integrity": "sha512-7bBs4ED9OmswdfDzpz4MpWgSrV7FXlc3zIagvLFjS5H+Mk7Snr21vQ6QwrsoCGMfNC4e4LQPdoULEt4ykz0SRQ==",
+      "version": "7.29.7",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/helper-environment-visitor": "^7.22.20",
-        "@babel/helper-module-imports": "^7.22.15",
-        "@babel/helper-simple-access": "^7.22.5",
-        "@babel/helper-split-export-declaration": "^7.22.6",
-        "@babel/helper-validator-identifier": "^7.22.20"
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -267,31 +241,9 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/helper-simple-access": {
-      "version": "7.22.5",
-      "integrity": "sha512-n0H99E/K+Bika3++WNL17POvo4rKWZ7lZEp1Q+fStVbUi8nxPQEBOlTmCOxW/0JsS56SKKQ+ojAe2pHKJHN35w==",
-      "dev": true,
-      "dependencies": {
-        "@babel/types": "^7.22.5"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-split-export-declaration": {
-      "version": "7.22.6",
-      "integrity": "sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==",
-      "dev": true,
-      "dependencies": {
-        "@babel/types": "^7.22.5"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.25.9",
-      "integrity": "sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==",
+      "version": "7.29.7",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -299,8 +251,8 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.25.9",
-      "integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==",
+      "version": "7.29.7",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -308,33 +260,34 @@
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.23.5",
-      "integrity": "sha512-85ttAOMLsr53VgXkTbkx8oA6YTfT4q7/HzXSLEYmjcSTJPMPQtvq1BD79Byep5xMUYbGRzEpDsjUf3dyp54IKw==",
+      "version": "7.29.7",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.27.0",
-      "integrity": "sha512-U5eyP/CTFPuNE3qk+WZMxFkp/4zUzdceQlfzf7DdGdhp+Fezd7HD+i8Y24ZuTMKX3wQBld449jijbGq6OdGNQg==",
+      "version": "7.29.7",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.27.0",
-        "@babel/types": "^7.27.0"
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.27.0",
-      "integrity": "sha512-iaepho73/2Pz7w2eMS0Q5f83+0RKI7i4xmiYeBmDzfRVbQtTOG7Ts0S4HzJVsTMGI9keU8rNfuZr8DKfSt7Yyg==",
+      "version": "7.29.7",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.27.0"
+        "@babel/types": "^7.29.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -519,55 +472,45 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.27.0",
-      "integrity": "sha512-2ncevenBqXI6qRMukPlXwHKHchC7RyMuu4xv5JBXRfOGVcTy1mXCD12qrp7Jsoxll1EV3+9sE4GugBVRjT2jFA==",
+      "version": "7.29.7",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.26.2",
-        "@babel/parser": "^7.27.0",
-        "@babel/types": "^7.27.0"
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.24.0",
-      "integrity": "sha512-HfuJlI8qq3dEDmNU5ChzzpZRWq+oxCZQyMzIMEqLho+AQnhMnKQUzH6ydo3RBl/YjPCuk68Y6s0Gx0AeyULiWw==",
+      "version": "7.29.7",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.23.5",
-        "@babel/generator": "^7.23.6",
-        "@babel/helper-environment-visitor": "^7.22.20",
-        "@babel/helper-function-name": "^7.23.0",
-        "@babel/helper-hoist-variables": "^7.22.5",
-        "@babel/helper-split-export-declaration": "^7.22.6",
-        "@babel/parser": "^7.24.0",
-        "@babel/types": "^7.24.0",
-        "debug": "^4.3.1",
-        "globals": "^11.1.0"
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "debug": "^4.3.1"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/traverse/node_modules/globals": {
-      "version": "11.12.0",
-      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/@babel/types": {
-      "version": "7.27.0",
-      "integrity": "sha512-H45s8fVLYjbhFH62dIJ3WtmJ6RSPt/3DRO0ZcT2SUiYiQyz3BLVb9ADEnLl91m74aQPS3AzzeajZHYOalWe3bg==",
+      "version": "7.29.7",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.25.9",
-        "@babel/helper-validator-identifier": "^7.25.9"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -989,8 +932,8 @@
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.14.2",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.0",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1853,16 +1796,23 @@
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
-      "version": "0.3.5",
-      "integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
+      "version": "0.3.13",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@jridgewell/set-array": "^1.2.1",
-        "@jridgewell/sourcemap-codec": "^1.4.10",
+        "@jridgewell/sourcemap-codec": "^1.5.0",
         "@jridgewell/trace-mapping": "^0.3.24"
-      },
-      "engines": {
-        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
       }
     },
     "node_modules/@jridgewell/resolve-uri": {
@@ -1873,23 +1823,17 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/@jridgewell/set-array": {
-      "version": "1.2.1",
-      "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
-      "dev": true,
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.4.14",
-      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
-      "dev": true
+      "version": "1.5.5",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.25",
-      "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
+      "version": "0.3.31",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
@@ -5498,6 +5442,18 @@
         }
       ]
     },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.11.1",
+      "integrity": "sha512-HYXq73DDpCtNzOmrFsm9eSwCvWCql0RzqjpDzXN9EadiLJ4DNat0nsZ/Bzmy+Ud12mb4/zKDY0cQ805ZzN+i0A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/basic-auth": {
       "version": "2.0.1",
       "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
@@ -5579,8 +5535,8 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.3",
-      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+      "version": "2.1.2",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -5597,8 +5553,8 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.23.0",
-      "integrity": "sha512-QW8HiM1shhT2GuzkvklfjcKDiWFXHOeFCIA/huJPwHsslwcydgk7X+z2zXpEijP98UCY7HbubZt5J2Zgvf0CaQ==",
+      "version": "4.28.7",
+      "integrity": "sha512-JxV13hNrFxqjOc8alRbq9dK1MM79NEXYpma2B2J4wAtpWS5zIEIKqWPGCl7N4o7Uc7B7itylh7SuDujATRyyTw==",
       "dev": true,
       "funding": [
         {
@@ -5614,11 +5570,13 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "dependencies": {
-        "caniuse-lite": "^1.0.30001587",
-        "electron-to-chromium": "^1.4.668",
-        "node-releases": "^2.0.14",
-        "update-browserslist-db": "^1.0.13"
+        "baseline-browser-mapping": "^2.10.44",
+        "caniuse-lite": "^1.0.30001806",
+        "electron-to-chromium": "^1.5.393",
+        "node-releases": "^2.0.51",
+        "update-browserslist-db": "^1.2.3"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -5870,8 +5828,8 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001594",
-      "integrity": "sha512-VblSX6nYqyJVs8DKFMldE2IVCJjZ225LW00ydtUWwh5hk9IfkTOffO6r8gJNsH0qqqeAF8KrbMYA2VEwTlGW5g==",
+      "version": "1.0.30001806",
+      "integrity": "sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==",
       "dev": true,
       "funding": [
         {
@@ -5886,7 +5844,8 @@
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
-      ]
+      ],
+      "license": "CC-BY-4.0"
     },
     "node_modules/cbor": {
       "version": "10.0.11",
@@ -7393,9 +7352,10 @@
       "dev": true
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.692",
-      "integrity": "sha512-d5rZRka9n2Y3MkWRN74IoAsxR0HK3yaAt7T50e3iT9VZmCCQDT3geXUO5ZRMhDToa1pkCeQXuNo+0g+NfDOVPA==",
-      "dev": true
+      "version": "1.5.396",
+      "integrity": "sha512-yHiw2Y3C3H9U6TMbOfoWK/BPreiOPXRfTWPBwQBoZG6/8TB6eOPnsy5oaRYuatR7Fw2SJ4kKforgufeo7fq0EQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/emittery": {
       "version": "0.13.1",
@@ -7532,9 +7492,10 @@
       }
     },
     "node_modules/escalade": {
-      "version": "3.1.1",
-      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+      "version": "3.2.0",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -11304,14 +11265,15 @@
       }
     },
     "node_modules/jsesc": {
-      "version": "2.5.2",
-      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+      "version": "3.1.0",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "jsesc": "bin/jsesc"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">=6"
       }
     },
     "node_modules/json-parse-even-better-errors": {
@@ -11443,8 +11405,19 @@
       "dev": true
     },
     "node_modules/linkify-it": {
-      "version": "5.0.0",
-      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+      "version": "5.0.2",
+      "integrity": "sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
+      "license": "MIT",
       "dependencies": {
         "uc.micro": "^2.0.0"
       }
@@ -11671,6 +11644,22 @@
       "version": "0.1.0",
       "integrity": "sha512-CkYQrPYZfWnu/DAmVCpTSX/xHpKZ80eKh2lAkyA6AJTef6bW+6JpbQZN5rofum7da+SyN1bi5ctTm+lTfcCW3g==",
       "dev": true
+    },
+    "node_modules/markdown-it": {
+      "version": "14.1.1",
+      "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "^4.4.0",
+        "linkify-it": "^5.0.0",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
+      }
     },
     "node_modules/marked": {
       "version": "4.1.1",
@@ -12105,8 +12094,8 @@
       "optional": true
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.16",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "funding": [
         {
           "type": "github",
@@ -12407,9 +12396,13 @@
       "dev": true
     },
     "node_modules/node-releases": {
-      "version": "2.0.14",
-      "integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==",
-      "dev": true
+      "version": "2.0.51",
+      "integrity": "sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/node-source-walk": {
       "version": "4.2.0",
@@ -12997,8 +12990,8 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.23",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "funding": [
         {
           "type": "opencollective",
@@ -13015,7 +13008,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -13041,8 +13034,8 @@
       }
     },
     "node_modules/postcss-url/node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.16",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -13730,8 +13723,8 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.4",
-      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
+      "version": "1.10.0",
+      "integrity": "sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -14308,8 +14301,8 @@
       }
     },
     "node_modules/supertap/node_modules/js-yaml": {
-      "version": "3.14.2",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.0",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -14364,8 +14357,8 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.13",
-      "integrity": "sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==",
+      "version": "7.5.22",
+      "integrity": "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -14869,8 +14862,8 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.0.13",
-      "integrity": "sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==",
+      "version": "1.2.3",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
       "dev": true,
       "funding": [
         {
@@ -14886,9 +14879,10 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "dependencies": {
-        "escalade": "^3.1.1",
-        "picocolors": "^1.0.0"
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
       },
       "bin": {
         "update-browserslist-db": "cli.js"
@@ -15244,7 +15238,8 @@
     "node_modules/yallist": {
       "version": "3.1.1",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/yaml": {
       "version": "2.7.0",
@@ -15769,22 +15764,6 @@
         "node": ">=12"
       }
     },
-    "packages/imperative/node_modules/markdown-it": {
-      "version": "14.1.1",
-      "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1",
-        "entities": "^4.4.0",
-        "linkify-it": "^5.0.0",
-        "mdurl": "^2.0.0",
-        "punycode.js": "^2.3.1",
-        "uc.micro": "^2.1.0"
-      },
-      "bin": {
-        "markdown-it": "bin/markdown-it.mjs"
-      }
-    },
     "packages/imperative/node_modules/npm-package-arg": {
       "version": "9.1.0",
       "integrity": "sha512-4J0GL+u2Nh6OnhvUKXRr2ZMG4lR8qtLp+kv7UiV00Y+nGiSxtttCyIRHCt5L5BNkXQld/RceYItau3MDOoGiBw==",
@@ -16067,45 +16046,36 @@
     }
   },
   "dependencies": {
-    "@ampproject/remapping": {
-      "version": "2.3.0",
-      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
-      "dev": true,
-      "requires": {
-        "@jridgewell/gen-mapping": "^0.3.5",
-        "@jridgewell/trace-mapping": "^0.3.24"
-      }
-    },
     "@babel/code-frame": {
-      "version": "7.26.2",
-      "integrity": "sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==",
+      "version": "7.29.7",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "dev": true,
       "requires": {
-        "@babel/helper-validator-identifier": "^7.25.9",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
-        "picocolors": "^1.0.0"
+        "picocolors": "^1.1.1"
       }
     },
     "@babel/compat-data": {
-      "version": "7.23.5",
-      "integrity": "sha512-uU27kfDRlhfKl+w1U6vp16IuvSLtjAxdArVXPa9BvLkrr7CYIsxH5adpHObeAGY/41+syctUWOZ140a2Rvkgjw==",
+      "version": "7.29.7",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
       "dev": true
     },
     "@babel/core": {
-      "version": "7.24.0",
-      "integrity": "sha512-fQfkg0Gjkza3nf0c7/w6Xf34BW4YvzNfACRLmmb7XRLa6XHdR+K9AlJlxneFfWYf6uhOzuzZVTjF/8KfndZANw==",
+      "version": "7.29.7",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "requires": {
-        "@ampproject/remapping": "^2.2.0",
-        "@babel/code-frame": "^7.23.5",
-        "@babel/generator": "^7.23.6",
-        "@babel/helper-compilation-targets": "^7.23.6",
-        "@babel/helper-module-transforms": "^7.23.3",
-        "@babel/helpers": "^7.24.0",
-        "@babel/parser": "^7.24.0",
-        "@babel/template": "^7.24.0",
-        "@babel/traverse": "^7.24.0",
-        "@babel/types": "^7.24.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/remapping": "^2.3.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -16126,24 +16096,25 @@
       }
     },
     "@babel/generator": {
-      "version": "7.23.6",
-      "integrity": "sha512-qrSfCYxYQB5owCmGLbl8XRpX1ytXlpueOb0N0UmQwA073KZxejgQTzAmJezxvpwQD9uGtK2shHdi55QT+MbjIw==",
+      "version": "7.29.7",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.23.6",
-        "@jridgewell/gen-mapping": "^0.3.2",
-        "@jridgewell/trace-mapping": "^0.3.17",
-        "jsesc": "^2.5.1"
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
       }
     },
     "@babel/helper-compilation-targets": {
-      "version": "7.23.6",
-      "integrity": "sha512-9JB548GZoQVmzrFgp8o7KxdgkTGm6xs9DW0o/Pim72UDjzr5ObUQ6ZzYPqA+g9OTS2bBQoctLJrky0RDCAWRgQ==",
+      "version": "7.29.7",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
       "dev": true,
       "requires": {
-        "@babel/compat-data": "^7.23.5",
-        "@babel/helper-validator-option": "^7.23.5",
-        "browserslist": "^4.22.2",
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
+        "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
       },
@@ -16163,46 +16134,28 @@
         }
       }
     },
-    "@babel/helper-environment-visitor": {
-      "version": "7.22.20",
-      "integrity": "sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA==",
+    "@babel/helper-globals": {
+      "version": "7.29.7",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
       "dev": true
     },
-    "@babel/helper-function-name": {
-      "version": "7.23.0",
-      "integrity": "sha512-OErEqsrxjZTJciZ4Oo+eoZqeW9UIiOcuYKRJA4ZAgV9myA+pOXhhmpfNCKjEH/auVfEYVFJ6y1Tc4r0eIApqiw==",
-      "dev": true,
-      "requires": {
-        "@babel/template": "^7.22.15",
-        "@babel/types": "^7.23.0"
-      }
-    },
-    "@babel/helper-hoist-variables": {
-      "version": "7.22.5",
-      "integrity": "sha512-wGjk9QZVzvknA6yKIUURb8zY3grXCcOZt+/7Wcy8O2uctxhplmUPkOdlgoNhmdVee2c92JXbf1xpMtVNbfoxRw==",
-      "dev": true,
-      "requires": {
-        "@babel/types": "^7.22.5"
-      }
-    },
     "@babel/helper-module-imports": {
-      "version": "7.22.15",
-      "integrity": "sha512-0pYVBnDKZO2fnSPCrgM/6WMc7eS20Fbok+0r88fp+YtWVLZrp4CkafFGIp+W0VKw4a22sgebPT99y+FDNMdP4w==",
+      "version": "7.29.7",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.22.15"
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
       }
     },
     "@babel/helper-module-transforms": {
-      "version": "7.23.3",
-      "integrity": "sha512-7bBs4ED9OmswdfDzpz4MpWgSrV7FXlc3zIagvLFjS5H+Mk7Snr21vQ6QwrsoCGMfNC4e4LQPdoULEt4ykz0SRQ==",
+      "version": "7.29.7",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
       "dev": true,
       "requires": {
-        "@babel/helper-environment-visitor": "^7.22.20",
-        "@babel/helper-module-imports": "^7.22.15",
-        "@babel/helper-simple-access": "^7.22.5",
-        "@babel/helper-split-export-declaration": "^7.22.6",
-        "@babel/helper-validator-identifier": "^7.22.20"
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       }
     },
     "@babel/helper-plugin-utils": {
@@ -16210,52 +16163,36 @@
       "integrity": "sha512-uLls06UVKgFG9QD4OeFYLEGteMIAa5kpTPcFL28yuCIIzsf6ZyKZMllKVOCZFhiZ5ptnwX4mtKdWCBE/uT4amg==",
       "dev": true
     },
-    "@babel/helper-simple-access": {
-      "version": "7.22.5",
-      "integrity": "sha512-n0H99E/K+Bika3++WNL17POvo4rKWZ7lZEp1Q+fStVbUi8nxPQEBOlTmCOxW/0JsS56SKKQ+ojAe2pHKJHN35w==",
-      "dev": true,
-      "requires": {
-        "@babel/types": "^7.22.5"
-      }
-    },
-    "@babel/helper-split-export-declaration": {
-      "version": "7.22.6",
-      "integrity": "sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==",
-      "dev": true,
-      "requires": {
-        "@babel/types": "^7.22.5"
-      }
-    },
     "@babel/helper-string-parser": {
-      "version": "7.25.9",
-      "integrity": "sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==",
+      "version": "7.29.7",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "dev": true
     },
     "@babel/helper-validator-identifier": {
-      "version": "7.25.9",
-      "integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==",
+      "version": "7.29.7",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true
     },
     "@babel/helper-validator-option": {
-      "version": "7.23.5",
-      "integrity": "sha512-85ttAOMLsr53VgXkTbkx8oA6YTfT4q7/HzXSLEYmjcSTJPMPQtvq1BD79Byep5xMUYbGRzEpDsjUf3dyp54IKw==",
+      "version": "7.29.7",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
       "dev": true
     },
     "@babel/helpers": {
-      "version": "7.27.0",
-      "integrity": "sha512-U5eyP/CTFPuNE3qk+WZMxFkp/4zUzdceQlfzf7DdGdhp+Fezd7HD+i8Y24ZuTMKX3wQBld449jijbGq6OdGNQg==",
+      "version": "7.29.7",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
       "dev": true,
       "requires": {
-        "@babel/template": "^7.27.0",
-        "@babel/types": "^7.27.0"
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
       }
     },
     "@babel/parser": {
-      "version": "7.27.0",
-      "integrity": "sha512-iaepho73/2Pz7w2eMS0Q5f83+0RKI7i4xmiYeBmDzfRVbQtTOG7Ts0S4HzJVsTMGI9keU8rNfuZr8DKfSt7Yyg==",
+      "version": "7.29.7",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.27.0"
+        "@babel/types": "^7.29.7"
       }
     },
     "@babel/plugin-syntax-async-generators": {
@@ -16379,46 +16316,36 @@
       }
     },
     "@babel/template": {
-      "version": "7.27.0",
-      "integrity": "sha512-2ncevenBqXI6qRMukPlXwHKHchC7RyMuu4xv5JBXRfOGVcTy1mXCD12qrp7Jsoxll1EV3+9sE4GugBVRjT2jFA==",
+      "version": "7.29.7",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.26.2",
-        "@babel/parser": "^7.27.0",
-        "@babel/types": "^7.27.0"
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
       }
     },
     "@babel/traverse": {
-      "version": "7.24.0",
-      "integrity": "sha512-HfuJlI8qq3dEDmNU5ChzzpZRWq+oxCZQyMzIMEqLho+AQnhMnKQUzH6ydo3RBl/YjPCuk68Y6s0Gx0AeyULiWw==",
+      "version": "7.29.7",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.23.5",
-        "@babel/generator": "^7.23.6",
-        "@babel/helper-environment-visitor": "^7.22.20",
-        "@babel/helper-function-name": "^7.23.0",
-        "@babel/helper-hoist-variables": "^7.22.5",
-        "@babel/helper-split-export-declaration": "^7.22.6",
-        "@babel/parser": "^7.24.0",
-        "@babel/types": "^7.24.0",
-        "debug": "^4.3.1",
-        "globals": "^11.1.0"
-      },
-      "dependencies": {
-        "globals": {
-          "version": "11.12.0",
-          "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-          "dev": true
-        }
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "debug": "^4.3.1"
       }
     },
     "@babel/types": {
-      "version": "7.27.0",
-      "integrity": "sha512-H45s8fVLYjbhFH62dIJ3WtmJ6RSPt/3DRO0ZcT2SUiYiQyz3BLVb9ADEnLl91m74aQPS3AzzeajZHYOalWe3bg==",
+      "version": "7.29.7",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "dev": true,
       "requires": {
-        "@babel/helper-string-parser": "^7.25.9",
-        "@babel/helper-validator-identifier": "^7.25.9"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       }
     },
     "@bcoe/v8-coverage": {
@@ -16684,8 +16611,8 @@
           }
         },
         "js-yaml": {
-          "version": "3.14.2",
-          "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+          "version": "3.15.0",
+          "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
           "dev": true,
           "requires": {
             "argparse": "^1.0.7",
@@ -17338,12 +17265,20 @@
       }
     },
     "@jridgewell/gen-mapping": {
-      "version": "0.3.5",
-      "integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
+      "version": "0.3.13",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
       "dev": true,
       "requires": {
-        "@jridgewell/set-array": "^1.2.1",
-        "@jridgewell/sourcemap-codec": "^1.4.10",
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "@jridgewell/remapping": {
+      "version": "2.3.5",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.24"
       }
     },
@@ -17352,19 +17287,14 @@
       "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
       "dev": true
     },
-    "@jridgewell/set-array": {
-      "version": "1.2.1",
-      "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
-      "dev": true
-    },
     "@jridgewell/sourcemap-codec": {
-      "version": "1.4.14",
-      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
+      "version": "1.5.5",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true
     },
     "@jridgewell/trace-mapping": {
-      "version": "0.3.25",
-      "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
+      "version": "0.3.31",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
       "dev": true,
       "requires": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -19407,18 +19337,6 @@
           "version": "7.18.3",
           "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA=="
         },
-        "markdown-it": {
-          "version": "14.1.1",
-          "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
-          "requires": {
-            "argparse": "^2.0.1",
-            "entities": "^4.4.0",
-            "linkify-it": "^5.0.0",
-            "mdurl": "^2.0.0",
-            "punycode.js": "^2.3.1",
-            "uc.micro": "^2.1.0"
-          }
-        },
         "npm-package-arg": {
           "version": "9.1.0",
           "integrity": "sha512-4J0GL+u2Nh6OnhvUKXRr2ZMG4lR8qtLp+kv7UiV00Y+nGiSxtttCyIRHCt5L5BNkXQld/RceYItau3MDOoGiBw==",
@@ -20173,6 +20091,11 @@
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
       "dev": true
     },
+    "baseline-browser-mapping": {
+      "version": "2.11.1",
+      "integrity": "sha512-HYXq73DDpCtNzOmrFsm9eSwCvWCql0RzqjpDzXN9EadiLJ4DNat0nsZ/Bzmy+Ud12mb4/zKDY0cQ805ZzN+i0A==",
+      "dev": true
+    },
     "basic-auth": {
       "version": "2.0.1",
       "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
@@ -20235,8 +20158,8 @@
       "requires": {}
     },
     "brace-expansion": {
-      "version": "2.0.3",
-      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+      "version": "2.1.2",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "requires": {
         "balanced-match": "^1.0.0"
       }
@@ -20249,14 +20172,15 @@
       }
     },
     "browserslist": {
-      "version": "4.23.0",
-      "integrity": "sha512-QW8HiM1shhT2GuzkvklfjcKDiWFXHOeFCIA/huJPwHsslwcydgk7X+z2zXpEijP98UCY7HbubZt5J2Zgvf0CaQ==",
+      "version": "4.28.7",
+      "integrity": "sha512-JxV13hNrFxqjOc8alRbq9dK1MM79NEXYpma2B2J4wAtpWS5zIEIKqWPGCl7N4o7Uc7B7itylh7SuDujATRyyTw==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "^1.0.30001587",
-        "electron-to-chromium": "^1.4.668",
-        "node-releases": "^2.0.14",
-        "update-browserslist-db": "^1.0.13"
+        "baseline-browser-mapping": "^2.10.44",
+        "caniuse-lite": "^1.0.30001806",
+        "electron-to-chromium": "^1.5.393",
+        "node-releases": "^2.0.51",
+        "update-browserslist-db": "^1.2.3"
       }
     },
     "bs-logger": {
@@ -20420,8 +20344,8 @@
       "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
     },
     "caniuse-lite": {
-      "version": "1.0.30001594",
-      "integrity": "sha512-VblSX6nYqyJVs8DKFMldE2IVCJjZ225LW00ydtUWwh5hk9IfkTOffO6r8gJNsH0qqqeAF8KrbMYA2VEwTlGW5g==",
+      "version": "1.0.30001806",
+      "integrity": "sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==",
       "dev": true
     },
     "cbor": {
@@ -21474,8 +21398,8 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.4.692",
-      "integrity": "sha512-d5rZRka9n2Y3MkWRN74IoAsxR0HK3yaAt7T50e3iT9VZmCCQDT3geXUO5ZRMhDToa1pkCeQXuNo+0g+NfDOVPA==",
+      "version": "1.5.396",
+      "integrity": "sha512-yHiw2Y3C3H9U6TMbOfoWK/BPreiOPXRfTWPBwQBoZG6/8TB6eOPnsy5oaRYuatR7Fw2SJ4kKforgufeo7fq0EQ==",
       "dev": true
     },
     "emittery": {
@@ -21573,8 +21497,8 @@
       }
     },
     "escalade": {
-      "version": "3.1.1",
-      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+      "version": "3.2.0",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
       "dev": true
     },
     "escape-string-regexp": {
@@ -24243,8 +24167,8 @@
       }
     },
     "jsesc": {
-      "version": "2.5.2",
-      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+      "version": "3.1.0",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
       "dev": true
     },
     "json-parse-even-better-errors": {
@@ -24344,8 +24268,8 @@
       "dev": true
     },
     "linkify-it": {
-      "version": "5.0.0",
-      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+      "version": "5.0.2",
+      "integrity": "sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==",
       "requires": {
         "uc.micro": "^2.0.0"
       }
@@ -24511,6 +24435,18 @@
       "version": "0.1.0",
       "integrity": "sha512-CkYQrPYZfWnu/DAmVCpTSX/xHpKZ80eKh2lAkyA6AJTef6bW+6JpbQZN5rofum7da+SyN1bi5ctTm+lTfcCW3g==",
       "dev": true
+    },
+    "markdown-it": {
+      "version": "14.1.1",
+      "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
+      "requires": {
+        "argparse": "^2.0.1",
+        "entities": "^4.4.0",
+        "linkify-it": "^5.0.0",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
+      }
     },
     "marked": {
       "version": "4.1.1",
@@ -24807,8 +24743,8 @@
       "optional": true
     },
     "nanoid": {
-      "version": "3.3.12",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ=="
+      "version": "3.3.16",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q=="
     },
     "natural-compare": {
       "version": "1.4.0",
@@ -24988,8 +24924,8 @@
       "dev": true
     },
     "node-releases": {
-      "version": "2.0.14",
-      "integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==",
+      "version": "2.0.51",
+      "integrity": "sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==",
       "dev": true
     },
     "node-source-walk": {
@@ -25382,10 +25318,10 @@
       }
     },
     "postcss": {
-      "version": "8.5.15",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.23",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "requires": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       }
@@ -25402,8 +25338,8 @@
       },
       "dependencies": {
         "brace-expansion": {
-          "version": "1.1.13",
-          "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+          "version": "1.1.16",
+          "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
           "dev": true,
           "requires": {
             "balanced-match": "^1.0.0",
@@ -25874,8 +25810,8 @@
       "dev": true
     },
     "shell-quote": {
-      "version": "1.8.4",
-      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
+      "version": "1.10.0",
+      "integrity": "sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==",
       "dev": true
     },
     "shiki": {
@@ -26283,8 +26219,8 @@
           "dev": true
         },
         "js-yaml": {
-          "version": "3.14.2",
-          "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+          "version": "3.15.0",
+          "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
           "dev": true,
           "requires": {
             "argparse": "^1.0.7",
@@ -26319,8 +26255,8 @@
       "dev": true
     },
     "tar": {
-      "version": "7.5.13",
-      "integrity": "sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==",
+      "version": "7.5.22",
+      "integrity": "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==",
       "dev": true,
       "requires": {
         "@isaacs/fs-minipass": "^4.0.0",
@@ -26641,12 +26577,12 @@
       "dev": true
     },
     "update-browserslist-db": {
-      "version": "1.0.13",
-      "integrity": "sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==",
+      "version": "1.2.3",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
       "dev": true,
       "requires": {
-        "escalade": "^3.1.1",
-        "picocolors": "^1.0.0"
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
       }
     },
     "uri-js": {

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the Zowe CLI package will be documented in this file.
 
 ## Recent Changes
 
-- BugFix: Hardened temporary file handling for the `zowe zos-files edit` command: the etag-refresh step no longer uses a shared, fixed path; edit temp directories are now scoped per user (so co-tenants on a shared temp location no longer conflict) and owner-only access is enforced on all platforms; and the downloaded working file is restricted to the owner. [#2826](https://github.com/zowe/zowe-cli/pull/2826)
+- BugFix: Hardened temporary file handling for the `zowe zos-files edit` command: the etag-refresh step no longer uses a shared, fixed path, and edit temp directories are now scoped per user (so co-tenants on a shared temp location no longer conflict) with owner-only access enforced on all platforms. [#2826](https://github.com/zowe/zowe-cli/pull/2826)
 - BugFix: Hardened daemon client authentication so that another local user cannot drive a daemon they do not own. [#2805](https://github.com/zowe/zowe-cli/pull/2805)
 - BugFix: Fixed "Access is denied" error when running CLI commands on Windows if daemon mode is active. [#2808](https://github.com/zowe/zowe-cli/issues/2808)
 - BugFix: Updated the `zowe zos-files uss edit` command to store temp files in a dedicated subdirectory with owner-only permissions (`0o700`). [#2815](https://github.com/zowe/zowe-cli/pull/2815)

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the Zowe CLI package will be documented in this file.
 
 ## Recent Changes
 
-- BugFix: Hardened temporary file handling in the `zowe zos-files edit` command.
+- BugFix: Hardened temporary file handling in the `zowe zos-files edit` command. [#2826](https://github.com/zowe/zowe-cli/pull/2826)
 - BugFix: Hardened daemon client authentication so that another local user cannot drive a daemon they do not own. [#2805](https://github.com/zowe/zowe-cli/pull/2805)
 - BugFix: Fixed "Access is denied" error when running CLI commands on Windows if daemon mode is active. [#2808](https://github.com/zowe/zowe-cli/issues/2808)
 - BugFix: Updated the `zowe zos-files uss edit` command to store temp files in a dedicated subdirectory with owner-only permissions (`0o700`). [#2815](https://github.com/zowe/zowe-cli/pull/2815)

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the Zowe CLI package will be documented in this file.
 
 ## Recent Changes
 
-- BugFix: Hardened temporary file handling in the `zowe zos-files edit` command. [#2826](https://github.com/zowe/zowe-cli/pull/2826)
+- BugFix: Hardened temporary file handling for the `zowe zos-files edit` command: the etag-refresh step no longer uses a shared, fixed path; edit temp directories are now scoped per user (so co-tenants on a shared temp location no longer conflict) and owner-only access is enforced on all platforms; and the downloaded working file is restricted to the owner. [#2826](https://github.com/zowe/zowe-cli/pull/2826)
 - BugFix: Hardened daemon client authentication so that another local user cannot drive a daemon they do not own. [#2805](https://github.com/zowe/zowe-cli/pull/2805)
 - BugFix: Fixed "Access is denied" error when running CLI commands on Windows if daemon mode is active. [#2808](https://github.com/zowe/zowe-cli/issues/2808)
 - BugFix: Updated the `zowe zos-files uss edit` command to store temp files in a dedicated subdirectory with owner-only permissions (`0o700`). [#2815](https://github.com/zowe/zowe-cli/pull/2815)

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to the Zowe CLI package will be documented in this file.
 
 ## Recent Changes
 
+- BugFix: Hardened temporary file handling in the `zowe zos-files edit` command.
 - BugFix: Hardened daemon client authentication so that another local user cannot drive a daemon they do not own. [#2805](https://github.com/zowe/zowe-cli/pull/2805)
 - BugFix: Fixed "Access is denied" error when running CLI commands on Windows if daemon mode is active. [#2808](https://github.com/zowe/zowe-cli/issues/2808)
 - BugFix: Updated the `zowe zos-files uss edit` command to store temp files in a dedicated subdirectory with owner-only permissions (`0o700`). [#2815](https://github.com/zowe/zowe-cli/pull/2815)

--- a/packages/cli/__tests__/zosfiles/__unit__/edit/Edit.utils.unit.test.ts
+++ b/packages/cli/__tests__/zosfiles/__unit__/edit/Edit.utils.unit.test.ts
@@ -104,11 +104,13 @@ describe("Files Edit Utilities", () => {
             let existsSyncSpy: jest.SpyInstance;
             let lstatSyncSpy: jest.SpyInstance;
             let mkdirSyncSpy: jest.SpyInstance;
+            let hasOwnerOnlyAccessSpy: jest.SpyInstance;
 
             beforeEach(() => {
                 existsSyncSpy = jest.spyOn(fs, "existsSync");
                 lstatSyncSpy = jest.spyOn(fs, "lstatSync");
                 mkdirSyncSpy = jest.spyOn(fs, "mkdirSync").mockImplementation(jest.fn() as any);
+                hasOwnerOnlyAccessSpy = jest.spyOn(IO, "hasOwnerOnlyAccess");
             });
 
             it("should create temp dir with mode 0o700 when it does not exist", async () => {
@@ -121,24 +123,26 @@ describe("Files Edit Utilities", () => {
                     { recursive: true, mode: 0o700 }
                 );
             });
-            it("should succeed when existing temp dir has correct permissions and owner", async () => {
+            it("should use a per-user temp directory name so co-tenants on a shared tmp don't collide", async () => {
+                existsSyncSpy.mockReturnValue(false);
+
+                const response = await EditUtilities.buildTempPath(localFileDS, commandParametersDs);
+                const expectedToken = (EditUtilities as any).getUserTempToken();
+
+                expect(expectedToken).toMatch(/^[0-9a-f]{10}$/);
+                expect(response).toContain(`zowe-edit-ds-${expectedToken}`);
+            });
+            it("should succeed when existing temp dir has owner-only access", async () => {
                 existsSyncSpy.mockReturnValue(true);
-                lstatSyncSpy.mockReturnValue({
-                    isDirectory: () => true,
-                    mode: 0o700,
-                    uid: process.getuid?.()
-                } as any);
+                lstatSyncSpy.mockReturnValue({ isDirectory: () => true } as any);
+                hasOwnerOnlyAccessSpy.mockReturnValue(true);
 
                 const response = await EditUtilities.buildTempPath(localFileDS, commandParametersDs);
                 expect(response).toContain("zowe-edit-ds");
             });
             it("should throw ImperativeError when temp dir path is not a directory", async () => {
                 existsSyncSpy.mockReturnValue(true);
-                lstatSyncSpy.mockReturnValue({
-                    isDirectory: () => false,
-                    mode: 0o700,
-                    uid: process.getuid?.()
-                } as any);
+                lstatSyncSpy.mockReturnValue({ isDirectory: () => false } as any);
 
                 try {
                     await EditUtilities.buildTempPath(localFileDS, commandParametersDs);
@@ -147,30 +151,12 @@ describe("Files Edit Utilities", () => {
                 }
                 expect(caughtError).toBeInstanceOf(ImperativeError);
                 expect(caughtError.message).toContain("Unsafe temp directory");
+                expect(hasOwnerOnlyAccessSpy).not.toHaveBeenCalled();
             });
-            it("should throw ImperativeError when temp dir has unsafe permissions", async () => {
+            it("should throw ImperativeError when temp dir does not have owner-only access", async () => {
                 existsSyncSpy.mockReturnValue(true);
-                lstatSyncSpy.mockReturnValue({
-                    isDirectory: () => true,
-                    mode: 0o755,
-                    uid: process.getuid?.()
-                } as any);
-
-                try {
-                    await EditUtilities.buildTempPath(localFileDS, commandParametersDs);
-                } catch(e) {
-                    caughtError = e;
-                }
-                expect(caughtError).toBeInstanceOf(ImperativeError);
-                expect(caughtError.message).toContain("Unsafe temp directory");
-            });
-            it("should throw ImperativeError when temp dir is owned by a different user", async () => {
-                existsSyncSpy.mockReturnValue(true);
-                lstatSyncSpy.mockReturnValue({
-                    isDirectory: () => true,
-                    mode: 0o700,
-                    uid: (process.getuid?.() ?? 0) + 1
-                } as any);
+                lstatSyncSpy.mockReturnValue({ isDirectory: () => true } as any);
+                hasOwnerOnlyAccessSpy.mockReturnValue(false);
 
                 try {
                     await EditUtilities.buildTempPath(localFileDS, commandParametersDs);
@@ -185,11 +171,13 @@ describe("Files Edit Utilities", () => {
             let existsSyncSpy: jest.SpyInstance;
             let lstatSyncSpy: jest.SpyInstance;
             let mkdirSyncSpy: jest.SpyInstance;
+            let hasOwnerOnlyAccessSpy: jest.SpyInstance;
 
             beforeEach(() => {
                 existsSyncSpy = jest.spyOn(fs, "existsSync");
                 lstatSyncSpy = jest.spyOn(fs, "lstatSync");
                 mkdirSyncSpy = jest.spyOn(fs, "mkdirSync").mockImplementation(jest.fn() as any);
+                hasOwnerOnlyAccessSpy = jest.spyOn(IO, "hasOwnerOnlyAccess");
             });
 
             it("should create temp dir with mode 0o700 when it does not exist", async () => {
@@ -202,24 +190,26 @@ describe("Files Edit Utilities", () => {
                     { recursive: true, mode: 0o700 }
                 );
             });
-            it("should succeed when existing temp dir has correct permissions and owner", async () => {
+            it("should use a per-user temp directory name so co-tenants on a shared tmp don't collide", async () => {
+                existsSyncSpy.mockReturnValue(false);
+
+                const response = await EditUtilities.buildTempPath(localFileUSS, commandParametersUss);
+                const expectedToken = (EditUtilities as any).getUserTempToken();
+
+                expect(expectedToken).toMatch(/^[0-9a-f]{10}$/);
+                expect(response).toContain(`zowe-edit-uss-${expectedToken}`);
+            });
+            it("should succeed when existing temp dir has owner-only access", async () => {
                 existsSyncSpy.mockReturnValue(true);
-                lstatSyncSpy.mockReturnValue({
-                    isDirectory: () => true,
-                    mode: 0o700,
-                    uid: process.getuid?.()
-                } as any);
+                lstatSyncSpy.mockReturnValue({ isDirectory: () => true } as any);
+                hasOwnerOnlyAccessSpy.mockReturnValue(true);
 
                 const response = await EditUtilities.buildTempPath(localFileUSS, commandParametersUss);
                 expect(response).toContain("zowe-edit-uss");
             });
             it("should throw ImperativeError when temp dir path is not a directory", async () => {
                 existsSyncSpy.mockReturnValue(true);
-                lstatSyncSpy.mockReturnValue({
-                    isDirectory: () => false,
-                    mode: 0o700,
-                    uid: process.getuid?.()
-                } as any);
+                lstatSyncSpy.mockReturnValue({ isDirectory: () => false } as any);
 
                 try {
                     await EditUtilities.buildTempPath(localFileUSS, commandParametersUss);
@@ -228,30 +218,12 @@ describe("Files Edit Utilities", () => {
                 }
                 expect(caughtError).toBeInstanceOf(ImperativeError);
                 expect(caughtError.message).toContain("Unsafe temp directory");
+                expect(hasOwnerOnlyAccessSpy).not.toHaveBeenCalled();
             });
-            it("should throw ImperativeError when temp dir has unsafe permissions", async () => {
+            it("should throw ImperativeError when temp dir does not have owner-only access", async () => {
                 existsSyncSpy.mockReturnValue(true);
-                lstatSyncSpy.mockReturnValue({
-                    isDirectory: () => true,
-                    mode: 0o755,
-                    uid: process.getuid?.()
-                } as any);
-
-                try {
-                    await EditUtilities.buildTempPath(localFileUSS, commandParametersUss);
-                } catch(e) {
-                    caughtError = e;
-                }
-                expect(caughtError).toBeInstanceOf(ImperativeError);
-                expect(caughtError.message).toContain("Unsafe temp directory");
-            });
-            it("should throw ImperativeError when temp dir is owned by a different user", async () => {
-                existsSyncSpy.mockReturnValue(true);
-                lstatSyncSpy.mockReturnValue({
-                    isDirectory: () => true,
-                    mode: 0o700,
-                    uid: (process.getuid?.() ?? 0) + 1
-                } as any);
+                lstatSyncSpy.mockReturnValue({ isDirectory: () => true } as any);
+                hasOwnerOnlyAccessSpy.mockReturnValue(false);
 
                 try {
                     await EditUtilities.buildTempPath(localFileUSS, commandParametersUss);
@@ -429,6 +401,26 @@ describe("Files Edit Utilities", () => {
             const response = await EditUtilities.localDownload(REAL_SESSION, localFile, false);
             expect(response.zosResp?.apiResponse.etag).toContain('remote etag');
             expect(EditUtilities.destroyTempFile).toHaveBeenCalledTimes(0);
+        });
+
+        it("should restrict the freshly downloaded stash file to the owner (0600) - [useStash = false]", async () => {
+            //TEST SETUP
+            const localFile = cloneDeep(localFileDS);
+            localFile.tempPath = "someStashPath";
+            downloadDataSetSpy.mockImplementation(jest.fn(async () => {
+                return zosResp;
+            }));
+            const chmodSpy = jest.spyOn(fs, "chmodSync").mockImplementation(jest.fn());
+
+            //TEST CONFIRMATION
+            await EditUtilities.localDownload(REAL_SESSION, localFile, false);
+            if (process.platform === "win32") {
+                // chmod mode is a no-op on Windows; the 0700 dir + icacls handle it there
+                expect(chmodSpy).not.toHaveBeenCalled();
+            } else {
+                expect(chmodSpy).toHaveBeenCalledWith("someStashPath", 0o600);
+            }
+            chmodSpy.mockRestore();
         });
 
         it("localDownload should properly pass non-falsy binary option to Download.dataSet", async () => {

--- a/packages/cli/__tests__/zosfiles/__unit__/edit/Edit.utils.unit.test.ts
+++ b/packages/cli/__tests__/zosfiles/__unit__/edit/Edit.utils.unit.test.ts
@@ -10,12 +10,13 @@
 */
 
 import { mockHandlerParameters } from "@zowe/cli-test-utils";
-import { AbstractSession, CliUtils, GuiResult, IHandlerParameters, ImperativeError, ProcessUtils } from "@zowe/imperative";
+import { AbstractSession, CliUtils, GuiResult, IHandlerParameters, ImperativeError, IO, ProcessUtils } from "@zowe/imperative";
 import { UNIT_TEST_ZOSMF_PROF_OPTS, UNIT_TEST_PROFILES_ZOSMF } from "../../../../../../__tests__/__src__/mocks/ZosmfProfileMock";
 import { EditDefinition } from "../../../../src/zosfiles/edit/Edit.definition";
 import { EditUtilities, ILocalFile, Prompt } from "../../../../src/zosfiles/edit/Edit.utils";
 import { cloneDeep } from "lodash";
 import * as fs from "fs";
+import { tmpdir } from "os";
 import { Download, IZosFilesResponse, Upload } from "@zowe/zos-files-for-zowe-sdk";
 import LocalfileDatasetHandler from "../../../../src/zosfiles/compare/lf-ds/LocalfileDataset.handler";
 import { CompareBaseHelper } from "../../../../src/zosfiles/compare/CompareBaseHelper";
@@ -403,6 +404,14 @@ describe("Files Edit Utilities", () => {
             const response = await EditUtilities.localDownload(REAL_SESSION, localFileUSS, true);
             expect(response.zosResp?.apiResponse.etag).toContain('remote etag');
             expect(EditUtilities.destroyTempFile).toHaveBeenCalledTimes(1);
+
+            //test that the etag refresh downloads to a safe, unique scratch path - not a shared/predictable one
+            const scratchPath = downloadUssFileSpy.mock.calls[0][2]?.file as string;
+            expect(scratchPath).toContain(path.join(tmpdir(), "zowe-edit-uss"));
+            expect(path.basename(scratchPath)).toMatch(/^\.etag-refresh-[0-9a-f]+$/);
+            expect(scratchPath).not.toContain("toDelete.txt");
+            //the unique scratch file (not the stash) is the one destroyed
+            expect(EditUtilities.destroyTempFile).toHaveBeenCalledWith(scratchPath);
         });
 
         it("should download etag and copy of remote - [fileType = 'ds', useStash = false]", async () => {

--- a/packages/cli/__tests__/zosfiles/__unit__/edit/Edit.utils.unit.test.ts
+++ b/packages/cli/__tests__/zosfiles/__unit__/edit/Edit.utils.unit.test.ts
@@ -403,26 +403,6 @@ describe("Files Edit Utilities", () => {
             expect(EditUtilities.destroyTempFile).toHaveBeenCalledTimes(0);
         });
 
-        it("should restrict the freshly downloaded stash file to the owner (0600) - [useStash = false]", async () => {
-            //TEST SETUP
-            const localFile = cloneDeep(localFileDS);
-            localFile.tempPath = "someStashPath";
-            downloadDataSetSpy.mockImplementation(jest.fn(async () => {
-                return zosResp;
-            }));
-            const chmodSpy = jest.spyOn(fs, "chmodSync").mockImplementation(jest.fn());
-
-            //TEST CONFIRMATION
-            await EditUtilities.localDownload(REAL_SESSION, localFile, false);
-            if (process.platform === "win32") {
-                // chmod mode is a no-op on Windows; the 0700 dir + icacls handle it there
-                expect(chmodSpy).not.toHaveBeenCalled();
-            } else {
-                expect(chmodSpy).toHaveBeenCalledWith("someStashPath", 0o600);
-            }
-            chmodSpy.mockRestore();
-        });
-
         it("localDownload should properly pass non-falsy binary option to Download.dataSet", async () => {
             //TEST SETUP
             const localFile = cloneDeep(localFileDS);

--- a/packages/cli/__tests__/zosfiles/__unit__/edit/Edit.utils.unit.test.ts
+++ b/packages/cli/__tests__/zosfiles/__unit__/edit/Edit.utils.unit.test.ts
@@ -79,6 +79,7 @@ describe("Files Edit Utilities", () => {
 
     beforeEach(async () => {
         jest.resetAllMocks();
+        jest.spyOn(IO, "giveAccessOnlyToOwner").mockImplementation(jest.fn());
     });
     describe("buildTempPath()", () => {
         it("should be able to build the correct temp path with ext argument - uss", async () => {

--- a/packages/cli/src/zosfiles/edit/Edit.utils.ts
+++ b/packages/cli/src/zosfiles/edit/Edit.utils.ts
@@ -11,7 +11,7 @@
 
 import { Download, Upload, IZosFilesResponse, IDownloadOptions, IUploadOptions } from "@zowe/zos-files-for-zowe-sdk";
 import { AbstractSession, IHandlerParameters, ImperativeError, ProcessUtils, GuiResult,
-    TextUtils, IDiffNameOptions, CliUtils } from "@zowe/imperative";
+    TextUtils, IDiffNameOptions, CliUtils, IO } from "@zowe/imperative";
 import { CompareBaseHelper } from "../compare/CompareBaseHelper";
 import { existsSync, lstatSync, mkdirSync, unlinkSync } from "fs";
 import { tmpdir } from "os";
@@ -94,23 +94,28 @@ export class EditUtilities {
 
     /**
      * Ensures a temp directory exists and is safe to use, creating it if necessary.
-     * On POSIX systems, verifies the directory isn't a pre-existing, loosely-permissioned
-     * directory planted by another local user sharing the same tmp location. On Windows,
-     * os.tmpdir() already resolves to a per-user directory whose ACLs prevent other local
-     * users from writing to it, so that co-tenancy risk doesn't apply and the check is skipped.
+     * Verifies the directory isn't a pre-existing, loosely-permissioned directory planted
+     * by another local user sharing the same tmp location. On POSIX this checks the mode
+     * bits and owner; on Windows, `fs.mkdirSync`'s mode option has no effect, so ACLs are
+     * actively locked down to the current user via {@link IO.giveAccessOnlyToOwner} instead.
      * @param {string} dir - the temp directory to validate or create
      * @memberof EditUtilities
      */
     private static ensureSafeTempDir(dir: string): void {
         if (!existsSync(dir)) {
             mkdirSync(dir, { recursive: true, mode: 0o700 });
+            if (process.platform === "win32") {
+                IO.giveAccessOnlyToOwner(dir);
+            }
             return;
         }
         const st = lstatSync(dir);
         if (!st.isDirectory()) {
             throw new ImperativeError({ msg: `Unsafe temp directory detected at ${dir}` });
         }
-        if (process.platform !== "win32" && ((st.mode & 0o777) !== 0o700 || st.uid !== process.getuid!())) {
+        if (process.platform === "win32") {
+            IO.giveAccessOnlyToOwner(dir);
+        } else if ((st.mode & 0o777) !== 0o700 || st.uid !== process.getuid!()) {
             throw new ImperativeError({ msg: `Unsafe temp directory detected at ${dir}` });
         }
     }
@@ -185,8 +190,18 @@ export class EditUtilities {
      * @returns {ILocalFile}
      */
     public static async localDownload(session: AbstractSession, lfFile: ILocalFile, useStash: boolean): Promise<ILocalFile>{
-        // account for both useStash|!useStash and uss|ds when downloading
-        const tempPath = useStash ? path.posix.join(tmpdir(), "toDelete.txt") : lfFile.tempPath;
+        // account for both useStash|!useStash and uss|ds when downloading.
+        // When only refreshing the etag (useStash), download to a throwaway scratch file with a
+        // unique, unpredictable name inside the safe temp dir rather than a shared, predictable path.
+        let scratchPath!: string;
+        if (useStash) {
+            const crypto = require("crypto");
+            const randomNameBytes = 16;
+            const scratchDir = path.join(tmpdir(), `zowe-edit-${lfFile.fileType}`);
+            EditUtilities.ensureSafeTempDir(scratchDir);
+            scratchPath = path.join(scratchDir, `.etag-refresh-${crypto.randomBytes(randomNameBytes).toString("hex")}`);
+        }
+        const tempPath = useStash ? scratchPath : lfFile.tempPath;
         const args: [AbstractSession, string, IDownloadOptions] = [
             session,
             lfFile.fileName,
@@ -206,7 +221,7 @@ export class EditUtilities {
         }
 
         if (useStash){
-            await this.destroyTempFile(path.posix.join(tmpdir(), "toDelete.txt"));
+            await this.destroyTempFile(scratchPath);
         }
         return lfFile;
     }

--- a/packages/cli/src/zosfiles/edit/Edit.utils.ts
+++ b/packages/cli/src/zosfiles/edit/Edit.utils.ts
@@ -13,7 +13,7 @@ import { Download, Upload, IZosFilesResponse, IDownloadOptions, IUploadOptions }
 import { AbstractSession, IHandlerParameters, ImperativeError, ProcessUtils, GuiResult,
     TextUtils, IDiffNameOptions, CliUtils, IO } from "@zowe/imperative";
 import { CompareBaseHelper } from "../compare/CompareBaseHelper";
-import { chmodSync, existsSync, lstatSync, mkdirSync, unlinkSync } from "fs";
+import { existsSync, lstatSync, mkdirSync, unlinkSync } from "fs";
 import { tmpdir, userInfo } from "os";
 import * as path from "path";
 import LocalfileDatasetHandler from "../compare/lf-ds/LocalfileDataset.handler";
@@ -254,17 +254,6 @@ export class EditUtilities {
             lfFile.encoding = args[2].encoding;
         }else{
             lfFile.zosResp = await Download.dataSet(...args);
-        }
-
-        if (!useStash && tempPath && process.platform !== "win32") {
-            // The stash now holds remote contents; restrict it to the owner (defense-in-depth atop
-            // the 0700 dir). Best-effort: the enclosing directory already blocks other-user access.
-            const ownerReadWrite = 0o600;
-            try {
-                chmodSync(tempPath, ownerReadWrite);
-            } catch (err) {
-                // ignore - the 0700 temp directory is the primary protection
-            }
         }
 
         if (useStash){

--- a/packages/cli/src/zosfiles/edit/Edit.utils.ts
+++ b/packages/cli/src/zosfiles/edit/Edit.utils.ts
@@ -13,8 +13,8 @@ import { Download, Upload, IZosFilesResponse, IDownloadOptions, IUploadOptions }
 import { AbstractSession, IHandlerParameters, ImperativeError, ProcessUtils, GuiResult,
     TextUtils, IDiffNameOptions, CliUtils, IO } from "@zowe/imperative";
 import { CompareBaseHelper } from "../compare/CompareBaseHelper";
-import { existsSync, lstatSync, mkdirSync, unlinkSync } from "fs";
-import { tmpdir } from "os";
+import { chmodSync, existsSync, lstatSync, mkdirSync, unlinkSync } from "fs";
+import { tmpdir, userInfo } from "os";
 import * as path from "path";
 import LocalfileDatasetHandler from "../compare/lf-ds/LocalfileDataset.handler";
 import LocalfileUssHandler from "../compare/lf-uss/LocalfileUss.handler";
@@ -64,6 +64,48 @@ export interface ILocalFile {
  */
 export class EditUtilities {
     /**
+     * Returns a short, filesystem-safe token that is unique per OS user, for building per-user
+     * temp directory names. Deriving the name from the user (rather than a random per-run value)
+     * keeps the path stable across invocations - so features like edit stash-resume still work -
+     * while ensuring co-tenants on a shared temp location get separate directories. The username
+     * is hashed so the token is path-safe for any username and works on every platform (numeric
+     * uids aren't available on Windows).
+     * @returns {string} - a hex token derived from the current OS user
+     * @memberof EditUtilities
+     */
+    private static getUserTempToken(): string {
+        let id = "default";
+        try {
+            id = userInfo().username;
+        } catch (err) {
+            // userInfo() can throw when the current user has no OS account entry; fall back to uid or a constant
+            if (typeof process.getuid === "function") {
+                id = String(process.getuid());
+            }
+        }
+        const crypto = require("crypto");
+        const tokenLen = 10;
+        return crypto.createHash("sha256").update(id).digest("hex").slice(0, tokenLen);
+    }
+
+    /**
+     * Build the per-user temp directory for edit files and ensure it is safe to use.
+     * The directory name includes a per-user token so co-tenants on a shared OS temp location get
+     * separate directories. With a shared name the first user to run would own the directory and
+     * {@link ensureSafeTempDir} would then reject it for everyone else. The token is derived from
+     * the current user (not random) so the path stays stable across runs and the stash remains
+     * re-findable.
+     * @param {EditFileType} fileType - "uss" or "ds"
+     * @returns {string} - absolute path to the ensured, per-user temp directory
+     * @memberof EditUtilities
+     */
+    private static ensureEditTempDir(fileType: EditFileType): string {
+        const dir = path.join(tmpdir(), `zowe-edit-${fileType}-${EditUtilities.getUserTempToken()}`);
+        EditUtilities.ensureSafeTempDir(dir);
+        return dir;
+    }
+
+    /**
      * Builds a temp path where local file will be saved. If uss file, file name will be hashed
      * to prevent any conflicts with file naming. A given filename will always result in the
      * same unique file path.
@@ -83,21 +125,21 @@ export class EditUtilities {
             // shorten hash
             const hashLen = 10;
             hash = hash.slice(0, hashLen);
-            const ussDir = path.join(tmpdir(), "zowe-edit-uss");
-            EditUtilities.ensureSafeTempDir(ussDir);
+            const ussDir = EditUtilities.ensureEditTempDir("uss");
             return path.join(ussDir, path.parse(lfFile.fileName).name + '_' + hash + ext);
         }
-        const dsDir = path.join(tmpdir(), "zowe-edit-ds");
-        EditUtilities.ensureSafeTempDir(dsDir);
+        const dsDir = EditUtilities.ensureEditTempDir("ds");
         return path.join(dsDir, lfFile.fileName + ext);
     }
 
     /**
      * Ensures a temp directory exists and is safe to use, creating it if necessary.
-     * Verifies the directory isn't a pre-existing, loosely-permissioned directory planted
-     * by another local user sharing the same tmp location. On POSIX this checks the mode
-     * bits and owner; on Windows, `fs.mkdirSync`'s mode option has no effect, so ACLs are
-     * actively locked down to the current user via {@link IO.giveAccessOnlyToOwner} instead.
+     * When creating, the directory is restricted to the owner (mode 0700 on POSIX; on Windows
+     * `fs.mkdirSync`'s `mode` is a no-op, so an owner-only ACL is set via {@link IO.giveAccessOnlyToOwner}).
+     * When the directory already exists, it is rejected unless it is a real directory whose access is
+     * restricted to the current user - verified the same way on every platform via
+     * {@link IO.hasOwnerOnlyAccess} - so a directory planted by another local user sharing the same
+     * tmp location is refused.
      * @param {string} dir - the temp directory to validate or create
      * @memberof EditUtilities
      */
@@ -109,13 +151,8 @@ export class EditUtilities {
             }
             return;
         }
-        const st = lstatSync(dir);
-        if (!st.isDirectory()) {
-            throw new ImperativeError({ msg: `Unsafe temp directory detected at ${dir}` });
-        }
-        if (process.platform === "win32") {
-            IO.giveAccessOnlyToOwner(dir);
-        } else if ((st.mode & 0o777) !== 0o700 || st.uid !== process.getuid!()) {
+        // Reject a planted symlink/non-directory (lstat does not follow symlinks) before checking access.
+        if (!lstatSync(dir).isDirectory() || !IO.hasOwnerOnlyAccess(dir)) {
             throw new ImperativeError({ msg: `Unsafe temp directory detected at ${dir}` });
         }
     }
@@ -197,8 +234,7 @@ export class EditUtilities {
         if (useStash) {
             const crypto = require("crypto");
             const randomNameBytes = 16;
-            const scratchDir = path.join(tmpdir(), `zowe-edit-${lfFile.fileType}`);
-            EditUtilities.ensureSafeTempDir(scratchDir);
+            const scratchDir = EditUtilities.ensureEditTempDir(lfFile.fileType);
             scratchPath = path.join(scratchDir, `.etag-refresh-${crypto.randomBytes(randomNameBytes).toString("hex")}`);
         }
         const tempPath = useStash ? scratchPath : lfFile.tempPath;
@@ -218,6 +254,17 @@ export class EditUtilities {
             lfFile.encoding = args[2].encoding;
         }else{
             lfFile.zosResp = await Download.dataSet(...args);
+        }
+
+        if (!useStash && tempPath && process.platform !== "win32") {
+            // The stash now holds remote contents; restrict it to the owner (defense-in-depth atop
+            // the 0700 dir). Best-effort: the enclosing directory already blocks other-user access.
+            const ownerReadWrite = 0o600;
+            try {
+                chmodSync(tempPath, ownerReadWrite);
+            } catch (err) {
+                // ignore - the 0700 temp directory is the primary protection
+            }
         }
 
         if (useStash){

--- a/packages/core/__tests__/apiml/__unit__/Services.unit.test.ts
+++ b/packages/core/__tests__/apiml/__unit__/Services.unit.test.ts
@@ -940,48 +940,48 @@ describe("APIML Services unit tests", () => {
     });
 
     it("should escape newlines and quotes in gatewayUrlConflicts (basePath conflict) comments", () => {
-            const testCase: IApimlProfileInfo[] = [{
+        const testCase: IApimlProfileInfo[] = [{
+            profName: "test1",
+            profType: "type1",
+            basePaths: [
+                "test1/v1",
+                "test1/v2"
+            ],
+            pluginConfigs: new Set(),
+            gatewayUrlConflicts: {
+                "pluginA": ["v1"],
+                "pluginB\n\"badKey\": \"badValue": ["v1\",\n\"bad\": \"data"]
+            }
+        }];
+        const actualJson = JSONC.stringify(Services.convertApimlProfileInfoToProfileConfig(testCase), null, ConfigConstants.INDENT);
+
+        const parsed = JSONC.parse(actualJson) as any;
+        expect(parsed.profiles.test1.properties.bad).toBeUndefined();
+        expect(parsed.profiles.test1.properties.badKey).toBeUndefined();
+    });
+
+    it("should escape newlines and quotes in a conflicting default profile type", () => {
+        const badProfType = "type1\",\n\"bad\": \"data";
+        const testCase: IApimlProfileInfo[] = [
+            {
                 profName: "test1",
-                profType: "type1",
-                basePaths: [
-                    "test1/v1",
-                    "test1/v2"
-                ],
+                profType: badProfType,
+                basePaths: ["test1/v1"],
                 pluginConfigs: new Set(),
-                gatewayUrlConflicts: {
-                    "pluginA": ["v1"],
-                    "pluginB\n\"badKey\": \"badValue": ["v1\",\n\"bad\": \"data"]
-                }
-            }];
-            const actualJson = JSONC.stringify(Services.convertApimlProfileInfoToProfileConfig(testCase), null, ConfigConstants.INDENT);
+                gatewayUrlConflicts: {}
+            },
+            {
+                profName: "test2",
+                profType: badProfType,
+                basePaths: ["test2/v1"],
+                pluginConfigs: new Set(),
+                gatewayUrlConflicts: {}
+            }
+        ];
+        const actualJson = JSONC.stringify(Services.convertApimlProfileInfoToProfileConfig(testCase), null, ConfigConstants.INDENT);
 
-            const parsed = JSONC.parse(actualJson) as any;
-            expect(parsed.profiles.test1.properties.bad).toBeUndefined();
-            expect(parsed.profiles.test1.properties.badKey).toBeUndefined();
-        });
-
-        it("should escape newlines and quotes in a conflicting default profile type", () => {
-            const badProfType = "type1\",\n\"bad\": \"data";
-            const testCase: IApimlProfileInfo[] = [
-                {
-                    profName: "test1",
-                    profType: badProfType,
-                    basePaths: ["test1/v1"],
-                    pluginConfigs: new Set(),
-                    gatewayUrlConflicts: {}
-                },
-                {
-                    profName: "test2",
-                    profType: badProfType,
-                    basePaths: ["test2/v1"],
-                    pluginConfigs: new Set(),
-                    gatewayUrlConflicts: {}
-                }
-            ];
-            const actualJson = JSONC.stringify(Services.convertApimlProfileInfoToProfileConfig(testCase), null, ConfigConstants.INDENT);
-
-            const parsed = JSONC.parse(actualJson) as any;
-            expect(parsed.defaults.bad).toBeUndefined();
-            expect(parsed.defaults[badProfType]).toBe("test1");
-        });
+        const parsed = JSONC.parse(actualJson) as any;
+        expect(parsed.defaults.bad).toBeUndefined();
+        expect(parsed.defaults[badProfType]).toBe("test1");
+    });
 });

--- a/packages/imperative/CHANGELOG.md
+++ b/packages/imperative/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to the Imperative package will be documented in this file.
 
 ## Recent Changes
 
+- BugFix: Added `IO.hasOwnerOnlyAccess` to check whether a file or directory's access is restricted to the current user only, cross-platform (POSIX mode bits/owner; Windows `icacls` ACL). [#2826](https://github.com/zowe/zowe-cli/pull/2826)
 - BugFix: Censored certain fields, and redacted token value from logs in `AbstractRestClient`. [#2816](https://github.com/zowe/zowe-cli/pull/2816)
  
 ## `5.27.22`

--- a/packages/imperative/CHANGELOG.md
+++ b/packages/imperative/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to the Imperative package will be documented in this file.
 
 - BugFix: Routed messages passed to the `Logger.trace` function through the `LoggerUtils.censorRawData` function, so secure config property values are redacted before written to the trace log. [#2822](https://github.com/zowe/zowe-cli/pull/2822)
 - BugFix: Censored certain fields, and redacted token value from logs in `AbstractRestClient`. [#2816](https://github.com/zowe/zowe-cli/pull/2816)
-- BugFix: Added `IO.hasOwnerOnlyAccess` to check whether a file or directory's access is restricted to the current user only, cross-platform (POSIX mode bits/owner; Windows `icacls` ACL). [#2826](https://github.com/zowe/zowe-cli/pull/2826)
+- BugFix: Added a `IO.hasOwnerOnlyAccess` utility function to check whether a file or directory's access is restricted to the current user only, cross-platform (POSIX mode bits/owner; Windows `icacls` ACL). [#2826](https://github.com/zowe/zowe-cli/pull/2826)
  
 ## `5.27.22`
 

--- a/packages/imperative/src/io/__tests__/IO.unit.test.ts
+++ b/packages/imperative/src/io/__tests__/IO.unit.test.ts
@@ -655,4 +655,89 @@ describe("IO tests", () => {
             });
         } // end win32
     }); // end giveAccessOnlyToOwner
+
+    describe("hasOwnerOnlyAccess", () => {
+        afterEach(() => {
+            jest.restoreAllMocks();
+        });
+
+        it("should throw when no file name is provided", () => {
+            let caughtError;
+            try {
+                IO.hasOwnerOnlyAccess("   ");
+            } catch (thrownError) {
+                caughtError = thrownError;
+            }
+            expect(caughtError.message).toContain("Expect Error: Required parameter 'fileName' must not be blank");
+        });
+
+        it("should return false when the path does not exist", () => {
+            jest.spyOn(IO, "existsSync").mockReturnValue(false);
+            expect(IO.hasOwnerOnlyAccess("/no/such/path")).toBe(false);
+        });
+
+        it("should return false when access cannot be read", () => {
+            jest.spyOn(IO, "existsSync").mockReturnValue(true);
+            jest.spyOn(os, "platform").mockReturnValue("linux");
+            jest.spyOn(fs, "statSync").mockImplementation(() => { throw new Error("boom"); });
+            expect(IO.hasOwnerOnlyAccess("/tmp/whatever")).toBe(false);
+        });
+
+        // The POSIX branch reads process.getuid(), which is undefined on Windows; gate to POSIX.
+        if (process.platform !== "win32") {
+            describe("POSIX", () => {
+                beforeEach(() => {
+                    jest.spyOn(IO, "existsSync").mockReturnValue(true);
+                    jest.spyOn(os, "platform").mockReturnValue("linux");
+                });
+                it("should return true for an owner-only path owned by the current user", () => {
+                    jest.spyOn(fs, "statSync").mockReturnValue({ mode: 0o700, uid: process.getuid!() } as any);
+                    expect(IO.hasOwnerOnlyAccess("/tmp/dir")).toBe(true);
+                });
+                it("should return false when group or others have any access", () => {
+                    jest.spyOn(fs, "statSync").mockReturnValue({ mode: 0o755, uid: process.getuid!() } as any);
+                    expect(IO.hasOwnerOnlyAccess("/tmp/dir")).toBe(false);
+                });
+                it("should return false when owned by a different user", () => {
+                    jest.spyOn(fs, "statSync").mockReturnValue({ mode: 0o700, uid: process.getuid!() + 1 } as any);
+                    expect(IO.hasOwnerOnlyAccess("/tmp/dir")).toBe(false);
+                });
+            });
+        }
+
+        describe("Windows", () => {
+            beforeEach(() => {
+                jest.spyOn(IO, "existsSync").mockReturnValue(true);
+                jest.spyOn(os, "platform").mockReturnValue("win32");
+                jest.spyOn(os, "userInfo").mockReturnValue({ username: "fernando" } as any);
+            });
+            it("should return true when icacls shows only the current user", () => {
+                jest.spyOn(ExecUtils, "spawnAndGetOutput").mockReturnValue(
+                    "C:\\Temp\\dir fernando:(F)\r\nSuccessfully processed 1 files; Failed processing 0 files" as any
+                );
+                expect(IO.hasOwnerOnlyAccess("C:\\Temp\\dir")).toBe(true);
+            });
+            it("should return true for a domain-qualified current user", () => {
+                jest.spyOn(ExecUtils, "spawnAndGetOutput").mockReturnValue(
+                    "C:\\Temp\\dir MYDOMAIN\\fernando:(F)\r\nSuccessfully processed 1 files; Failed processing 0 files" as any
+                );
+                expect(IO.hasOwnerOnlyAccess("C:\\Temp\\dir")).toBe(true);
+            });
+            it("should return false when more than one access entry is present", () => {
+                jest.spyOn(ExecUtils, "spawnAndGetOutput").mockReturnValue(
+                    "C:\\Temp\\dir NT AUTHORITY\\SYSTEM:(F)\r\n" +
+                    "          BUILTIN\\Administrators:(F)\r\n" +
+                    "          fernando:(F)\r\n" +
+                    "Successfully processed 1 files; Failed processing 0 files" as any
+                );
+                expect(IO.hasOwnerOnlyAccess("C:\\Temp\\dir")).toBe(false);
+            });
+            it("should return false when the single access entry is a different user", () => {
+                jest.spyOn(ExecUtils, "spawnAndGetOutput").mockReturnValue(
+                    "C:\\Temp\\dir someoneelse:(F)\r\nSuccessfully processed 1 files; Failed processing 0 files" as any
+                );
+                expect(IO.hasOwnerOnlyAccess("C:\\Temp\\dir")).toBe(false);
+            });
+        });
+    }); // end hasOwnerOnlyAccess
 });

--- a/packages/imperative/src/io/__tests__/IO.unit.test.ts
+++ b/packages/imperative/src/io/__tests__/IO.unit.test.ts
@@ -600,6 +600,30 @@ describe("IO tests", () => {
             });
         } // end win32
 
+        if (sysInfo.platform === "win32") {
+            it("should restrict file access on Windows when icacls reports its summary in a non-English locale", () => {
+                let caughtError;
+                let spawnSpy: any;
+                try {
+                    // Simulate that the file exists
+                    jest.spyOn(IO, "existsSync").mockReturnValue(true);
+
+                    // the summary line's wording varies by Windows display language; only its
+                    // "<n> processed; <n> failed" shape should matter, not its text content
+                    spawnSpy = jest.spyOn(ExecUtils, "spawnAndGetOutput");
+                    spawnSpy.mockReturnValue("Número de archivos procesados: 1; Errores encontrados: 0");
+
+                    const testPermFile = __dirname + "/onlyUserAccess.txt";
+                    IO.giveAccessOnlyToOwner(testPermFile);
+                } catch (thrownError) {
+                    caughtError = thrownError;
+                }
+
+                expect(caughtError).toBeUndefined();
+                expect(spawnSpy).toHaveBeenCalledTimes(1);
+            });
+        } // end win32
+
         if (sysInfo.platform !== "win32") {
             it("should restrict file access with execute permission on Posix", () => {
                 const testPermFile = __dirname + "/onlyUserAccess.txt";
@@ -709,17 +733,17 @@ describe("IO tests", () => {
             beforeEach(() => {
                 jest.spyOn(IO, "existsSync").mockReturnValue(true);
                 jest.spyOn(os, "platform").mockReturnValue("win32");
-                jest.spyOn(os, "userInfo").mockReturnValue({ username: "fernando" } as any);
+                jest.spyOn(os, "userInfo").mockReturnValue({ username: "rubyTheDog" } as any);
             });
             it("should return true when icacls shows only the current user", () => {
                 jest.spyOn(ExecUtils, "spawnAndGetOutput").mockReturnValue(
-                    "C:\\Temp\\dir fernando:(F)\r\nSuccessfully processed 1 files; Failed processing 0 files" as any
+                    "C:\\Temp\\dir rubyTheDog:(F)\r\nSuccessfully processed 1 files; Failed processing 0 files" as any
                 );
                 expect(IO.hasOwnerOnlyAccess("C:\\Temp\\dir")).toBe(true);
             });
             it("should return true for a domain-qualified current user", () => {
                 jest.spyOn(ExecUtils, "spawnAndGetOutput").mockReturnValue(
-                    "C:\\Temp\\dir MYDOMAIN\\fernando:(F)\r\nSuccessfully processed 1 files; Failed processing 0 files" as any
+                    "C:\\Temp\\dir MYDOMAIN\\rubyTheDog:(F)\r\nSuccessfully processed 1 files; Failed processing 0 files" as any
                 );
                 expect(IO.hasOwnerOnlyAccess("C:\\Temp\\dir")).toBe(true);
             });
@@ -727,16 +751,24 @@ describe("IO tests", () => {
                 jest.spyOn(ExecUtils, "spawnAndGetOutput").mockReturnValue(
                     "C:\\Temp\\dir NT AUTHORITY\\SYSTEM:(F)\r\n" +
                     "          BUILTIN\\Administrators:(F)\r\n" +
-                    "          fernando:(F)\r\n" +
+                    "          rubyTheDog:(F)\r\n" +
                     "Successfully processed 1 files; Failed processing 0 files" as any
                 );
                 expect(IO.hasOwnerOnlyAccess("C:\\Temp\\dir")).toBe(false);
             });
             it("should return false when the single access entry is a different user", () => {
                 jest.spyOn(ExecUtils, "spawnAndGetOutput").mockReturnValue(
-                    "C:\\Temp\\dir someoneelse:(F)\r\nSuccessfully processed 1 files; Failed processing 0 files" as any
+                    "C:\\Temp\\dir monaTheCat:(F)\r\nSuccessfully processed 1 files; Failed processing 0 files" as any
                 );
                 expect(IO.hasOwnerOnlyAccess("C:\\Temp\\dir")).toBe(false);
+            });
+            it("should return true when icacls reports its summary line in a non-English locale", () => {
+                // the summary line's wording varies by Windows display language; only its
+                // shape (no "identity:(perms)" pattern) should matter, not its text content
+                jest.spyOn(ExecUtils, "spawnAndGetOutput").mockReturnValue(
+                    "C:\\Temp\\dir rubyTheDog:(F)\r\nNúmero de archivos procesados: 1; Errores encontrados: 0" as any
+                );
+                expect(IO.hasOwnerOnlyAccess("C:\\Temp\\dir")).toBe(true);
             });
         });
     }); // end hasOwnerOnlyAccess

--- a/packages/imperative/src/io/__tests__/IO.unit.test.ts
+++ b/packages/imperative/src/io/__tests__/IO.unit.test.ts
@@ -715,14 +715,17 @@ describe("IO tests", () => {
                     jest.spyOn(os, "platform").mockReturnValue("linux");
                 });
                 it("should return true for an owner-only path owned by the current user", () => {
+                    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
                     jest.spyOn(fs, "statSync").mockReturnValue({ mode: 0o700, uid: process.getuid!() } as any);
                     expect(IO.hasOwnerOnlyAccess("/tmp/dir")).toBe(true);
                 });
                 it("should return false when group or others have any access", () => {
+                    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
                     jest.spyOn(fs, "statSync").mockReturnValue({ mode: 0o755, uid: process.getuid!() } as any);
                     expect(IO.hasOwnerOnlyAccess("/tmp/dir")).toBe(false);
                 });
                 it("should return false when owned by a different user", () => {
+                    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
                     jest.spyOn(fs, "statSync").mockReturnValue({ mode: 0o700, uid: process.getuid!() + 1 } as any);
                     expect(IO.hasOwnerOnlyAccess("/tmp/dir")).toBe(false);
                 });

--- a/packages/imperative/src/io/src/IO.ts
+++ b/packages/imperative/src/io/src/IO.ts
@@ -370,6 +370,47 @@ export class IO {
     }
 
     /**
+     * Determine whether a file or directory's access is restricted to its owner only.
+     * On POSIX, this means the mode bits grant no permissions to group or others, and
+     * the file is owned by the current user. On Windows, this means `icacls` reports a
+     * single access control entry - restricted to the current user - with inheritance
+     * disabled (i.e. exactly what {@link IO.giveAccessOnlyToOwner} sets up).
+     *
+     * @param  {string} fileName - file or directory to check.
+     * @returns {boolean} - true if only the current user has access, false otherwise
+     *                       (including if the path does not exist or cannot be read).
+     */
+    public static hasOwnerOnlyAccess(fileName: string): boolean {
+        ImperativeExpect.toBeDefinedAndNonBlank(fileName, "fileName");
+        try {
+            if (!IO.existsSync(fileName)) {
+                return false;
+            }
+            if (os.platform() === IO.OS_WIN32) {
+                // On windows, ask icacls for the current ACL and confirm it grants
+                // access to nobody but the current user (mirrors what giveAccessOnlyToOwner sets).
+                const stdout = ExecUtils.spawnAndGetOutput("icacls", [ fileName ], { encoding: "utf8" }).toString();
+                const aces: string[] = stdout.split(/\r?\n/)
+                    .map((line: string) => line.startsWith(fileName) ? line.slice(fileName.length) : line)
+                    .map((line: string) => line.trim())
+                    .filter((line: string) => line.length > 0 && !line.startsWith("Successfully processed"));
+                if (aces.length !== 1) {
+                    return false;
+                }
+                const identity = aces[0].split(":")[0].trim().toLowerCase();
+                const username = os.userInfo().username.toLowerCase();
+                return identity === username || identity.endsWith(`\\${username}`);
+            } else { // we are on Posix
+                const stat = fs.statSync(fileName);
+                const noGroupOrOtherAccess = (stat.mode & (fs.constants.S_IRWXG | fs.constants.S_IRWXO)) === 0;
+                return noGroupOrOtherAccess && stat.uid === process.getuid!();
+            }
+        } catch (errObj) {
+            return false;
+        }
+    }
+
+    /**
      * Create a file asynchronously
      * @static
      * @param  {string} file    - file to create

--- a/packages/imperative/src/io/src/IO.ts
+++ b/packages/imperative/src/io/src/IO.ts
@@ -412,6 +412,7 @@ export class IO {
             } else { // we are on Posix
                 const stat = fs.statSync(fileName);
                 const noGroupOrOtherAccess = (stat.mode & (fs.constants.S_IRWXG | fs.constants.S_IRWXO)) === 0;
+                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
                 return noGroupOrOtherAccess && stat.uid === process.getuid!();
             }
         } catch (error_) {

--- a/packages/imperative/src/io/src/IO.ts
+++ b/packages/imperative/src/io/src/IO.ts
@@ -348,8 +348,14 @@ export class IO {
                 const stdout = ExecUtils.spawnAndGetOutput("icacls",
                     [ fileName, "/inheritancelevel:r", "/grant:r", `${os.userInfo().username}:F`, "/c" ],
                     { encoding: "utf8"}
-                );
-                if (!stdout.includes("Successfully processed 1 files; Failed processing 0 files")) {
+                ).toString();
+                // icacls can exit 0 while still failing to process the file, so its summary line
+                // must be checked too. Match the "<n> processed; <n> failed" shape instead of the
+                // English wording (which varies by Windows display language) - the failure count
+                // is always the second number in the semicolon-separated summary.
+                const summaryLine = stdout.split(/\r?\n/).map((line) => line.trim()).find((line) => /\d+[^;]*;[^;]*\d+/.test(line));
+                const failedCount = Number(summaryLine?.match(/\d+/g)?.[1]);
+                if (failedCount !== 0) {
                     throw new Error(`icacls reports that it could not change file access:\n${stdout}`);
                 }
             } else { // we are on Posix
@@ -393,7 +399,10 @@ export class IO {
                 const aces: string[] = stdout.split(/\r?\n/)
                     .map((line: string) => line.startsWith(fileName) ? line.slice(fileName.length) : line)
                     .map((line: string) => line.trim())
-                    .filter((line: string) => line.length > 0 && !line.startsWith("Successfully processed"));
+                    // Keep only ACE lines (identity followed by a parenthesized permission set, e.g.
+                    // "DESKTOP-XYZ\username:(OI)(CI)(F)"). The localized summary line never has this shape,
+                    // so this drops it without matching its wording, which varies by Windows display language.
+                    .filter((line: string) => line.includes(":(") && line.endsWith(")"));
                 if (aces.length !== 1) {
                     return false;
                 }

--- a/packages/imperative/src/io/src/IO.ts
+++ b/packages/imperative/src/io/src/IO.ts
@@ -414,7 +414,7 @@ export class IO {
                 const noGroupOrOtherAccess = (stat.mode & (fs.constants.S_IRWXG | fs.constants.S_IRWXO)) === 0;
                 return noGroupOrOtherAccess && stat.uid === process.getuid!();
             }
-        } catch (errObj) {
+        } catch (error_) {
             return false;
         }
     }

--- a/packages/imperative/src/logger/__tests__/LoggerUtils.unit.test.ts
+++ b/packages/imperative/src/logger/__tests__/LoggerUtils.unit.test.ts
@@ -248,7 +248,7 @@ describe("LoggerUtils tests", () => {
         });
 
         // A persistent daemon reloads the active team config before each command, so a change
-        // to the on-disk "secure" arrays has to take effect on the next command rather than 
+        // to the on-disk "secure" arrays has to take effect on the next command rather than
         // being frozen at first use.
         describe("should reflect on-disk secure arrays on every call (daemon cache invalidation)", () => {
             beforeEach(() => {

--- a/packages/imperative/src/logger/src/LoggerUtils.ts
+++ b/packages/imperative/src/logger/src/LoggerUtils.ts
@@ -55,7 +55,7 @@ export class LoggerUtils {
     /**
      * Escape every regular-expression metacharacter in a string so it can be safely embedded in a `RegExp` as a
      * literal. Secure values and option names are user-supplied and can frequently contain these characters.
-     * 
+     *
      * @param {string} value - The literal string to escape
      * @returns {string} - The escaped string, safe to pass to `new RegExp`
      */

--- a/packages/imperative/src/rest/src/client/AbstractRestClient.ts
+++ b/packages/imperative/src/rest/src/client/AbstractRestClient.ts
@@ -984,7 +984,7 @@ export abstract class AbstractRestClient {
         if (optionsForLogging.headers) {
             optionsForLogging.headers = { ...optionsForLogging.headers };
             const sensitiveHeaders = ["authorization", "cookie", "proxy-authorization"];
-            
+
             for (const key of Object.keys(optionsForLogging.headers)) {
                 if (sensitiveHeaders.includes(key.toLowerCase())) {
                     optionsForLogging.headers[key] = LoggerUtils.CENSOR_RESPONSE;

--- a/packages/imperative/src/utilities/src/diff/WebDiffManager.ts
+++ b/packages/imperative/src/utilities/src/diff/WebDiffManager.ts
@@ -123,10 +123,12 @@ export class WebDiffManager implements IWebDiffManager {
      * @returns A safely-encoded JavaScript string literal
      */
     private encodeForScript(str: string): string {
+        const hex = 16;
         return JSON.stringify(str)
             .replaceAll("<", "\\u003c")
             .replaceAll(">", "\\u003e")
-            .replace(/[\u2028\u2029]/g, (ch) => "\\u" + ch.codePointAt(0)!.toString(16));
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            .replace(/[\u2028\u2029]/g, (ch) => "\\u" + ch.codePointAt(0)!.toString(hex));
     }
 
     /**

--- a/packages/workflows/src/Create.ts
+++ b/packages/workflows/src/Create.ts
@@ -193,7 +193,8 @@ export class CreateWorkflow{
         if (customDir){
             remoteFile = customDir + "/" + basename(localFile);
         } else {
-            remoteFile = WorkflowConstants.tempPath + "/" + userId + crypto.randomBytes(8).toString('hex') + basename(localFile);
+            const hashLength = 8;
+            remoteFile = WorkflowConstants.tempPath + "/" + userId + crypto.randomBytes(hashLength).toString('hex') + basename(localFile);
         }
         return remoteFile;
     }


### PR DESCRIPTION
**What It Does**

Follow-up to #2815. That PR moved the `zowe zos-files edit` working files into a safe temp location. This PR extends the same behavior to the temporary file used to refresh the etag during an edit. 

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->

Run the unit tests: `npx jest packages/cli/__tests__/zosfiles/__unit__/edit/`

**Review Checklist**
I certify that I have:
- [x] updated the changelog
- [x] manually tested my changes
- [x] added/updated automated unit/integration tests
- [x] created/ran system tests (provide build number if applicable)
  - `2468`
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
