### PR TITLE
add default tso and abstract rest client timeout

### DIFF
--- a/packages/imperative/CHANGELOG.md
+++ b/packages/imperative/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Imperative package will be documented in this file.
 
+## Recent Changes
+
+- BugFix: Added a default request completion timeout to the `AbstractRestClient`class. [#2842](https://github.com/zowe/zowe-cli/pull/2842)
+
 ## `8.35.0`
 
 - Enhancement: Added a `ConfigRedact` API, accessible via the `Config.api.redact` class instance, with methods for programmatically retrieving Zowe configuration layers with sensitive values redacted. [#2827](https://github.com/zowe/zowe-cli/pull/2827)

--- a/packages/imperative/CHANGELOG.md
+++ b/packages/imperative/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the Imperative package will be documented in this file.
 
 ## Recent Changes
 
-- BugFix: Added a default request completion timeout to the `AbstractRestClient`class. [#2842](https://github.com/zowe/zowe-cli/pull/2842)
+- BugFix: Added a default request completion timeout to the `AbstractRestClient` class. [#2842](https://github.com/zowe/zowe-cli/pull/2842)
 - BugFix: Removed top level import of an ESM dependency (`sanitize-html`) for better compatibility with dev tools like Jest. [#2841](https://github.com/zowe/zowe-cli/pull/2841)
 
 ## `8.35.0`

--- a/packages/imperative/src/rest/__tests__/client/AbstractRestClient.unit.test.ts
+++ b/packages/imperative/src/rest/__tests__/client/AbstractRestClient.unit.test.ts
@@ -799,7 +799,8 @@ describe("AbstractRestClient tests", () => {
 
         expect(requestFnc).toHaveBeenCalledTimes(1);
         expect(readEnvSpy).toHaveBeenCalledTimes(1);
-        expect(session.ISession.requestCompletionTimeout).toBeUndefined();
+        // Falls back to the 30 minute default when the env variable value cannot be parsed
+        expect(session.ISession.requestCompletionTimeout).toBe(30 * 60 * 1000);
     });
 
     it("should handle a request completion timeout and use the provided callback", async () => {

--- a/packages/imperative/src/rest/src/client/AbstractRestClient.ts
+++ b/packages/imperative/src/rest/src/client/AbstractRestClient.ts
@@ -59,6 +59,7 @@ export abstract class AbstractRestClient {
      * @type {number}
      * @memberof AbstractRestClient
      */
+    // eslint-disable-next-line @typescript-eslint/no-magic-numbers
     private static readonly DEFAULT_REQUEST_COMPLETION_TIMEOUT: number = 30 * 60 * 1000;
 
     /**

--- a/packages/imperative/src/rest/src/client/AbstractRestClient.ts
+++ b/packages/imperative/src/rest/src/client/AbstractRestClient.ts
@@ -52,6 +52,16 @@ export type RestClientResolve = (data: string) => void;
 export abstract class AbstractRestClient {
 
     /**
+     * Default number of milliseconds to wait for a REST request to complete when no
+     * explicit requestCompletionTimeout was set on the session or via environment variable
+     * @private
+     * @static
+     * @type {number}
+     * @memberof AbstractRestClient
+     */
+    private static readonly DEFAULT_REQUEST_COMPLETION_TIMEOUT: number = 30 * 60 * 1000;
+
+    /**
      * Contains REST chucks
      * @private
      * @type {Buffer[]}
@@ -573,11 +583,14 @@ export abstract class AbstractRestClient {
             }
 
             this.session.ISession.requestCompletionTimeout ??= isNaN(Number(requestCompletionTimeout)) ? undefined : Number(requestCompletionTimeout);
-            if (this.session.ISession.requestCompletionTimeout != null) {
-                Logger.getImperativeLogger().info(
-                    "Setting request completion timeout ms: " + String(this.mSession.ISession.requestCompletionTimeout)
-                );
-            }
+        }
+
+        // Default to a 30 minute request completion timeout if one was not set via session options or environment variable
+        this.session.ISession.requestCompletionTimeout ??= AbstractRestClient.DEFAULT_REQUEST_COMPLETION_TIMEOUT;
+        if (this.session.ISession.requestCompletionTimeout != null) {
+            Logger.getImperativeLogger().info(
+                "Setting request completion timeout ms: " + String(this.mSession.ISession.requestCompletionTimeout)
+            );
         }
 
         /**

--- a/packages/zostso/CHANGELOG.md
+++ b/packages/zostso/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Zowe z/OS TSO SDK package will be documented in this file.
 
+## Recent Changes
+
+- BugFix: Added a default timeout while collecting TSO responses, and a 100ms delay before polling again when no TSO data is returned. [#2842](https://github.com/zowe/zowe-cli/pull/2842)
+
 ## `8.33.0`
 
 - Enhancement: Added a new optional boolean field `useLegacyApi` to the `IIssueTsoCmdOpts` interface used to call the `IssueTso.issueTsoCmd` method. For more details, see [the CLI changelog](../cli/CHANGELOG.md). [#2738](https://github.com/zowe/zowe-cli/issues/2738)

--- a/packages/zostso/__tests__/__unit__/SendTso.unit.test.ts
+++ b/packages/zostso/__tests__/__unit__/SendTso.unit.test.ts
@@ -12,6 +12,10 @@
 import { ImperativeError, Session } from "@zowe/imperative";
 import { ISendResponse, IZosmfTsoResponse, SendTso } from "../../src";
 import { ZosmfRestClient } from "@zowe/core-for-zowe-sdk";
+import { TsoConstants } from "../../src/TsoConstants";
+
+// Captured before any test gets a chance to permanently overwrite the static method below
+const originalGetAllResponses = SendTso.getAllResponses;
 
 const PRETEND_SESSION = new Session({
     user: "user",
@@ -39,6 +43,29 @@ const ZOSMF_RESPONSE: IZosmfTsoResponse = {
             DATA: "some response"
         }
     }]
+};
+const RESPONSE_WITH_PROMPT: IZosmfTsoResponse = {
+    servletKey: "key",
+    queueID: "4",
+    ver: "0100",
+    reused: false,
+    timeout: false,
+    sessionID: "0x37",
+    tsoData: [{
+        "TSO PROMPT": {
+            VERSION: "0100",
+            HIDDEN: "N"
+        }
+    }]
+};
+const RESPONSE_WITH_NO_DATA: IZosmfTsoResponse = {
+    servletKey: "key",
+    queueID: "4",
+    ver: "0100",
+    reused: false,
+    timeout: false,
+    sessionID: "0x37",
+    tsoData: undefined
 };
 
 describe("TsoSend sendDataToTSOCollect - failing scenarios", () => {
@@ -141,6 +168,61 @@ describe("TsoSend getDataFromTSO", () => {
         expect(error).not.toBeDefined();
         expect(response).toBeDefined();
         expect(ZosmfRestClient.getExpectJSON as any).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe("TsoSend getAllResponses", () => {
+    beforeEach(() => {
+        // An earlier suite permanently overwrites this static method with a mock, so restore it here
+        (SendTso.getAllResponses as any) = originalGetAllResponses;
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+        jest.useRealTimers();
+    });
+
+    it("should collect messages and stop once a TSO PROMPT is reached", async () => {
+        (SendTso.getDataFromTSO as any) = jest.fn().mockResolvedValueOnce(RESPONSE_WITH_PROMPT);
+
+        const response = await SendTso.getAllResponses(PRETEND_SESSION, ZOSMF_RESPONSE);
+
+        expect(response.messages).toEqual("some response\n");
+        expect(response.tsos).toEqual([ZOSMF_RESPONSE]);
+        expect(SendTso.getDataFromTSO as any).toHaveBeenCalledTimes(1);
+    });
+
+    it("should debounce for 100ms and poll again when no tsoData is returned", async () => {
+        jest.useFakeTimers();
+        const getDataFromTSOMock = jest.fn()
+            .mockResolvedValueOnce(RESPONSE_WITH_NO_DATA)
+            .mockResolvedValueOnce(RESPONSE_WITH_PROMPT);
+        (SendTso.getDataFromTSO as any) = getDataFromTSOMock;
+
+        const responsePromise = SendTso.getAllResponses(PRETEND_SESSION, ZOSMF_RESPONSE);
+        await jest.advanceTimersByTimeAsync(TsoConstants.DEFAULT_NO_DATA_DEBOUNCE);
+        const response = await responsePromise;
+
+        expect(getDataFromTSOMock).toHaveBeenCalledTimes(2);
+        expect(response.messages).toEqual("some response\n");
+    });
+
+    it("should throw an error when the TSO PROMPT timeout is exceeded", async () => {
+        (SendTso.getDataFromTSO as any) = jest.fn().mockResolvedValue(ZOSMF_RESPONSE);
+        jest.spyOn(Date, "now")
+            .mockReturnValueOnce(0) // start time
+            .mockReturnValueOnce(0) // first loop iteration check, timeout not yet exceeded
+            .mockReturnValue(TsoConstants.DEFAULT_PROMPT_TIMEOUT + 1); // subsequent checks exceed the timeout
+
+        let error: ImperativeError;
+        try {
+            await SendTso.getAllResponses(PRETEND_SESSION, ZOSMF_RESPONSE);
+        } catch (thrownError) {
+            error = thrownError;
+        }
+
+        expect(error).toBeDefined();
+        expect(error.message).toContain("Timed out waiting for a TSO PROMPT");
     });
 });
 

--- a/packages/zostso/src/SendTso.ts
+++ b/packages/zostso/src/SendTso.ts
@@ -95,12 +95,9 @@ export class SendTso {
                 tso.tsoData.forEach((data) => {
                     if (data[TsoConstants.TSO_MESSAGE]) {
                         messages += data[TsoConstants.TSO_MESSAGE].DATA + "\n";
-                    } else if (data[TsoConstants.TSO_PROMPT]) {
-                        // handle case where we get a PROMPT but no data has been accumulated yet
-                        if (messages !== "") {
-                            done = true;
-                        } else {
-                        }
+                    } else if (data[TsoConstants.TSO_PROMPT] && messages !== "") {
+                        // ignore a PROMPT reached before any data has been accumulated yet
+                        done = true;
                     }
                 });
             } else {

--- a/packages/zostso/src/SendTso.ts
+++ b/packages/zostso/src/SendTso.ts
@@ -9,11 +9,11 @@
 *
 */
 
-import { AbstractSession, Headers } from "@zowe/imperative";
+import { AbstractSession, Headers, ImperativeError } from "@zowe/imperative";
 import { ZosmfRestClient } from "@zowe/core-for-zowe-sdk";
 
 import { TsoValidator } from "./TsoValidator";
-import { noDataInput, noServletKeyInput, TsoConstants } from "./TsoConstants";
+import { noDataInput, noServletKeyInput, TsoConstants, tsoPromptTimeout } from "./TsoConstants";
 import { ISendTsoParms } from "./doc/input/ISendTsoParms";
 import { IZosmfTsoResponse } from "./doc/zosmf/IZosmfTsoResponse";
 import { ICollectedResponses } from "./doc/ICollectedResponses";
@@ -86,7 +86,11 @@ export class SendTso {
         const tsos: IZosmfTsoResponse[] = [];
         tsos.push(tso);
         let messages: string = "";
+        const startTime = Date.now();
         while (!done) {
+            if (Date.now() - startTime > TsoConstants.DEFAULT_PROMPT_TIMEOUT) {
+                throw new ImperativeError({msg: tsoPromptTimeout.message});
+            }
             if (!(tso.tsoData == null)) {
                 tso.tsoData.forEach((data) => {
                     if (data[TsoConstants.TSO_MESSAGE]) {
@@ -96,10 +100,12 @@ export class SendTso {
                         if (messages !== "") {
                             done = true;
                         } else {
-                            // TSO PROMPT reached without getting any data, retrying
                         }
                     }
                 });
+            } else {
+                // No content returned yet - debounce briefly before polling again
+                await new Promise((resolve) => setTimeout(resolve, TsoConstants.DEFAULT_NO_DATA_DEBOUNCE));
             }
             if (!done) {
                 tso = await SendTso.getDataFromTSO(session, tso.servletKey);

--- a/packages/zostso/src/TsoConstants.ts
+++ b/packages/zostso/src/TsoConstants.ts
@@ -168,6 +168,22 @@ export class TsoConstants {
      */
     public static readonly TSO_MESSAGE = "TSO MESSAGE";
 
+    /**
+     * Default number of milliseconds to wait for a TSO PROMPT while collecting responses before giving up
+     * @static
+     * @type {number}
+     * @memberof TsoConstants
+     */
+    public static readonly DEFAULT_PROMPT_TIMEOUT: number = 30 * 60 * 1000;
+
+    /**
+     * Default number of milliseconds to wait before polling again when no TSO data was returned
+     * @static
+     * @type {number}
+     * @memberof TsoConstants
+     */
+    public static readonly DEFAULT_NO_DATA_DEBOUNCE: number = 100;
+
 }
 
 /**
@@ -268,5 +284,15 @@ export const noDataInput: IMessageDefinition = {
  */
 export const noCommandInput: IMessageDefinition = {
     message: apiErrorHeader.message + ` No command text was provided.`
+};
+
+/**
+ * Timed out waiting for a TSO PROMPT error message
+ * @static
+ * @type {IMessageDefinition}
+ * @memberof TsoConstants
+ */
+export const tsoPromptTimeout: IMessageDefinition = {
+    message: apiErrorHeader.message + ` Timed out waiting for a TSO PROMPT response.`
 };
 

--- a/packages/zostso/src/TsoConstants.ts
+++ b/packages/zostso/src/TsoConstants.ts
@@ -174,6 +174,7 @@ export class TsoConstants {
      * @type {number}
      * @memberof TsoConstants
      */
+    // eslint-disable-next-line @typescript-eslint/no-magic-numbers
     public static readonly DEFAULT_PROMPT_TIMEOUT: number = 30 * 60 * 1000;
 
     /**


### PR DESCRIPTION
**What It Does**
Adds a 30 minute default timeout for REST requests and TSO wait duration for "TSO PROMPT"

**How to Test**
WIP 

**Review Checklist**
I certify that I have:
- [x] updated the changelog
- [x] manually tested my changes
- [x] added/updated automated unit/integration tests
- [x] created/ran system tests (2533)
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
