### PR TITLE
fix user check on binary request

### DIFF
--- a/zowex/Cargo.lock
+++ b/zowex/Cargo.lock
@@ -727,6 +727,7 @@ dependencies = [
  "fslock",
  "home",
  "is-terminal",
+ "libc",
  "pathsearch",
  "rpassword",
  "serde",

--- a/zowex/Cargo.toml
+++ b/zowex/Cargo.toml
@@ -24,6 +24,9 @@ tokio = { version = "1.44.2", features = ["io-util", "macros", "net", "rt-multi-
 whoami = "1.5.0"
 yansi = "0.5.1"
 
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
 [target.'cfg(windows)'.dependencies]
 fslock = "0.2.1"
 windows-sys = { version = "0.52.0", features = [

--- a/zowex/src/comm.rs
+++ b/zowex/src/comm.rs
@@ -20,6 +20,9 @@ use tokio::io::AsyncBufReadExt;
 use tokio::io::AsyncWriteExt;
 use tokio::io::BufReader;
 
+#[cfg(target_family = "unix")]
+use std::os::unix::io::AsRawFd;
+
 #[cfg(target_family = "windows")]
 use std::os::windows::io::AsRawHandle;
 #[cfg(target_family = "windows")]
@@ -81,14 +84,33 @@ pub async fn comm_establish_connection(
     let stream = loop {
         #[cfg(target_family = "unix")]
         if let Ok(good_stream) = DaemonClient::connect(daemon_socket).await {
-            // We made our connection. Break with the actual stream value
-            break good_stream;
+            if comm_peer_is_current_user(&good_stream) {
+                // We made our connection. Break with the actual stream value
+                break good_stream;
+            }
+            // A socket with our daemon's name exists, but it is not served by a
+            // process running as the current user. The daemon directory is
+            // normally restricted to its owner, so this should not happen, but
+            // a socket left in a relaxed ZOWE_DAEMON_DIR (or created during the
+            // window before the directory was restricted) could be served by
+            // another local account in order to capture what we would otherwise
+            // send to it. Drop this connection and keep retrying/starting our
+            // own daemon instead of trusting it. Only warn once, since this
+            // branch is reached on every retry.
+            static WARNED_UNTRUSTED_SOCKET: std::sync::Once = std::sync::Once::new();
+            WARNED_UNTRUSTED_SOCKET.call_once(|| {
+                eprintln!(
+                    "Warning: The Zowe daemon socket at {} does not belong to the current user. Ignoring it.",
+                    daemon_socket
+                );
+            });
+            drop(good_stream);
         }
 
         #[cfg(target_family = "windows")]
         match ClientOptions::new().open(daemon_socket) {
             Ok(stream) => {
-                if windows_pipe_owned_by_current_user(&stream) {
+                if comm_peer_is_current_user(&stream) {
                     break stream;
                 }
                 // A pipe with our daemon's name exists, but it is not served by a
@@ -179,6 +201,100 @@ pub async fn comm_establish_connection(
     };
 
     Ok(stream)
+}
+
+/**
+ * Confirm that the process serving the other end of our connection runs as the
+ * current user, so that we never hand our command line, environment, stdin, or
+ * secure prompt replies to a daemon impersonated by another local account.
+ *
+ * The comparison is made against the OS-reported identity of the peer process
+ * rather than against the ownership of the socket or pipe in the file system,
+ * because only the former identifies the process that will actually read what
+ * we send. Any failure to positively confirm a match is treated as untrusted.
+ *
+ * @param stream
+ *      The already-connected socket or pipe client.
+ *
+ * @returns
+ *      true only if the process serving the connection runs as the current user.
+ */
+#[cfg(target_family = "unix")]
+pub fn comm_peer_is_current_user(stream: &DaemonClient) -> bool {
+    match comm_peer_uid(stream.as_raw_fd()) {
+        // SAFETY: geteuid takes no arguments and is documented as always
+        // succeeding, so there is no error case to handle.
+        Some(peer_uid) => peer_uid == unsafe { libc::geteuid() },
+        None => {
+            eprintln!(
+                "Warning: Unable to verify the owner of the Zowe daemon socket. Details = {}",
+                io::Error::last_os_error()
+            );
+            false
+        }
+    }
+}
+
+#[cfg(target_family = "windows")]
+pub fn comm_peer_is_current_user(stream: &DaemonClient) -> bool {
+    windows_pipe_owned_by_current_user(stream)
+}
+
+/**
+ * Ask the kernel for the effective user ID of the process on the other end of
+ * a connected Unix domain socket.
+ *
+ * Both mechanisms below report the credentials that the peer held when the
+ * connection was established, not the credentials it holds now, so the answer
+ * cannot be invalidated by a later change on the peer side.
+ *
+ * @param fd
+ *      The file descriptor of the connected socket.
+ *
+ * @returns
+ *      The effective UID of the peer, or None if the kernel would not tell us.
+ */
+#[cfg(target_family = "unix")]
+fn comm_peer_uid(fd: i32) -> Option<u32> {
+    // Linux and Android report a ucred struct of { pid, uid, gid }.
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    {
+        let mut peer_cred: libc::ucred = unsafe { std::mem::zeroed() };
+        let mut peer_cred_len = std::mem::size_of::<libc::ucred>() as libc::socklen_t;
+
+        // SAFETY: peer_cred and peer_cred_len describe a correctly sized and
+        // correctly typed ucred buffer that outlives this call.
+        let got_peer_cred = unsafe {
+            libc::getsockopt(
+                fd,
+                libc::SOL_SOCKET,
+                libc::SO_PEERCRED,
+                &mut peer_cred as *mut libc::ucred as *mut libc::c_void,
+                &mut peer_cred_len,
+            )
+        };
+
+        if got_peer_cred != 0 || (peer_cred_len as usize) < std::mem::size_of::<libc::ucred>() {
+            return None;
+        }
+        Some(peer_cred.uid)
+    }
+
+    // macOS and the BSDs report the UID and GID directly.
+    #[cfg(not(any(target_os = "linux", target_os = "android")))]
+    {
+        let mut peer_uid: libc::uid_t = 0;
+        let mut peer_gid: libc::gid_t = 0;
+
+        // SAFETY: both out parameters are correctly typed locals that outlive
+        // this call.
+        let got_peer_eid = unsafe { libc::getpeereid(fd, &mut peer_uid, &mut peer_gid) };
+
+        if got_peer_eid != 0 {
+            return None;
+        }
+        Some(peer_uid)
+    }
 }
 
 /**
@@ -310,6 +426,19 @@ pub async fn comm_talk(message: &[u8], stream: &mut DaemonClient) -> io::Result<
      */
     stream.writable().await?;
 
+    /* Re-verify the peer immediately before we disclose anything to it. The
+     * request carries our command line, environment, and daemon token, so we
+     * check here as well as at connection time rather than relying on the
+     * caller having handed us a stream that was already vetted.
+     */
+    if !comm_peer_is_current_user(stream) {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "The Zowe daemon is not being served by a process running as the current user. \
+             Refusing to send the command to it.",
+        ));
+    }
+
     // write request to daemon
     stream.write_all(message).await?;
 
@@ -372,6 +501,21 @@ pub async fn comm_talk(message: &[u8], stream: &mut DaemonClient) -> io::Result<
                     if let Some(s) = p.stderr {
                         eprint!("{}", s);
                         io::stderr().flush().unwrap();
+                    }
+
+                    /* A prompt asks us to collect input from the user and send
+                     * it onward, which for securePrompt is a credential typed in
+                     * response to text that the peer controls. Verify the peer
+                     * once more before we display that text or read the reply.
+                     */
+                    if (p.prompt.is_some() || p.securePrompt.is_some())
+                        && !comm_peer_is_current_user(reader.get_ref())
+                    {
+                        return Err(io::Error::new(
+                            io::ErrorKind::PermissionDenied,
+                            "The Zowe daemon is not being served by a process running as the \
+                             current user. Refusing to supply the requested input.",
+                        ));
                     }
 
                     if let Some(s) = p.prompt {

--- a/zowex/src/comm.rs
+++ b/zowex/src/comm.rs
@@ -20,9 +20,6 @@ use tokio::io::AsyncBufReadExt;
 use tokio::io::AsyncWriteExt;
 use tokio::io::BufReader;
 
-#[cfg(target_family = "unix")]
-use std::os::unix::io::AsRawFd;
-
 #[cfg(target_family = "windows")]
 use std::os::windows::io::AsRawHandle;
 #[cfg(target_family = "windows")]
@@ -212,6 +209,9 @@ pub async fn comm_establish_connection(
  * rather than against the ownership of the socket or pipe in the file system,
  * because only the former identifies the process that will actually read what
  * we send. Any failure to positively confirm a match is treated as untrusted.
+ * On Unix, `UnixStream::peer_cred` reports the credentials the peer held when
+ * the connection was established, so the answer cannot be invalidated by a
+ * later change on the peer side.
  *
  * @param stream
  *      The already-connected socket or pipe client.
@@ -221,14 +221,14 @@ pub async fn comm_establish_connection(
  */
 #[cfg(target_family = "unix")]
 pub fn comm_peer_is_current_user(stream: &DaemonClient) -> bool {
-    match comm_peer_uid(stream.as_raw_fd()) {
+    match stream.peer_cred() {
         // SAFETY: geteuid takes no arguments and is documented as always
         // succeeding, so there is no error case to handle.
-        Some(peer_uid) => peer_uid == unsafe { libc::geteuid() },
-        None => {
+        Ok(peer_cred) => peer_cred.uid() == unsafe { libc::geteuid() },
+        Err(e) => {
             eprintln!(
                 "Warning: Unable to verify the owner of the Zowe daemon socket. Details = {}",
-                io::Error::last_os_error()
+                e
             );
             false
         }
@@ -238,63 +238,6 @@ pub fn comm_peer_is_current_user(stream: &DaemonClient) -> bool {
 #[cfg(target_family = "windows")]
 pub fn comm_peer_is_current_user(stream: &DaemonClient) -> bool {
     windows_pipe_owned_by_current_user(stream)
-}
-
-/**
- * Ask the kernel for the effective user ID of the process on the other end of
- * a connected Unix domain socket.
- *
- * Both mechanisms below report the credentials that the peer held when the
- * connection was established, not the credentials it holds now, so the answer
- * cannot be invalidated by a later change on the peer side.
- *
- * @param fd
- *      The file descriptor of the connected socket.
- *
- * @returns
- *      The effective UID of the peer, or None if the kernel would not tell us.
- */
-#[cfg(target_family = "unix")]
-fn comm_peer_uid(fd: i32) -> Option<u32> {
-    // Linux and Android report a ucred struct of { pid, uid, gid }.
-    #[cfg(any(target_os = "linux", target_os = "android"))]
-    {
-        let mut peer_cred: libc::ucred = unsafe { std::mem::zeroed() };
-        let mut peer_cred_len = std::mem::size_of::<libc::ucred>() as libc::socklen_t;
-
-        // SAFETY: peer_cred and peer_cred_len describe a correctly sized and
-        // correctly typed ucred buffer that outlives this call.
-        let got_peer_cred = unsafe {
-            libc::getsockopt(
-                fd,
-                libc::SOL_SOCKET,
-                libc::SO_PEERCRED,
-                &mut peer_cred as *mut libc::ucred as *mut libc::c_void,
-                &mut peer_cred_len,
-            )
-        };
-
-        if got_peer_cred != 0 || (peer_cred_len as usize) < std::mem::size_of::<libc::ucred>() {
-            return None;
-        }
-        Some(peer_cred.uid)
-    }
-
-    // macOS and the BSDs report the UID and GID directly.
-    #[cfg(not(any(target_os = "linux", target_os = "android")))]
-    {
-        let mut peer_uid: libc::uid_t = 0;
-        let mut peer_gid: libc::gid_t = 0;
-
-        // SAFETY: both out parameters are correctly typed locals that outlive
-        // this call.
-        let got_peer_eid = unsafe { libc::getpeereid(fd, &mut peer_uid, &mut peer_gid) };
-
-        if got_peer_eid != 0 {
-            return None;
-        }
-        Some(peer_uid)
-    }
 }
 
 /**

--- a/zowex/src/test.rs
+++ b/zowex/src/test.rs
@@ -236,6 +236,45 @@ fn unit_test_util_restrict_zowe_bin_to_owner() {
     );
 }
 
+#[cfg(target_family = "unix")]
+#[tokio::test]
+async fn unit_test_comm_peer_is_current_user() {
+    use crate::comm::comm_peer_is_current_user;
+    use tokio::net::{UnixListener, UnixStream};
+
+    // Both ends of this socket belong to the process running the test, so the
+    // check must accept them. The negative case (a socket served by a different
+    // user) cannot be produced without a second account, so it is not covered.
+    let sock_path = env::temp_dir().join("zowe_test_comm_peer_cred.sock");
+    std::fs::remove_file(&sock_path).ok();
+
+    let listener = UnixListener::bind(&sock_path).expect("should bind the test socket");
+
+    // Accept concurrently, so that our own connect can complete.
+    let accept_task = tokio::spawn(async move { listener.accept().await });
+    let client_end = UnixStream::connect(&sock_path)
+        .await
+        .expect("should connect to the test socket");
+    let (server_end, _addr) = accept_task
+        .await
+        .expect("the accept task should not panic")
+        .expect("should accept the test connection");
+
+    println!("--- test_comm_peer_is_current_user: socket path = {}", sock_path.display());
+    assert!(
+        comm_peer_is_current_user(&client_end),
+        "the client end should trust a peer running as the current user"
+    );
+    assert!(
+        comm_peer_is_current_user(&server_end),
+        "the server end should trust a peer running as the current user"
+    );
+
+    drop(client_end);
+    drop(server_end);
+    std::fs::remove_file(&sock_path).ok();
+}
+
 #[tokio::test]
 // test daemon restart
 async fn integration_test_restart() {


### PR DESCRIPTION
**What It Does**
Adds a IUD check on requests

**How to Test**
Run `cargo test unit --manifest-path=zowex/Cargo.toml`

**Review Checklist**
I certify that I have:
- [ ] updated the changelog
- [x] manually tested my changes
- [x] added/updated automated unit/integration tests
- [ ] created/ran system tests (provide build number if applicable)
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
