### PR TITLE
should not interpret no response as a success

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Zowe CLI package will be documented in this file.
 
+## Recent Changes
+
+- BugFix: Fixed the daemon client reporting a command as successful when the daemon closed the connection without sending an exit code. [#2873](https://github.com/zowe/zowe-cli/pull/2873)
+
 ## `8.35.1`
 
 - **Breaking**: `zowe zos-uss` (ssh) commands now verify the z/OS SSH server's host key before sending credentials. On first connect you confirm the fingerprint and the key is saved to your ssh profile; a changed key is rejected. Use `--insecure` to skip verification or `--host-key` to pin a key. [#2813](https://github.com/zowe/zowe-cli/pull/2813)

--- a/packages/cli/__tests__/daemon/__unit__/__snapshots__/DaemonClient.unit.test.ts.snap
+++ b/packages/cli/__tests__/daemon/__unit__/__snapshots__/DaemonClient.unit.test.ts.snap
@@ -178,3 +178,5 @@ Object {
   },
 }
 `;
+
+exports[`DaemonClient tests should shutdown when keyword is specified 1`] = `undefined`;

--- a/packages/cli/src/daemon/DaemonClient.ts
+++ b/packages/cli/src/daemon/DaemonClient.ts
@@ -97,6 +97,10 @@ export class DaemonClient {
             }
         }
 
+        // Send dummy response to avoid empty error code handling.
+        const responsePayload: string = DaemonRequest.create({ exitCode: 0 });
+        this.mClient.write(responsePayload);
+
         this.mClient.end();
         this.mServer.close();
     }

--- a/zowex/src/comm.rs
+++ b/zowex/src/comm.rs
@@ -390,6 +390,7 @@ pub async fn comm_talk(message: &[u8], stream: &mut DaemonClient) -> io::Result<
     let mut reader = BufReader::new(stream);
 
     let mut exit_code = EXIT_CODE_SUCCESS;
+    let mut got_exit_code = false;
     let mut _progress = false;
 
     // get the daemon directory so we can read the token from its pid file later on
@@ -494,6 +495,9 @@ pub async fn comm_talk(message: &[u8], stream: &mut DaemonClient) -> io::Result<
                         reader.get_mut().write_all(v.as_bytes()).await?;
                     }
 
+                    if p.exitCode.is_some() {
+                        got_exit_code = true;
+                    }
                     exit_code = p.exitCode.unwrap_or(EXIT_CODE_SUCCESS);
                     _progress = p.progress.unwrap_or(false);
 
@@ -505,6 +509,12 @@ pub async fn comm_talk(message: &[u8], stream: &mut DaemonClient) -> io::Result<
                     }
                 } else {
                     // end of reading
+                    if !got_exit_code {
+                        return Err(io::Error::new(
+                            io::ErrorKind::UnexpectedEof,
+                            "The Zowe daemon closed the connection before returning an exit code.",
+                        ));
+                    }
                     break;
                 }
             }

--- a/zowex/src/test.rs
+++ b/zowex/src/test.rs
@@ -275,6 +275,102 @@ async fn unit_test_comm_peer_is_current_user() {
     std::fs::remove_file(&sock_path).ok();
 }
 
+#[cfg(target_family = "unix")]
+#[tokio::test]
+async fn unit_test_comm_talk_errors_on_eof_without_exit_code() {
+    use crate::comm::comm_talk;
+    use tokio::io::AsyncWriteExt;
+    use tokio::net::{UnixListener, UnixStream};
+
+    let sock_path = env::temp_dir().join("zowe_test_comm_talk_eof_no_exit.sock");
+    std::fs::remove_file(&sock_path).ok();
+
+    let listener = UnixListener::bind(&sock_path).expect("should bind the test socket");
+
+    let daemon_task = tokio::spawn(async move {
+        let (mut server_end, _addr) = listener
+            .accept()
+            .await
+            .expect("should accept the test connection");
+
+        server_end
+            .write_all(b"{\"stdout\":\"partial output\"}\x0c")
+            .await
+            .expect("should write the fake daemon response");
+        server_end
+            .flush()
+            .await
+            .expect("should flush the fake daemon response");
+        drop(server_end);
+    });
+
+    let mut client_end = UnixStream::connect(&sock_path)
+        .await
+        .expect("should connect to the test socket");
+
+    let result = comm_talk(b"{}", &mut client_end).await;
+
+    daemon_task.await.expect("the fake daemon task should not panic");
+    std::fs::remove_file(&sock_path).ok();
+
+    match result {
+        Err(err_val) => {
+            assert_eq!(
+                err_val.kind(),
+                std::io::ErrorKind::UnexpectedEof,
+                "an EOF without an exit code should surface as UnexpectedEof, got: {}",
+                err_val
+            );
+        }
+        Ok(exit_code) => {
+            panic!("comm_talk should not report success on an unexpected EOF, got exit code {}", exit_code);
+        }
+    }
+}
+
+#[cfg(target_family = "unix")]
+#[tokio::test]
+async fn unit_test_comm_talk_returns_exit_code_before_eof() {
+    use crate::comm::comm_talk;
+    use tokio::io::AsyncWriteExt;
+    use tokio::net::{UnixListener, UnixStream};
+
+    let sock_path = env::temp_dir().join("zowe_test_comm_talk_eof_with_exit.sock");
+    std::fs::remove_file(&sock_path).ok();
+
+    let listener = UnixListener::bind(&sock_path).expect("should bind the test socket");
+
+    let daemon_task = tokio::spawn(async move {
+        let (mut server_end, _addr) = listener
+            .accept()
+            .await
+            .expect("should accept the test connection");
+        server_end
+            .write_all(b"{\"exitCode\":42}\x0c")
+            .await
+            .expect("should write the fake daemon response");
+        server_end
+            .flush()
+            .await
+            .expect("should flush the fake daemon response");
+        drop(server_end);
+    });
+
+    let mut client_end = UnixStream::connect(&sock_path)
+        .await
+        .expect("should connect to the test socket");
+
+    let result = comm_talk(b"{}", &mut client_end).await;
+
+    daemon_task.await.expect("the fake daemon task should not panic");
+    std::fs::remove_file(&sock_path).ok();
+
+    assert_eq!(
+        result.expect("comm_talk should succeed when the daemon sends an exit code"),
+        42
+    );
+}
+
 #[tokio::test]
 // test daemon restart
 async fn integration_test_restart() {

--- a/zowex/src/test.rs
+++ b/zowex/src/test.rs
@@ -279,7 +279,7 @@ async fn unit_test_comm_peer_is_current_user() {
 #[tokio::test]
 async fn unit_test_comm_talk_errors_on_eof_without_exit_code() {
     use crate::comm::comm_talk;
-    use tokio::io::AsyncWriteExt;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
     use tokio::net::{UnixListener, UnixStream};
 
     let sock_path = env::temp_dir().join("zowe_test_comm_talk_eof_no_exit.sock");
@@ -292,6 +292,12 @@ async fn unit_test_comm_talk_errors_on_eof_without_exit_code() {
             .accept()
             .await
             .expect("should accept the test connection");
+
+        let mut request_buf = [0u8; 2];
+        server_end
+            .read_exact(&mut request_buf)
+            .await
+            .expect("should read the fake client request");
 
         server_end
             .write_all(b"{\"stdout\":\"partial output\"}\x0c")
@@ -332,7 +338,7 @@ async fn unit_test_comm_talk_errors_on_eof_without_exit_code() {
 #[tokio::test]
 async fn unit_test_comm_talk_returns_exit_code_before_eof() {
     use crate::comm::comm_talk;
-    use tokio::io::AsyncWriteExt;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
     use tokio::net::{UnixListener, UnixStream};
 
     let sock_path = env::temp_dir().join("zowe_test_comm_talk_eof_with_exit.sock");
@@ -345,6 +351,13 @@ async fn unit_test_comm_talk_returns_exit_code_before_eof() {
             .accept()
             .await
             .expect("should accept the test connection");
+
+        let mut request_buf = [0u8; 2];
+        server_end
+            .read_exact(&mut request_buf)
+            .await
+            .expect("should read the fake client request");
+
         server_end
             .write_all(b"{\"exitCode\":42}\x0c")
             .await

--- a/zowex/src/test.rs
+++ b/zowex/src/test.rs
@@ -275,7 +275,6 @@ async fn unit_test_comm_peer_is_current_user() {
     std::fs::remove_file(&sock_path).ok();
 }
 
-#[cfg(target_family = "unix")]
 #[tokio::test]
 async fn unit_test_comm_talk_errors_on_eof_without_exit_code() {
     use crate::comm::comm_talk;
@@ -334,7 +333,6 @@ async fn unit_test_comm_talk_errors_on_eof_without_exit_code() {
     }
 }
 
-#[cfg(target_family = "unix")]
 #[tokio::test]
 async fn unit_test_comm_talk_returns_exit_code_before_eof() {
     use crate::comm::comm_talk;

--- a/zowex/src/test.rs
+++ b/zowex/src/test.rs
@@ -13,6 +13,7 @@
 
 #[cfg(test)]
 use std::env;
+use std::io;
 use std::thread;
 use std::time::Duration;
 
@@ -275,13 +276,16 @@ async fn unit_test_comm_peer_is_current_user() {
     std::fs::remove_file(&sock_path).ok();
 }
 
-#[tokio::test]
-async fn unit_test_comm_talk_errors_on_eof_without_exit_code() {
+
+// Run comm_talk against a fake daemon that writes a single canned response
+// and then closes the connection, and return comm_talk's result.
+#[cfg(target_family = "unix")]
+async fn comm_talk_with_fake_daemon_response(test_name: &str, response: &'static [u8]) -> io::Result<i32> {
     use crate::comm::comm_talk;
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
     use tokio::net::{UnixListener, UnixStream};
 
-    let sock_path = env::temp_dir().join("zowe_test_comm_talk_eof_no_exit.sock");
+    let sock_path = env::temp_dir().join(format!("zowe_test_{}.sock", test_name));
     std::fs::remove_file(&sock_path).ok();
 
     let listener = UnixListener::bind(&sock_path).expect("should bind the test socket");
@@ -299,7 +303,7 @@ async fn unit_test_comm_talk_errors_on_eof_without_exit_code() {
             .expect("should read the fake client request");
 
         server_end
-            .write_all(b"{\"stdout\":\"partial output\"}\x0c")
+            .write_all(response)
             .await
             .expect("should write the fake daemon response");
         server_end
@@ -317,6 +321,64 @@ async fn unit_test_comm_talk_errors_on_eof_without_exit_code() {
 
     daemon_task.await.expect("the fake daemon task should not panic");
     std::fs::remove_file(&sock_path).ok();
+
+    result
+}
+
+/// Windows counterpart of [comm_talk_with_fake_daemon_response] using a named pipe.
+#[cfg(target_family = "windows")]
+async fn comm_talk_with_fake_daemon_response(test_name: &str, response: &'static [u8]) -> io::Result<i32> {
+    use crate::comm::comm_talk;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::windows::named_pipe::{ClientOptions, ServerOptions};
+
+    let pipe_name = format!(r"\\.\pipe\zowe_test_{}", test_name);
+
+    let mut server = ServerOptions::new()
+        .create(&pipe_name)
+        .expect("should create the test pipe");
+
+    let daemon_task = tokio::spawn(async move {
+        server
+            .connect()
+            .await
+            .expect("should accept the test connection");
+
+        let mut request_buf = [0u8; 2];
+        server
+            .read_exact(&mut request_buf)
+            .await
+            .expect("should read the fake client request");
+
+        server
+            .write_all(response)
+            .await
+            .expect("should write the fake daemon response");
+        server
+            .flush()
+            .await
+            .expect("should flush the fake daemon response");
+        drop(server);
+    });
+
+    let mut client_end = ClientOptions::new()
+        .open(&pipe_name)
+        .expect("should connect to the test pipe");
+
+    let result = comm_talk(b"{}", &mut client_end).await;
+
+    daemon_task.await.expect("the fake daemon task should not panic");
+
+    result
+}
+
+#[tokio::test]
+async fn unit_test_comm_talk_errors_on_eof_without_exit_code() {
+    let result = comm_talk_with_fake_daemon_response(
+        "comm_talk_eof_no_exit",
+        b"{\"stdout\":\"partial output\"}\x0c",
+    )
+    .await;
 
     match result {
         Err(err_val) => {
@@ -335,46 +397,8 @@ async fn unit_test_comm_talk_errors_on_eof_without_exit_code() {
 
 #[tokio::test]
 async fn unit_test_comm_talk_returns_exit_code_before_eof() {
-    use crate::comm::comm_talk;
-    use tokio::io::{AsyncReadExt, AsyncWriteExt};
-    use tokio::net::{UnixListener, UnixStream};
-
-    let sock_path = env::temp_dir().join("zowe_test_comm_talk_eof_with_exit.sock");
-    std::fs::remove_file(&sock_path).ok();
-
-    let listener = UnixListener::bind(&sock_path).expect("should bind the test socket");
-
-    let daemon_task = tokio::spawn(async move {
-        let (mut server_end, _addr) = listener
-            .accept()
-            .await
-            .expect("should accept the test connection");
-
-        let mut request_buf = [0u8; 2];
-        server_end
-            .read_exact(&mut request_buf)
-            .await
-            .expect("should read the fake client request");
-
-        server_end
-            .write_all(b"{\"exitCode\":42}\x0c")
-            .await
-            .expect("should write the fake daemon response");
-        server_end
-            .flush()
-            .await
-            .expect("should flush the fake daemon response");
-        drop(server_end);
-    });
-
-    let mut client_end = UnixStream::connect(&sock_path)
-        .await
-        .expect("should connect to the test socket");
-
-    let result = comm_talk(b"{}", &mut client_end).await;
-
-    daemon_task.await.expect("the fake daemon task should not panic");
-    std::fs::remove_file(&sock_path).ok();
+    let result =
+        comm_talk_with_fake_daemon_response("comm_talk_eof_with_exit", b"{\"exitCode\":42}\x0c").await;
 
     assert_eq!(
         result.expect("comm_talk should succeed when the daemon sends an exit code"),


### PR DESCRIPTION
**What It Does**
Fix no exit code silently being interpreted as success

**How to Test**
`cargo test unit --manifest-path=zowex/Cargo.toml`



**Review Checklist**
I certify that I have:
- [ ] updated the changelog
- [x] manually tested my changes
- [x] added/updated automated unit/integration tests
- [x] created/ran system tests (#2585)
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
