### PR TITLE
Restrict npm version for Dependabot and CLI devs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,10 @@
         "ts-node": "^7.0.1",
         "typedoc": "^0.26.3",
         "typescript": "^5.5.3"
+      },
+      "engines": {
+        "node": ">=20.9.0",
+        "npm": "^10.0.0"
       }
     },
     "__tests__/__packages__/cli-test-utils": {

--- a/package.json
+++ b/package.json
@@ -77,6 +77,11 @@
     "typedoc": "^0.26.3",
     "typescript": "^5.5.3"
   },
+  "engines": {
+    "node": ">=20.9.0",
+    "npm": "^10.0.0"
+  },
+  "packageManager": "npm@10.9.8",
   "jestSonar": {
     "reportPath": "__tests__/__results__/jest-sonar"
   },


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->
* Defines `packageManager` in top-level `package.json` which should influence the npm version used by Dependabot
  * This property must define an exact version and does not support ranges so we use the latest `npm@10`
* Defines `engines` in top level package.json so that a range of npm versions is allowed for CLI devs
  * If you try to install with Node 24 + npm 11, the command succeeds but displays a warning

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->

**Review Checklist**
I certify that I have:
- [ ] updated the changelog
- [ ] manually tested my changes
- [ ] added/updated automated unit/integration tests
- [ ] created/ran system tests (provide build number if applicable)
- [ ] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
