### PR TITLE
Ensure safety checks are atomic

### DIFF
--- a/packages/zosfiles/CHANGELOG.md
+++ b/packages/zosfiles/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to the Zowe z/OS files SDK package will be documented in thi
 
 - Enhancement: Added the ability to resolve data set aliases to their true target names using the `zowe zos-files list alias` command or the `List.resolveAlias` SDK method. [#2728](https://github.com/zowe/zowe-cli/issues/2728)
 - BugFix: Hardened temporary directory handling for partitioned data set copy so the staging directory is scoped per user (co-tenants on a shared temp location no longer conflict) and owner-only access is enforced and re-verified on all platforms. [#2823](https://github.com/zowe/zowe-cli/pull/2823)
+- **Breaking:** The `ZosFilesUtils.ensureSafeTempDir` function no longer creates missing parent directories recursively; the temp directory's immediate parent must already exist. This avoids a race condition where a recursive `mkdir` could create part of the path before the safety checks ran. [#TBD](https://github.com/zowe/zowe-cli/pull/TBD)
 
 ## `8.33.1`
 

--- a/packages/zosfiles/CHANGELOG.md
+++ b/packages/zosfiles/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the Zowe z/OS files SDK package will be documented in thi
 
 ## Recent Changes
 
-- **Breaking:** The `ZosFilesUtils.ensureSafeTempDir` function no longer creates missing parent directories recursively; the temp directory's immediate parent must already exist. This avoids a race condition where a recursive `mkdir` could create part of the path before the safety checks ran. [#2831](https://github.com/zowe/zowe-cli/pull/2831)
+- **Breaking:** The `ZosFilesUtils.ensureSafeTempDir` function no longer creates missing parent directories recursively; the temp directory's immediate parent must already exist. This avoids a race condition where a recursive `mkdir` function call could create part of the path before the safety checks ran. [#2831](https://github.com/zowe/zowe-cli/pull/2831)
 
 ## `8.35.0`
 

--- a/packages/zosfiles/CHANGELOG.md
+++ b/packages/zosfiles/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to the Zowe z/OS files SDK package will be documented in thi
 
 - Enhancement: Added the ability to resolve data set aliases to their true target names using the `zowe zos-files list alias` command or the `List.resolveAlias` SDK method. [#2728](https://github.com/zowe/zowe-cli/issues/2728)
 - BugFix: Hardened temporary directory handling for partitioned data set copy so the staging directory is scoped per user (co-tenants on a shared temp location no longer conflict) and owner-only access is enforced and re-verified on all platforms. [#2823](https://github.com/zowe/zowe-cli/pull/2823)
-- **Breaking:** The `ZosFilesUtils.ensureSafeTempDir` function no longer creates missing parent directories recursively; the temp directory's immediate parent must already exist. This avoids a race condition where a recursive `mkdir` could create part of the path before the safety checks ran. [#TBD](https://github.com/zowe/zowe-cli/pull/TBD)
+- **Breaking:** The `ZosFilesUtils.ensureSafeTempDir` function no longer creates missing parent directories recursively; the temp directory's immediate parent must already exist. This avoids a race condition where a recursive `mkdir` could create part of the path before the safety checks ran. [#2831](https://github.com/zowe/zowe-cli/pull/2831)
 
 ## `8.33.1`
 

--- a/packages/zosfiles/CHANGELOG.md
+++ b/packages/zosfiles/CHANGELOG.md
@@ -2,11 +2,14 @@
 
 All notable changes to the Zowe z/OS files SDK package will be documented in this file.
 
+## Recent Changes
+
+- **Breaking:** The `ZosFilesUtils.ensureSafeTempDir` function no longer creates missing parent directories recursively; the temp directory's immediate parent must already exist. This avoids a race condition where a recursive `mkdir` could create part of the path before the safety checks ran. [#2831](https://github.com/zowe/zowe-cli/pull/2831)
+
 ## `8.35.0`
 
 - Enhancement: Added the ability to resolve data set aliases to their true target names using the `zowe zos-files list alias` command or the `List.resolveAlias` SDK method. [#2728](https://github.com/zowe/zowe-cli/issues/2728)
 - BugFix: Hardened temporary directory handling for partitioned data set copy so the staging directory is scoped per user (co-tenants on a shared temp location no longer conflict) and owner-only access is enforced and re-verified on all platforms. [#2823](https://github.com/zowe/zowe-cli/pull/2823)
-- **Breaking:** The `ZosFilesUtils.ensureSafeTempDir` function no longer creates missing parent directories recursively; the temp directory's immediate parent must already exist. This avoids a race condition where a recursive `mkdir` could create part of the path before the safety checks ran. [#2831](https://github.com/zowe/zowe-cli/pull/2831)
 
 ## `8.33.1`
 

--- a/packages/zosfiles/__tests__/__unit__/utils/ZosFilesUtils.unit.test.ts
+++ b/packages/zosfiles/__tests__/__unit__/utils/ZosFilesUtils.unit.test.ts
@@ -306,13 +306,12 @@ describe("ZosFilesUtils", () => {
     describe("ensureSafeTempDir", () => {
         const realPlatform = process.platform;
         const setPlatform = (value: string) => Object.defineProperty(process, "platform", { value, configurable: true });
-        let existsSyncSpy: jest.SpyInstance;
         let lstatSyncSpy: jest.SpyInstance;
         let mkdirSyncSpy: jest.SpyInstance;
         let giveAccessSpy: jest.SpyInstance;
         let hasOwnerOnlyAccessSpy: jest.SpyInstance;
+        const eexist = () => { const err: any = new Error("EEXIST"); err.code = "EEXIST"; throw err; };
         beforeEach(() => {
-            existsSyncSpy = jest.spyOn(fs, "existsSync");
             lstatSyncSpy = jest.spyOn(fs, "lstatSync");
             mkdirSyncSpy = jest.spyOn(fs, "mkdirSync").mockImplementation(jest.fn());
             giveAccessSpy = jest.spyOn(IO, "giveAccessOnlyToOwner").mockImplementation(jest.fn());
@@ -325,36 +324,53 @@ describe("ZosFilesUtils", () => {
 
         it("should create the directory owner-only when it does not exist (POSIX)", () => {
             setPlatform("linux");
-            existsSyncSpy.mockReturnValue(false);
+            lstatSyncSpy.mockReturnValue({ isDirectory: () => true } as any);
+            hasOwnerOnlyAccessSpy.mockReturnValue(true);
             ZosFilesUtils.ensureSafeTempDir("/tmp/zowe-edit-ds-abc");
-            expect(mkdirSyncSpy).toHaveBeenCalledWith("/tmp/zowe-edit-ds-abc", { recursive: true, mode: 0o700 });
+            expect(mkdirSyncSpy).toHaveBeenCalledWith("/tmp/zowe-edit-ds-abc", { recursive: false, mode: 0o700 });
             expect(giveAccessSpy).not.toHaveBeenCalled();
-            expect(hasOwnerOnlyAccessSpy).not.toHaveBeenCalled();
+            expect(hasOwnerOnlyAccessSpy).toHaveBeenCalledWith("/tmp/zowe-edit-ds-abc");
         });
         it("should set an owner-only ACL when creating on Windows", () => {
             setPlatform("win32");
-            existsSyncSpy.mockReturnValue(false);
+            lstatSyncSpy.mockReturnValue({ isDirectory: () => true } as any);
+            hasOwnerOnlyAccessSpy.mockReturnValue(true);
             ZosFilesUtils.ensureSafeTempDir("C:\\Temp\\zowe-edit-ds-abc");
             expect(giveAccessSpy).toHaveBeenCalledWith("C:\\Temp\\zowe-edit-ds-abc");
         });
         it("should accept a pre-existing directory whose access is restricted to the current user (any platform)", () => {
-            existsSyncSpy.mockReturnValue(true);
+            mkdirSyncSpy.mockImplementation(eexist);
             lstatSyncSpy.mockReturnValue({ isDirectory: () => true } as any);
             hasOwnerOnlyAccessSpy.mockReturnValue(true);
             expect(() => ZosFilesUtils.ensureSafeTempDir("/tmp/zowe-edit-ds-abc")).not.toThrow();
             expect(hasOwnerOnlyAccessSpy).toHaveBeenCalledWith("/tmp/zowe-edit-ds-abc");
         });
         it("should reject a pre-existing directory that is not restricted to the current user (any platform)", () => {
-            existsSyncSpy.mockReturnValue(true);
+            mkdirSyncSpy.mockImplementation(eexist);
             lstatSyncSpy.mockReturnValue({ isDirectory: () => true } as any);
             hasOwnerOnlyAccessSpy.mockReturnValue(false);
             expect(() => ZosFilesUtils.ensureSafeTempDir("/tmp/zowe-edit-ds-abc")).toThrow(/Unsafe temp directory/);
         });
         it("should reject when the path exists but is not a directory (e.g. a planted symlink)", () => {
-            existsSyncSpy.mockReturnValue(true);
+            mkdirSyncSpy.mockImplementation(eexist);
             lstatSyncSpy.mockReturnValue({ isDirectory: () => false } as any);
             expect(() => ZosFilesUtils.ensureSafeTempDir("/tmp/zowe-edit-ds-abc")).toThrow(/Unsafe temp directory/);
             expect(hasOwnerOnlyAccessSpy).not.toHaveBeenCalled();
+        });
+        it("should reject a directory planted mid-race between a hypothetical existence check and creation", () => {
+            // Even though nothing "existed" beforehand from the caller's point of view, mkdirSync throwing
+            // EEXIST means something is there now - the safety check below must still run unconditionally.
+            mkdirSyncSpy.mockImplementation(eexist);
+            lstatSyncSpy.mockReturnValue({ isDirectory: () => true } as any);
+            hasOwnerOnlyAccessSpy.mockReturnValue(false);
+            expect(() => ZosFilesUtils.ensureSafeTempDir("/tmp/zowe-edit-ds-abc")).toThrow(/Unsafe temp directory/);
+            expect(giveAccessSpy).not.toHaveBeenCalled();
+        });
+        it("should rethrow non-EEXIST errors from mkdirSync", () => {
+            const err: any = new Error("EACCES");
+            err.code = "EACCES";
+            mkdirSyncSpy.mockImplementation(() => { throw err; });
+            expect(() => ZosFilesUtils.ensureSafeTempDir("/tmp/zowe-edit-ds-abc")).toThrow(err);
         });
     });
 

--- a/packages/zosfiles/src/utils/ZosFilesUtils.ts
+++ b/packages/zosfiles/src/utils/ZosFilesUtils.ts
@@ -88,22 +88,22 @@ export class ZosFilesUtils {
 
     /**
      * Ensures a temp directory exists and is safe to use, creating it if necessary.
-     * When creating, the directory is restricted to the owner (mode 0700 on POSIX; on Windows
-     * `fs.mkdirSync`'s `mode` is a no-op, so an owner-only ACL is set via {@link IO.giveAccessOnlyToOwner}).
-     * When the directory already exists, it is rejected unless it is a real directory whose access is
-     * restricted to the current user - verified the same way on every platform via
-     * {@link IO.hasOwnerOnlyAccess} - so a directory planted by another local user sharing the same
-     * tmp location is refused.
+     * Ownership and permissions are always verified after the creation attempt, whether or not the
+     * directory already existed, so a directory planted by another local user sharing the same tmp
+     * location is rejected.
      * @param {string} dir - the temp directory to validate or create
      * @throws {ImperativeError} - when the directory exists but is not safe to use
      */
     public static ensureSafeTempDir(dir: string): void {
-        if (!fs.existsSync(dir)) {
-            fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+        try {
+            fs.mkdirSync(dir, { recursive: false, mode: 0o700 });
             if (process.platform === "win32") {
                 IO.giveAccessOnlyToOwner(dir);
             }
-            return;
+        } catch (err) {
+            if (err.code !== "EEXIST") {
+                throw err;
+            }
         }
         // Reject a planted symlink/non-directory (lstat does not follow symlinks) before checking access.
         if (!fs.lstatSync(dir).isDirectory() || !IO.hasOwnerOnlyAccess(dir)) {


### PR DESCRIPTION
**What It Does**
Ensures that safety checks are atomic to avoid race conditions

**How to Test**
Run `npx jest packages/zosfiles/__tests__/__unit__/utils/ZosFilesUtils.unit.test.ts`

**Review Checklist**
I certify that I have:
- [x] updated the changelog
- [x] manually tested my changes
- [x] added/updated automated unit/integration tests
- [ ] created/ran system tests (provide build number if applicable)
- [ ] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
