### PR TITLE
Restrict access permissions on Windows TLS named pipe

### DIFF
--- a/packages/secrets/CHANGELOG.md
+++ b/packages/secrets/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to the Zowe Secrets SDK package will be documented in this file.
 
+## Recent Changes
+- BugFix: Restricts the discretionary access control list (DACL) on Windows local named pipes so that access is for the owner only. [#2872](https://github.com/zowe/zowe-cli/pull/2872)
+
 ## `8.33.4`
 
 - BugFix: Adjusted permissions for the macOS TLS socket to ensure secure use. [#2811](https://github.com/zowe/zowe-cli/pull/2811)

--- a/packages/secrets/core/Cargo.toml
+++ b/packages/secrets/core/Cargo.toml
@@ -17,6 +17,8 @@ features = [
   "Win32_Security_Cryptography",
   "Win32_Security_Cryptography_Catalog",
   "Win32_Networking_WinHttp",
+  "Win32_Security",
+  "Win32_Security_Authorization",
   "Win32_System_Diagnostics_Debug",
   "Win32_System_Memory",
   "Win32_System_WindowsProgramming",

--- a/packages/secrets/core/src/os/win/tls_pipe.rs
+++ b/packages/secrets/core/src/os/win/tls_pipe.rs
@@ -46,6 +46,28 @@ fn schannel_error_hint(code: i32) -> &'static str {
     }
 }
 
+fn owner_only_security_descriptor() -> Result<PSECURITY_DESCRIPTOR, KeyringError> {
+    let mut sddl_wide: Vec<u16> = OWNER_ONLY_SDDL.encode_utf16().collect();
+    sddl_wide.push(0);
+
+    let mut sec_desc: PSECURITY_DESCRIPTOR = std::ptr::null_mut();
+    let conv_res = unsafe {
+        ConvertStringSecurityDescriptorToSecurityDescriptorW(
+            sddl_wide.as_ptr(),
+            SDDL_REVISION_1,
+            &mut sec_desc,
+            std::ptr::null_mut(),
+        )
+    };
+
+    if conv_res == 0 {
+        let err = unsafe { GetLastError() };
+        return Err(KeyringError::Os(format!("Failed to convert SDDL to security descriptor. Error: {}", err)));
+    }
+
+    Ok(sec_desc)
+}
+
 pub fn create_tls_pipe(
     remote_host: &String,
     remote_port: u16,
@@ -69,23 +91,7 @@ pub fn create_tls_pipe(
     let mut wide_name: Vec<u16> = pipe_name_str.encode_utf16().collect();
     wide_name.push(0);
 
-    let mut sddl_wide: Vec<u16> = OWNER_ONLY_SDDL.encode_utf16().collect();
-    sddl_wide.push(0);
-
-    let mut sec_desc: PSECURITY_DESCRIPTOR = std::ptr::null_mut();
-    let conv_res = unsafe {
-        ConvertStringSecurityDescriptorToSecurityDescriptorW(
-            sddl_wide.as_ptr(),
-            SDDL_REVISION_1,
-            &mut sec_desc,
-            std::ptr::null_mut(),
-        )
-    };
-
-    if conv_res == 0 {
-        let err = unsafe { GetLastError() };
-        return Err(KeyringError::Os(format!("Failed to convert SDDL to security descriptor. Error: {}", err)));
-    }
+    let sec_desc = owner_only_security_descriptor()?;
 
     let mut sec_attrs = SECURITY_ATTRIBUTES {
         nLength: std::mem::size_of::<SECURITY_ATTRIBUTES>() as u32,
@@ -106,13 +112,13 @@ pub fn create_tls_pipe(
         )
     };
 
+    let create_err = unsafe { GetLastError() };
     unsafe {
         LocalFree(sec_desc as _);
     }
 
     if pipe_handle == INVALID_HANDLE_VALUE {
-        let err = unsafe { GetLastError() };
-        return Err(KeyringError::Os(format!("Failed to create named pipe. Error: {}", err)));
+        return Err(KeyringError::Os(format!("Failed to create named pipe. Error: {}", create_err)));
     }
 
     let remote_addr = format!("{}:{}", remote_host, remote_port);
@@ -275,20 +281,9 @@ mod tests {
 
     #[test]
     fn test_owner_only_sddl_conversion() {
-        let mut sddl_wide: Vec<u16> = OWNER_ONLY_SDDL.encode_utf16().collect();
-        sddl_wide.push(0);
+        let sec_desc = owner_only_security_descriptor()
+            .expect("owner-only security descriptor should be constructible");
 
-        let mut sec_desc: PSECURITY_DESCRIPTOR = std::ptr::null_mut();
-        let conv_res = unsafe {
-            ConvertStringSecurityDescriptorToSecurityDescriptorW(
-                sddl_wide.as_ptr(),
-                SDDL_REVISION_1,
-                &mut sec_desc,
-                std::ptr::null_mut(),
-            )
-        };
-
-        assert_ne!(conv_res, 0, "ConvertStringSecurityDescriptorToSecurityDescriptorW should succeed");
         assert_ne!(sec_desc, std::ptr::null_mut(), "Security descriptor pointer should not be null");
 
         unsafe {

--- a/packages/secrets/core/src/os/win/tls_pipe.rs
+++ b/packages/secrets/core/src/os/win/tls_pipe.rs
@@ -6,13 +6,22 @@ use std::io::{Read, Write};
 use std::thread;
 use windows_sys::Win32::System::Pipes::{CreateNamedPipeW, ConnectNamedPipe, PeekNamedPipe};
 use windows_sys::Win32::Foundation::{CloseHandle, INVALID_HANDLE_VALUE, GetLastError, ERROR_PIPE_CONNECTED};
+use windows_sys::Win32::System::Memory::LocalFree;
+use windows_sys::Win32::Security::{SECURITY_ATTRIBUTES, PSECURITY_DESCRIPTOR};
+use windows_sys::Win32::Security::Authorization::ConvertStringSecurityDescriptorToSecurityDescriptorW;
 
 // Named pipe constants
 const PIPE_ACCESS_DUPLEX: u32 = 0x00000003;
 const PIPE_TYPE_BYTE: u32 = 0x00000000;
 const PIPE_READMODE_BYTE: u32 = 0x00000000;
 const PIPE_WAIT: u32 = 0x00000000;
+const PIPE_REJECT_REMOTE_CLIENTS: u32 = 0x00000008;
 const FILE_FLAG_FIRST_PIPE_INSTANCE: u32 = 0x00080000;
+const SDDL_REVISION_1: u32 = 1;
+
+// SDDL granting full control to the creating process's owner only; all other
+// principals (including Everyone / ANONYMOUS LOGON) get no access.
+const OWNER_ONLY_SDDL: &str = "D:P(A;;GA;;;OW)";
 
 /// Map Windows Schannel HRESULT codes to their documented symbolic name and cause.
 /// Values are verified against winapi/src/shared/winerror.rs.
@@ -60,18 +69,46 @@ pub fn create_tls_pipe(
     let mut wide_name: Vec<u16> = pipe_name_str.encode_utf16().collect();
     wide_name.push(0);
 
+    let mut sddl_wide: Vec<u16> = OWNER_ONLY_SDDL.encode_utf16().collect();
+    sddl_wide.push(0);
+
+    let mut sec_desc: PSECURITY_DESCRIPTOR = std::ptr::null_mut();
+    let conv_res = unsafe {
+        ConvertStringSecurityDescriptorToSecurityDescriptorW(
+            sddl_wide.as_ptr(),
+            SDDL_REVISION_1,
+            &mut sec_desc,
+            std::ptr::null_mut(),
+        )
+    };
+
+    if conv_res == 0 {
+        let err = unsafe { GetLastError() };
+        return Err(KeyringError::Os(format!("Failed to convert SDDL to security descriptor. Error: {}", err)));
+    }
+
+    let mut sec_attrs = SECURITY_ATTRIBUTES {
+        nLength: std::mem::size_of::<SECURITY_ATTRIBUTES>() as u32,
+        lpSecurityDescriptor: sec_desc,
+        bInheritHandle: 0,
+    };
+
     let pipe_handle = unsafe {
         CreateNamedPipeW(
             wide_name.as_ptr(),
             PIPE_ACCESS_DUPLEX | FILE_FLAG_FIRST_PIPE_INSTANCE,
-            PIPE_TYPE_BYTE | PIPE_READMODE_BYTE | PIPE_WAIT,
+            PIPE_TYPE_BYTE | PIPE_READMODE_BYTE | PIPE_WAIT | PIPE_REJECT_REMOTE_CLIENTS,
             1, // Max instances
             16384, // out buffer size
             16384, // in buffer size
             0, // default timeout
-            std::ptr::null(), // default security attributes
+            &mut sec_attrs,
         )
     };
+
+    unsafe {
+        LocalFree(sec_desc as _);
+    }
 
     if pipe_handle == INVALID_HANDLE_VALUE {
         let err = unsafe { GetLastError() };
@@ -230,5 +267,33 @@ pub fn create_tls_pipe(
     });
 
     Ok(socket_path_ret)
+}
+
+#[cfg(all(test, target_os = "windows"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_owner_only_sddl_conversion() {
+        let mut sddl_wide: Vec<u16> = OWNER_ONLY_SDDL.encode_utf16().collect();
+        sddl_wide.push(0);
+
+        let mut sec_desc: PSECURITY_DESCRIPTOR = std::ptr::null_mut();
+        let conv_res = unsafe {
+            ConvertStringSecurityDescriptorToSecurityDescriptorW(
+                sddl_wide.as_ptr(),
+                SDDL_REVISION_1,
+                &mut sec_desc,
+                std::ptr::null_mut(),
+            )
+        };
+
+        assert_ne!(conv_res, 0, "ConvertStringSecurityDescriptorToSecurityDescriptorW should succeed");
+        assert_ne!(sec_desc, std::ptr::null_mut(), "Security descriptor pointer should not be null");
+
+        unsafe {
+            LocalFree(sec_desc as _);
+        }
+    }
 }
 


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->
Restricts DACL on Windows local named pipes so that it's access owner only.

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->
1. On Windows machine (or VM), create a non administrator user in settings
2. In Powershell, get the SID of that user by running : `Get-LocalUser | Select-Object Name, SID`
3. Modify `tls_pipe.rs` by replacing the `OW` on line 24 (const OWNER_ONLY_SDDL) with the SID
4. Then build the secrets package and run a command (such as listing datasets) and see that an error occurs restricting access

**Review Checklist**
I certify that I have:
- [x] updated the changelog
- [x] manually tested my changes
- [x] added/updated automated unit/integration tests
- [ ] created/ran system tests (provide build number if applicable)
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
